### PR TITLE
🐛(back) enable pg_trgm extension

### DIFF
--- a/src/backend/core/migrations/0001_initial.py
+++ b/src/backend/core/migrations/0001_initial.py
@@ -182,4 +182,8 @@ class Migration(migrations.Migration):
             "CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;",
             reverse_sql="DROP EXTENSION IF EXISTS fuzzystrmatch;",
         ),
+        migrations.RunSQL(
+            "CREATE EXTENSION IF NOT EXISTS pg_trgm;",
+            reverse_sql="DROP EXTENSION IF EXISTS pg_trgm;",
+        ),
     ]


### PR DESCRIPTION
Without this extension we couldn't filter using %> operator.

