### PR TITLE
🐛(back) concurrency issues while creating item

### DIFF
--- a/src/backend/core/tests/authentication/test_backends.py
+++ b/src/backend/core/tests/authentication/test_backends.py
@@ -537,7 +537,7 @@ def test_authentication_verify_claims_success(django_assert_num_queries, monkeyp
     monkeypatch.setattr(OIDCAuthenticationBackend, "get_userinfo", get_userinfo_mocked)
 
     with django_assert_num_queries(
-        6 + 15
+        6 + 18
     ):  # 6 for user creation, 15 for workspace creation
         user = klass.get_or_create_user(
             access_token="test-token", id_token=None, payload=None

--- a/src/backend/core/tests/test_models_invitations.py
+++ b/src/backend/core/tests/test_models_invitations.py
@@ -143,7 +143,7 @@ def test_models_invitationd_new_user_filter_expired_invitations():
     ).exists()
 
 
-@pytest.mark.parametrize("num_invitations, num_queries", [(0, 18), (1, 22), (20, 22)])
+@pytest.mark.parametrize("num_invitations, num_queries", [(0, 21), (1, 25), (20, 25)])
 def test_models_invitations_new_userd_user_creation_constant_num_queries(
     django_assert_num_queries, num_invitations, num_queries
 ):


### PR DESCRIPTION
## Purpose

We have a race condition when several items are created at the same time. To avoid this race condition, we lock the Item table in ROW EXCLUSIVE MODE when calling the child creation.


## Proposal

- [x] 🐛(back) concurrency issues while creating item

Fixes #70
