### PR TITLE
Filter items by their type in the viewset

### DIFF
--- a/src/backend/core/api/filters.py
+++ b/src/backend/core/api/filters.py
@@ -18,7 +18,7 @@ class ItemFilter(django_filters.FilterSet):
 
     class Meta:
         model = models.Item
-        fields = ["title"]
+        fields = ["title", "type"]
 
 
 class ListItemFilter(ItemFilter):
@@ -33,7 +33,7 @@ class ListItemFilter(ItemFilter):
 
     class Meta:
         model = models.Item
-        fields = ["is_creator_me", "is_favorite", "title"]
+        fields = ["is_creator_me", "is_favorite", "title", "type"]
 
     # pylint: disable=unused-argument
     def filter_is_creator_me(self, queryset, name, value):


### PR DESCRIPTION
## Purpose

We want to filter on the list and children views the items by their
type.
Before doing that we have refactor the filter_queryset method to move content related to the list view in its own method.

## Proposal

- [x] ♻️(back) refactor item list view
- [x] ✨(back) allow to filter items by their type
