### PR TITLE
🐛(front) prevent selection clearing with modifier keys

### DIFF
--- a/src/frontend/apps/drive/src/features/explorer/components/ExplorerInner.tsx
+++ b/src/frontend/apps/drive/src/features/explorer/components/ExplorerInner.tsx
@@ -112,7 +112,8 @@ export const ExplorerInner = (props: ExplorerProps) => {
     const hasAnyClass = classesToCheck.some((className) =>
       target.classList.contains(className)
     );
-    if (hasAnyClass) {
+
+    if (hasAnyClass && !event?.ctrlKey && !event?.metaKey) {
       selection.clearSelection();
       setSelectedItems([]);
     }


### PR DESCRIPTION
## Purpose

Updated the selection clearing logic to prevent clearing when the Ctrl or Meta key is pressed. This change enhances user experience by allowing multiple selections while holding modifier keys.

