### PR TITLE
Add codes to validation errors

### DIFF
--- a/src/backend/core/api/__init__.py
+++ b/src/backend/core/api/__init__.py
@@ -1,12 +1,13 @@
 """Drive core API endpoints"""
 
 from django.conf import settings
-from django.core.exceptions import ValidationError
+from django.core.exceptions import ValidationError as DjangoValidationError
 
+from drf_standardized_errors.handler import exception_handler as drf_exception_handler
 from rest_framework import exceptions as drf_exceptions
-from rest_framework import views as drf_views
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
+from rest_framework.serializers import as_serializer_error
 
 
 def exception_handler(exc, context):
@@ -16,18 +17,10 @@ def exception_handler(exc, context):
     This code comes from twidi's gist:
     https://gist.github.com/twidi/9d55486c36b6a51bdcb05ce3a763e79f
     """
-    if isinstance(exc, ValidationError):
-        detail = None
-        if hasattr(exc, "message_dict"):
-            detail = exc.message_dict
-        elif hasattr(exc, "message"):
-            detail = exc.message
-        elif hasattr(exc, "messages"):
-            detail = exc.messages
+    if isinstance(exc, DjangoValidationError):
+        exc = drf_exceptions.ValidationError(as_serializer_error(exc))
 
-        exc = drf_exceptions.ValidationError(detail=detail)
-
-    return drf_views.exception_handler(exc, context)
+    return drf_exception_handler(exc, context)
 
 
 # pylint: disable=unused-argument

--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -303,7 +303,8 @@ class ItemSerializer(ListItemSerializer):
                     "title": _(
                         "An item with this title already exists in the current path."
                     )
-                }
+                },
+                code="item_update_title_already_exists",
             )
 
         return super().update(instance, validated_data)
@@ -382,7 +383,8 @@ class CreateItemSerializer(ItemSerializer):
         if request:
             if models.Item.objects.filter(id=value).exists():
                 raise serializers.ValidationError(
-                    "An item with this ID already exists. You cannot override it."
+                    "An item with this ID already exists. You cannot override it.",
+                    code="item_create_existing_id",
                 )
 
         return value
@@ -392,7 +394,8 @@ class CreateItemSerializer(ItemSerializer):
         if attrs["type"] == models.ItemTypeChoices.FILE:
             if attrs.get("filename") is None:
                 raise serializers.ValidationError(
-                    {"filename": _("This field is required for files.")}
+                    {"filename": _("This field is required for files.")},
+                    code="item_create_file_filename_required",
                 )
 
             # When it's a file we force the title with the filename
@@ -403,7 +406,8 @@ class CreateItemSerializer(ItemSerializer):
             and attrs.get("title") is None
         ):
             raise serializers.ValidationError(
-                {"title": _("This field is required for folders.")}
+                {"title": _("This field is required for folders.")},
+                code="item_create_folder_title_required",
             )
 
         return super().validate(attrs)
@@ -501,7 +505,8 @@ class InvitationSerializer(serializers.ModelSerializer):
                 role=models.RoleChoices.OWNER,
             ).exists():
                 raise serializers.ValidationError(
-                    "Only owners of a item can invite other users as owners."
+                    "Only owners of a item can invite other users as owners.",
+                    code="invitation_role_owner_limited_to_owners",
                 )
 
         return role

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -900,7 +900,13 @@ class Item(TreeModel, BaseModel):
                 }
             )
 
-        if self.deleted_at < get_trashbin_cutoff():
+        if (
+            self.deleted_at < get_trashbin_cutoff()
+            or Item.objects.filter(
+                path__ancestors=self.path,
+                hard_deleted_at__isnull=False,
+            ).exists()
+        ):
             raise ValidationError(
                 {
                     "deleted_at": ValidationError(

--- a/src/backend/core/tests/items/test_api_item_accesses.py
+++ b/src/backend/core/tests/items/test_api_item_accesses.py
@@ -23,7 +23,14 @@ def test_api_item_accesses_list_anonymous():
     response = APIClient().get(f"/api/v1.0/items/{item.id!s}/accesses/")
     assert response.status_code == 401
     assert response.json() == {
-        "detail": "Authentication credentials were not provided."
+        "errors": [
+            {
+                "attr": None,
+                "code": "not_authenticated",
+                "detail": "Authentication credentials were not provided.",
+            },
+        ],
+        "type": "client_error",
     }
 
 
@@ -140,7 +147,14 @@ def test_api_item_accesses_retrieve_anonymous():
 
     assert response.status_code == 401
     assert response.json() == {
-        "detail": "Authentication credentials were not provided."
+        "errors": [
+            {
+                "attr": None,
+                "code": "not_authenticated",
+                "detail": "Authentication credentials were not provided.",
+            },
+        ],
+        "type": "client_error",
     }
 
 
@@ -162,7 +176,14 @@ def test_api_item_accesses_retrieve_authenticated_unrelated():
     )
     assert response.status_code == 403
     assert response.json() == {
-        "detail": "You do not have permission to perform this action."
+        "errors": [
+            {
+                "attr": None,
+                "code": "permission_denied",
+                "detail": "You do not have permission to perform this action.",
+            },
+        ],
+        "type": "client_error",
     }
 
     # Accesses related to another item should be excluded even if the user is related to it
@@ -175,7 +196,16 @@ def test_api_item_accesses_retrieve_authenticated_unrelated():
         )
 
         assert response.status_code == 404
-        assert response.json() == {"detail": "No ItemAccess matches the given query."}
+        assert response.json() == {
+            "errors": [
+                {
+                    "attr": None,
+                    "code": "not_found",
+                    "detail": "Not found.",
+                },
+            ],
+            "type": "client_error",
+        }
 
 
 @pytest.mark.parametrize("via", VIA)

--- a/src/backend/core/tests/items/test_api_item_accesses_create.py
+++ b/src/backend/core/tests/items/test_api_item_accesses_create.py
@@ -34,8 +34,16 @@ def test_api_item_accesses_create_anonymous():
 
     assert response.status_code == 401
     assert response.json() == {
-        "detail": "Authentication credentials were not provided."
+        "errors": [
+            {
+                "attr": None,
+                "code": "not_authenticated",
+                "detail": "Authentication credentials were not provided.",
+            },
+        ],
+        "type": "client_error",
     }
+
     assert models.ItemAccess.objects.filter(user=other_user, item=item).count() == 0
 
 
@@ -132,8 +140,16 @@ def test_api_item_accesses_create_authenticated_administrator(via, mock_user_tea
 
     assert response.status_code == 403
     assert response.json() == {
-        "detail": "Only owners of a resource can assign other users as owners."
+        "errors": [
+            {
+                "attr": None,
+                "code": "permission_denied",
+                "detail": "Only owners of a resource can assign other users as owners.",
+            },
+        ],
+        "type": "client_error",
     }
+
     assert models.ItemAccess.objects.filter(user=other_user, item=item).count() == 0
 
     # It should be allowed to create a lower access

--- a/src/backend/core/tests/items/test_api_item_upload_ended.py
+++ b/src/backend/core/tests/items/test_api_item_upload_ended.py
@@ -29,7 +29,9 @@ def test_api_item_upload_ended_no_permissions(role):
     client.force_login(user)
 
     if role:
-        item = factories.ItemFactory(users=[(user, role)], link_role=LinkRoleChoices.READER)
+        item = factories.ItemFactory(
+            users=[(user, role)], link_role=LinkRoleChoices.READER
+        )
     else:
         item = factories.ItemFactory(link_role=LinkRoleChoices.READER)
 
@@ -51,11 +53,17 @@ def test_api_item_upload_ended_on_none_file_item(item_type):
     factories.UserItemAccessFactory(item=item, user=user, role="owner")
 
     response = client.post(f"/api/v1.0/items/{item.id!s}/upload-ended/")
-
-    assert response.json() == {
-        "item": "This action is only available for items of type FILE."
-    }
     assert response.status_code == 400
+    assert response.json() == {
+        "type": "validation_error",
+        "errors": [
+            {
+                "code": "item_upload_type_unavailable",
+                "detail": "This action is only available for items of type FILE.",
+                "attr": "item",
+            }
+        ],
+    }
 
 
 def test_api_item_upload_ended_on_wrong_upload_state():
@@ -75,7 +83,14 @@ def test_api_item_upload_ended_on_wrong_upload_state():
 
     assert response.status_code == 400
     assert response.json() == {
-        "item": "This action is only available for items in PENDING state."
+        "type": "validation_error",
+        "errors": [
+            {
+                "code": "item_upload_state_not_pending",
+                "detail": "This action is only available for items in PENDING state.",
+                "attr": "item",
+            }
+        ],
     }
 
 

--- a/src/backend/core/tests/items/test_api_items_children_list.py
+++ b/src/backend/core/tests/items/test_api_items_children_list.py
@@ -209,7 +209,14 @@ def test_api_items_children_list_anonymous_restricted_or_authenticated(reach):
 
     assert response.status_code == 401
     assert response.json() == {
-        "detail": "Authentication credentials were not provided."
+        "errors": [
+            {
+                "attr": None,
+                "code": "not_authenticated",
+                "detail": "Authentication credentials were not provided.",
+            },
+        ],
+        "type": "client_error",
     }
 
 
@@ -428,7 +435,14 @@ def test_api_items_children_list_authenticated_unrelated_restricted():
     )
     assert response.status_code == 403
     assert response.json() == {
-        "detail": "You do not have permission to perform this action."
+        "errors": [
+            {
+                "attr": None,
+                "code": "permission_denied",
+                "detail": "You do not have permission to perform this action.",
+            },
+        ],
+        "type": "client_error",
     }
 
 
@@ -651,7 +665,14 @@ def test_api_items_children_list_authenticated_related_child():
     )
     assert response.status_code == 403
     assert response.json() == {
-        "detail": "You do not have permission to perform this action."
+        "errors": [
+            {
+                "attr": None,
+                "code": "permission_denied",
+                "detail": "You do not have permission to perform this action.",
+            },
+        ],
+        "type": "client_error",
     }
 
 
@@ -677,7 +698,14 @@ def test_api_items_children_list_authenticated_related_team_none(mock_user_teams
     response = client.get(f"/api/v1.0/items/{item.id!s}/children/")
     assert response.status_code == 403
     assert response.json() == {
-        "detail": "You do not have permission to perform this action."
+        "errors": [
+            {
+                "attr": None,
+                "code": "permission_denied",
+                "detail": "You do not have permission to perform this action.",
+            },
+        ],
+        "type": "client_error",
     }
 
 
@@ -914,7 +942,13 @@ def test_api_items_children_list_filter_wrong_type():
         f"/api/v1.0/items/{item.id!s}/children/?type=unknown",
     )
     assert response.status_code == 400
-
     assert response.json() == {
-        "type": ["Select a valid choice. unknown is not one of the available choices."]
+        "errors": [
+            {
+                "attr": "type",
+                "code": "invalid",
+                "detail": "Select a valid choice. unknown is not one of the available choices.",
+            },
+        ],
+        "type": "validation_error",
     }

--- a/src/backend/core/tests/items/test_api_items_create.py
+++ b/src/backend/core/tests/items/test_api_items_create.py
@@ -73,7 +73,16 @@ def test_api_items_create_file_authenticated_no_filename():
         format="json",
     )
     assert response.status_code == 400
-    assert response.json() == {"filename": ["This field is required for files."]}
+    assert response.json() == {
+        "errors": [
+            {
+                "attr": "filename",
+                "code": "item_create_file_filename_required",
+                "detail": "This field is required for files.",
+            },
+        ],
+        "type": "validation_error",
+    }
 
 
 def test_api_items_create_file_authenticated_success():
@@ -131,7 +140,16 @@ def test_api_items_create_authenticated_title_null():
     )
 
     assert response.status_code == 400
-    assert response.json() == {"title": ["This field is required for folders."]}
+    assert response.json() == {
+        "errors": [
+            {
+                "attr": "title",
+                "code": "item_create_folder_title_required",
+                "detail": "This field is required for folders.",
+            },
+        ],
+        "type": "validation_error",
+    }
 
 
 def test_api_items_create_force_id_success():
@@ -180,7 +198,14 @@ def test_api_items_create_force_id_existing():
 
     assert response.status_code == 400
     assert response.json() == {
-        "id": ["An item with this ID already exists. You cannot override it."]
+        "errors": [
+            {
+                "attr": "id",
+                "code": "item_create_existing_id",
+                "detail": "An item with this ID already exists. You cannot override it.",
+            },
+        ],
+        "type": "validation_error",
     }
 
 

--- a/src/backend/core/tests/items/test_api_items_delete.py
+++ b/src/backend/core/tests/items/test_api_items_delete.py
@@ -73,7 +73,14 @@ def test_api_items_delete_authenticated_not_owner(via, role, mock_user_teams):
 
     assert response.status_code == 403
     assert response.json() == {
-        "detail": "You do not have permission to perform this action."
+        "errors": [
+            {
+                "attr": None,
+                "code": "permission_denied",
+                "detail": "You do not have permission to perform this action.",
+            },
+        ],
+        "type": "client_error",
     }
     assert models.Item.objects.count() == existing_items
 

--- a/src/backend/core/tests/items/test_api_items_favorite.py
+++ b/src/backend/core/tests/items/test_api_items_favorite.py
@@ -25,7 +25,14 @@ def test_api_item_favorite_anonymous_user(method, reach):
 
     assert response.status_code == 401
     assert response.json() == {
-        "detail": "Authentication credentials were not provided."
+        "errors": [
+            {
+                "attr": None,
+                "code": "not_authenticated",
+                "detail": "Authentication credentials were not provided.",
+            },
+        ],
+        "type": "client_error",
     }
 
     # Verify in database
@@ -78,7 +85,14 @@ def test_api_item_favorite_authenticated_post_forbidden():
 
     assert response.status_code == 403
     assert response.json() == {
-        "detail": "You do not have permission to perform this action."
+        "errors": [
+            {
+                "attr": None,
+                "code": "permission_denied",
+                "detail": "You do not have permission to perform this action.",
+            },
+        ],
+        "type": "client_error",
     }
 
     # Verify in database
@@ -133,7 +147,14 @@ def test_api_item_favorite_authenticated_post_already_favorited_forbidden():
 
     assert response.status_code == 403
     assert response.json() == {
-        "detail": "You do not have permission to perform this action."
+        "errors": [
+            {
+                "attr": None,
+                "code": "permission_denied",
+                "detail": "You do not have permission to perform this action.",
+            },
+        ],
+        "type": "client_error",
     }
 
     # Verify in database
@@ -184,7 +205,14 @@ def test_api_item_favorite_authenticated_delete_forbidden():
 
     assert response.status_code == 403
     assert response.json() == {
-        "detail": "You do not have permission to perform this action."
+        "errors": [
+            {
+                "attr": None,
+                "code": "permission_denied",
+                "detail": "You do not have permission to perform this action.",
+            },
+        ],
+        "type": "client_error",
     }
 
     # Verify in database
@@ -237,7 +265,14 @@ def test_api_item_favorite_authenticated_delete_not_favorited_forbidden():
 
     assert response.status_code == 403
     assert response.json() == {
-        "detail": "You do not have permission to perform this action."
+        "errors": [
+            {
+                "attr": None,
+                "code": "permission_denied",
+                "detail": "You do not have permission to perform this action.",
+            },
+        ],
+        "type": "client_error",
     }
 
     # Verify in database

--- a/src/backend/core/tests/items/test_api_items_hard_delete.py
+++ b/src/backend/core/tests/items/test_api_items_hard_delete.py
@@ -73,11 +73,18 @@ def test_api_items_hard_delete_authenticated_owner_not_soft_deleted_should_fails
     response = client.delete(f"/api/v1.0/items/{item.id!s}/hard-delete/")
     assert response.status_code == 400
     assert response.json() == {
-        "hard_deleted_at": ["To hard delete an item, it must first be soft deleted."]
+        "errors": [
+            {
+                "attr": "hard_deleted_at",
+                "code": "item_hard_delete_should_soft_delete_first",
+                "detail": "To hard delete an item, it must first be soft deleted.",
+            },
+        ],
+        "type": "validation_error",
     }
 
 
-def test_api_items_hard_delete_authenticated_owner_already_hard_deleted_should_fails():
+def test_api_items_hard_delete_authenticated_owner_already_hard_deleted_should_fail():
     """
     Authenticated users should not be allowed to hard delete an item if it is already hard deleted.
     """

--- a/src/backend/core/tests/items/test_api_items_link_configuration.py
+++ b/src/backend/core/tests/items/test_api_items_link_configuration.py
@@ -27,7 +27,14 @@ def test_api_items_link_configuration_update_anonymous(reach, role):
     )
     assert response.status_code == 401
     assert response.json() == {
-        "detail": "Authentication credentials were not provided."
+        "errors": [
+            {
+                "attr": None,
+                "code": "not_authenticated",
+                "detail": "Authentication credentials were not provided.",
+            },
+        ],
+        "type": "client_error",
     }
 
     item.refresh_from_db()
@@ -61,7 +68,14 @@ def test_api_items_link_configuration_update_authenticated_unrelated(reach, role
 
     assert response.status_code == 403
     assert response.json() == {
-        "detail": "You do not have permission to perform this action."
+        "errors": [
+            {
+                "attr": None,
+                "code": "permission_denied",
+                "detail": "You do not have permission to perform this action.",
+            },
+        ],
+        "type": "client_error",
     }
 
     item.refresh_from_db()
@@ -103,7 +117,14 @@ def test_api_items_link_configuration_update_authenticated_related_forbidden(
 
     assert response.status_code == 403
     assert response.json() == {
-        "detail": "You do not have permission to perform this action."
+        "errors": [
+            {
+                "attr": None,
+                "code": "permission_denied",
+                "detail": "You do not have permission to perform this action.",
+            },
+        ],
+        "type": "client_error",
     }
 
     item.refresh_from_db()

--- a/src/backend/core/tests/items/test_api_items_list_filters.py
+++ b/src/backend/core/tests/items/test_api_items_list_filters.py
@@ -440,5 +440,12 @@ def test_api_items_list_filter_unknown_type():
 
     assert response.status_code == 400
     assert response.json() == {
-        "type": ["Select a valid choice. unknown is not one of the available choices."]
+        "errors": [
+            {
+                "attr": "type",
+                "code": "invalid",
+                "detail": "Select a valid choice. unknown is not one of the available choices.",
+            },
+        ],
+        "type": "validation_error",
     }

--- a/src/backend/core/tests/items/test_api_items_retrieve.py
+++ b/src/backend/core/tests/items/test_api_items_retrieve.py
@@ -124,7 +124,14 @@ def test_api_items_retrieve_anonymous_public_child():
 
     assert response.status_code == 401
     assert response.json() == {
-        "detail": "Authentication credentials were not provided."
+        "errors": [
+            {
+                "attr": None,
+                "code": "not_authenticated",
+                "detail": "Authentication credentials were not provided.",
+            },
+        ],
+        "type": "client_error",
     }
 
 
@@ -137,7 +144,14 @@ def test_api_items_retrieve_anonymous_restricted_or_authenticated(reach):
 
     assert response.status_code == 401
     assert response.json() == {
-        "detail": "Authentication credentials were not provided."
+        "errors": [
+            {
+                "attr": None,
+                "code": "not_authenticated",
+                "detail": "Authentication credentials were not provided.",
+            },
+        ],
+        "type": "client_error",
     }
 
 
@@ -268,7 +282,14 @@ def test_api_items_retrieve_authenticated_public_or_authenticated_child(reach):
 
     assert response.status_code == 403
     assert response.json() == {
-        "detail": "You do not have permission to perform this action."
+        "errors": [
+            {
+                "attr": None,
+                "code": "permission_denied",
+                "detail": "You do not have permission to perform this action.",
+            },
+        ],
+        "type": "client_error",
     }
 
 
@@ -314,7 +335,14 @@ def test_api_items_retrieve_authenticated_unrelated_restricted():
     )
     assert response.status_code == 403
     assert response.json() == {
-        "detail": "You do not have permission to perform this action."
+        "errors": [
+            {
+                "attr": None,
+                "code": "permission_denied",
+                "detail": "You do not have permission to perform this action.",
+            },
+        ],
+        "type": "client_error",
     }
 
 
@@ -486,7 +514,14 @@ def test_api_items_retrieve_authenticated_related_child():
     )
     assert response.status_code == 403
     assert response.json() == {
-        "detail": "You do not have permission to perform this action."
+        "errors": [
+            {
+                "attr": None,
+                "code": "permission_denied",
+                "detail": "You do not have permission to perform this action.",
+            },
+        ],
+        "type": "client_error",
     }
 
 
@@ -516,7 +551,14 @@ def test_api_items_retrieve_authenticated_related_team_none(mock_user_teams):
     response = client.get(f"/api/v1.0/items/{item.id!s}/")
     assert response.status_code == 403
     assert response.json() == {
-        "detail": "You do not have permission to perform this action."
+        "errors": [
+            {
+                "attr": None,
+                "code": "permission_denied",
+                "detail": "You do not have permission to perform this action.",
+            },
+        ],
+        "type": "client_error",
     }
 
 
@@ -828,7 +870,16 @@ def test_api_items_retrieve_soft_deleted_anonymous(reach, depth):
     response = APIClient().get(f"/api/v1.0/items/{items[-1].id!s}/")
 
     assert response.status_code == 404
-    assert response.json() == {"detail": "Not found."}
+    assert response.json() == {
+        "errors": [
+            {
+                "attr": None,
+                "code": "not_found",
+                "detail": "Not found.",
+            },
+        ],
+        "type": "client_error",
+    }
 
     fourty_days_ago = timezone.now() - timedelta(days=40)
     deleted_item.deleted_at = fourty_days_ago
@@ -838,7 +889,16 @@ def test_api_items_retrieve_soft_deleted_anonymous(reach, depth):
     response = APIClient().get(f"/api/v1.0/items/{items[-1].id!s}/")
 
     assert response.status_code == 404
-    assert response.json() == {"detail": "Not found."}
+    assert response.json() == {
+        "errors": [
+            {
+                "attr": None,
+                "code": "not_found",
+                "detail": "Not found.",
+            },
+        ],
+        "type": "client_error",
+    }
 
 
 @pytest.mark.parametrize("depth", [1, 2, 3])
@@ -876,7 +936,16 @@ def test_api_items_retrieve_soft_deleted_authenticated(reach, depth):
     response = client.get(f"/api/v1.0/items/{items[-1].id!s}/")
 
     assert response.status_code == 404
-    assert response.json() == {"detail": "Not found."}
+    assert response.json() == {
+        "errors": [
+            {
+                "attr": None,
+                "code": "not_found",
+                "detail": "Not found.",
+            },
+        ],
+        "type": "client_error",
+    }
 
     fourty_days_ago = timezone.now() - timedelta(days=40)
     deleted_item.deleted_at = fourty_days_ago
@@ -886,7 +955,16 @@ def test_api_items_retrieve_soft_deleted_authenticated(reach, depth):
     response = client.get(f"/api/v1.0/items/{items[-1].id!s}/")
 
     assert response.status_code == 404
-    assert response.json() == {"detail": "Not found."}
+    assert response.json() == {
+        "errors": [
+            {
+                "attr": None,
+                "code": "not_found",
+                "detail": "Not found.",
+            },
+        ],
+        "type": "client_error",
+    }
 
 
 @pytest.mark.parametrize("depth", [1, 2, 3])
@@ -932,7 +1010,16 @@ def test_api_items_retrieve_soft_deleted_related(role, depth):
         assert response.json()["id"] == str(item.id)
     else:
         assert response.status_code == 404
-        assert response.json() == {"detail": "Not found."}
+        assert response.json() == {
+            "errors": [
+                {
+                    "attr": None,
+                    "code": "not_found",
+                    "detail": "Not found.",
+                },
+            ],
+            "type": "client_error",
+        }
 
 
 @pytest.mark.parametrize("depth", [1, 2, 3])
@@ -976,7 +1063,16 @@ def test_api_items_retrieve_permanently_deleted_related(role, depth):
     response = client.get(f"/api/v1.0/items/{item.id!s}/")
 
     assert response.status_code == 404
-    assert response.json() == {"detail": "Not found."}
+    assert response.json() == {
+        "errors": [
+            {
+                "attr": None,
+                "code": "not_found",
+                "detail": "Not found.",
+            },
+        ],
+        "type": "client_error",
+    }
 
 
 def test_api_items_retrieve_file_uploaded():

--- a/src/backend/core/tests/items/test_api_items_update.py
+++ b/src/backend/core/tests/items/test_api_items_update.py
@@ -55,7 +55,14 @@ def test_api_items_update_anonymous_forbidden(reach, role, via_parent):
     )
     assert response.status_code == 401
     assert response.json() == {
-        "detail": "Authentication credentials were not provided."
+        "errors": [
+            {
+                "attr": None,
+                "code": "not_authenticated",
+                "detail": "Authentication credentials were not provided.",
+            },
+        ],
+        "type": "client_error",
     }
 
     item.refresh_from_db()
@@ -106,7 +113,14 @@ def test_api_items_update_authenticated_unrelated_forbidden(reach, role, via_par
 
     assert response.status_code == 403
     assert response.json() == {
-        "detail": "You do not have permission to perform this action."
+        "errors": [
+            {
+                "attr": None,
+                "code": "permission_denied",
+                "detail": "You do not have permission to perform this action.",
+            },
+        ],
+        "type": "client_error",
     }
 
     item.refresh_from_db()
@@ -226,7 +240,14 @@ def test_api_items_update_authenticated_reader(via, via_parent, mock_user_teams)
 
     assert response.status_code == 403
     assert response.json() == {
-        "detail": "You do not have permission to perform this action."
+        "errors": [
+            {
+                "attr": None,
+                "code": "permission_denied",
+                "detail": "You do not have permission to perform this action.",
+            },
+        ],
+        "type": "client_error",
     }
 
     item.refresh_from_db()
@@ -394,7 +415,14 @@ def test_api_items_update_title_unique_in_current_path():
     )
     assert response.status_code == 400
     assert response.json() == {
-        "title": "An item with this title already exists in the current path."
+        "errors": [
+            {
+                "attr": "title",
+                "code": "item_update_title_already_exists",
+                "detail": "An item with this title already exists in the current path.",
+            },
+        ],
+        "type": "validation_error",
     }
 
 

--- a/src/backend/core/tests/test_api_users.py
+++ b/src/backend/core/tests/test_api_users.py
@@ -18,7 +18,14 @@ def test_api_users_list_anonymous():
     response = client.get("/api/v1.0/users/")
     assert response.status_code == 401
     assert response.json() == {
-        "detail": "Authentication credentials were not provided."
+        "errors": [
+            {
+                "attr": None,
+                "code": "not_authenticated",
+                "detail": "Authentication credentials were not provided.",
+            },
+        ],
+        "type": "client_error",
     }
 
 
@@ -229,7 +236,14 @@ def test_api_users_retrieve_me_anonymous():
     response = client.get("/api/v1.0/users/me/")
     assert response.status_code == 401
     assert response.json() == {
-        "detail": "Authentication credentials were not provided."
+        "errors": [
+            {
+                "attr": None,
+                "code": "not_authenticated",
+                "detail": "Authentication credentials were not provided.",
+            },
+        ],
+        "type": "client_error",
     }
 
 
@@ -262,7 +276,14 @@ def test_api_users_retrieve_anonymous():
 
     assert response.status_code == 401
     assert response.json() == {
-        "detail": "Authentication credentials were not provided."
+        "errors": [
+            {
+                "attr": None,
+                "code": "not_authenticated",
+                "detail": "Authentication credentials were not provided.",
+            },
+        ],
+        "type": "client_error",
     }
 
 
@@ -280,7 +301,16 @@ def test_api_users_retrieve_authenticated_self():
         f"/api/v1.0/users/{user.id!s}/",
     )
     assert response.status_code == 405
-    assert response.json() == {"detail": 'Method "GET" not allowed.'}
+    assert response.json() == {
+        "errors": [
+            {
+                "attr": None,
+                "code": "method_not_allowed",
+                "detail": 'Method "GET" not allowed.',
+            },
+        ],
+        "type": "client_error",
+    }
 
 
 def test_api_users_retrieve_authenticated_other():
@@ -299,7 +329,16 @@ def test_api_users_retrieve_authenticated_other():
         f"/api/v1.0/users/{other_user.id!s}/",
     )
     assert response.status_code == 405
-    assert response.json() == {"detail": 'Method "GET" not allowed.'}
+    assert response.json() == {
+        "errors": [
+            {
+                "attr": None,
+                "code": "method_not_allowed",
+                "detail": 'Method "GET" not allowed.',
+            },
+        ],
+        "type": "client_error",
+    }
 
 
 def test_api_users_create_anonymous():
@@ -313,8 +352,16 @@ def test_api_users_create_anonymous():
     )
     assert response.status_code == 401
     assert response.json() == {
-        "detail": "Authentication credentials were not provided."
+        "errors": [
+            {
+                "attr": None,
+                "code": "not_authenticated",
+                "detail": "Authentication credentials were not provided.",
+            },
+        ],
+        "type": "client_error",
     }
+
     assert models.User.objects.exists() is False
 
 
@@ -334,7 +381,17 @@ def test_api_users_create_authenticated():
         format="json",
     )
     assert response.status_code == 405
-    assert response.json() == {"detail": 'Method "POST" not allowed.'}
+    assert response.json() == {
+        "errors": [
+            {
+                "attr": None,
+                "code": "method_not_allowed",
+                "detail": 'Method "POST" not allowed.',
+            },
+        ],
+        "type": "client_error",
+    }
+
     assert models.User.objects.exclude(id=user.id).exists() is False
 
 
@@ -353,7 +410,14 @@ def test_api_users_update_anonymous():
 
     assert response.status_code == 401
     assert response.json() == {
-        "detail": "Authentication credentials were not provided."
+        "errors": [
+            {
+                "attr": None,
+                "code": "not_authenticated",
+                "detail": "Authentication credentials were not provided.",
+            },
+        ],
+        "type": "client_error",
     }
 
     user.refresh_from_db()
@@ -434,7 +498,14 @@ def test_api_users_patch_anonymous():
         )
         assert response.status_code == 401
         assert response.json() == {
-            "detail": "Authentication credentials were not provided."
+            "errors": [
+                {
+                    "attr": None,
+                    "code": "not_authenticated",
+                    "detail": "Authentication credentials were not provided.",
+                },
+            ],
+            "type": "client_error",
         }
 
     user.refresh_from_db()

--- a/src/backend/drive/settings.py
+++ b/src/backend/drive/settings.py
@@ -295,6 +295,7 @@ class Base(Configuration):
     INSTALLED_APPS = [
         "core",
         "drf_spectacular",
+        "drf_standardized_errors",
         # Third party apps
         "corsheaders",
         "django_filters",

--- a/src/backend/drive/urls.py
+++ b/src/backend/drive/urls.py
@@ -23,6 +23,7 @@ if settings.DEBUG:
         urlpatterns
         + staticfiles_urlpatterns()
         + static(settings.MEDIA_URL, item_root=settings.MEDIA_ROOT)
+        + debug_toolbar_urls()
     )
 
 
@@ -47,5 +48,3 @@ if settings.USE_SWAGGER or settings.DEBUG:
             name="redoc-schema",
         ),
     ]
-
-urlpatterns += debug_toolbar_urls()

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "djangorestframework==3.15.2",
     "dockerflow==2024.4.2",
     "drf_spectacular==0.28.0",
+    "drf-standardized-errors==0.14.1",
     "easy_thumbnails==2.10",
     "factory_boy==3.3.1",
     "gunicorn==23.0.0",

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -32,7 +32,6 @@ dependencies = [
     "django-configurations==2.5.1",
     "django-cors-headers==4.6.0",
     "django-countries==7.6.1",
-    "django-debug-toolbar==5.1.0",
     "django-filter==24.3",
     "django-ltree@git+https://github.com/mariocesar/django-ltree@5d955bc82021a50c522ee524106f6709e3b414e4",
     "django-parler==2.3",
@@ -68,6 +67,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+    "django-debug-toolbar==5.1.0",
     "django-extensions==3.2.3",
     "drf-spectacular-sidecar==2024.12.1",
     "freezegun==1.5.1",


### PR DESCRIPTION
## Purpose

Add standardized error codes for 40x responses

## Proposal

Proper handling of 40x error responses by the frontend requires machine codes.

DRF only returns a human readable message by default by we can rely on the standardized_errors package mentioned in DRF documentation.
