### PR TITLE
🐛(frontend) many fix before prod

### DIFF
--- a/src/frontend/apps/drive/src/features/explorer/components/ExplorerInner.tsx
+++ b/src/frontend/apps/drive/src/features/explorer/components/ExplorerInner.tsx
@@ -15,7 +15,6 @@ export const ExplorerInner = (props: ExplorerProps) => {
   const {
     setSelectedItems,
     itemId,
-    item,
     setRightPanelForcedItem,
     displayMode,
     selectedItems,
@@ -117,7 +116,8 @@ export const ExplorerInner = (props: ExplorerProps) => {
     const hasAnyClass = classesToCheck.some((className) =>
       target.classList.contains(className)
     );
-    if (hasAnyClass) {
+
+    if (hasAnyClass && !event?.ctrlKey && !event?.metaKey) {
       selection.clearSelection();
       setSelectedItems([]);
     }

--- a/src/frontend/apps/drive/src/features/explorer/components/grid/ExplorerGrid.tsx
+++ b/src/frontend/apps/drive/src/features/explorer/components/grid/ExplorerGrid.tsx
@@ -6,7 +6,7 @@ import {
   getCoreRowModel,
   useReactTable,
 } from "@tanstack/react-table";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import {
   itemToTreeItem,
@@ -25,6 +25,7 @@ import { ExplorerGridNameCell } from "./ExplorerGridNameCell";
 import { ExplorerGridUpdatedAtCell } from "./ExplorerGridUpdatedAtCell";
 import { ExplorerGridActionsCell } from "./ExplorerGridActionsCell";
 import { ExplorerProps, useExplorerInner } from "../Explorer";
+import { useDragItemContext } from "../ExplorerDndProvider";
 
 const EMPTY_ARRAY: Item[] = [];
 
@@ -43,14 +44,12 @@ export const ExplorerGrid = (props: ExplorerProps) => {
   } = useExplorer();
 
   const { filters } = useExplorerInner();
+  const { overedItemIds, setOveredItemIds } = useDragItemContext();
 
   const effectiveOnNavigate = props.onNavigate ?? onNavigate;
 
   const treeContext = useTreeContext();
   const columnHelper = createColumnHelper<Item>();
-  const [overedItemIds, setOveredItemIds] = useState<Record<string, boolean>>(
-    {}
-  );
 
   const columns = [
     columnHelper.accessor("title", {

--- a/src/frontend/apps/drive/src/features/explorer/components/modals/ExplorerRenameItemModal.tsx
+++ b/src/frontend/apps/drive/src/features/explorer/components/modals/ExplorerRenameItemModal.tsx
@@ -11,6 +11,7 @@ import { RhfInput } from "@/features/forms/components/RhfInput";
 import { useMutationRenameItem } from "../../hooks/useMutations";
 import { useRef } from "react";
 import { getExtension } from "../../utils/utils";
+import { useTreeContext } from "@gouvfr-lasuite/ui-kit";
 
 type Inputs = {
   title: string;
@@ -21,6 +22,7 @@ export const ExplorerRenameItemModal = (
     item: Item;
   }
 ) => {
+  const treeContext = useTreeContext<Item>();
   const { t } = useTranslation();
   const form = useForm<Inputs>({
     defaultValues: {
@@ -31,10 +33,20 @@ export const ExplorerRenameItemModal = (
   const updateItem = useMutationRenameItem();
 
   const onSubmit: SubmitHandler<Inputs> = async (data) => {
-    updateItem.mutate({
-      ...data,
-      id: props.item.id,
-    });
+    await updateItem.mutateAsync(
+      {
+        ...data,
+        id: props.item.id,
+      },
+      {
+        onSuccess: () => {
+          treeContext?.treeData.updateNode(props.item.id, {
+            title: data.title,
+          });
+        },
+      }
+    );
+
     props.onClose();
   };
 

--- a/src/frontend/apps/drive/src/features/explorer/components/tree/ExplorerTree.tsx
+++ b/src/frontend/apps/drive/src/features/explorer/components/tree/ExplorerTree.tsx
@@ -11,7 +11,7 @@ import {
   TreeViewNodeTypeEnum,
   useTreeContext,
 } from "@gouvfr-lasuite/ui-kit";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { ExplorerTreeItem } from "./ExplorerTreeItem";
 import { useMoveItems } from "../../api/useMoveItem";
 import { ExplorerCreateFolderModal } from "../modals/ExplorerCreateFolderModal";
@@ -22,9 +22,8 @@ import { addItemsMovedToast } from "../toasts/addItemsMovedToast";
 import { ExplorerTreeMoveConfirmationModal } from "./ExplorerTreeMoveConfirmationModal";
 
 export const ExplorerTree = () => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const move = useMoveItems();
-  const moveCallbackRef = useRef<() => void>(null);
   const moveConfirmationModal = useModal();
   const [moveState, setMoveState] = useState<{
     moveCallback: () => void;
@@ -149,6 +148,17 @@ export const ExplorerTree = () => {
       setTreeIsInitialized(true);
     }
   }, [initialOpenState, setTreeIsInitialized, treeIsInitialized]);
+
+  // When the language changes, we update the tree titles to be sure they are translated
+  useEffect(() => {
+    treeContext?.treeData.updateNode("PERSONAL_SPACE", {
+      headerTitle: t("explorer.workspaces.mainWorkspace"),
+    });
+
+    treeContext?.treeData.updateNode("SHARED_SPACE", {
+      headerTitle: t("explorer.tree.sharedSpace"),
+    });
+  }, [i18n.language, t]);
 
   const createFolderModal = useModal();
   const createWorkspaceModal = useModal();

--- a/src/frontend/apps/drive/src/features/explorer/components/tree/ExplorerTreeItem.tsx
+++ b/src/frontend/apps/drive/src/features/explorer/components/tree/ExplorerTreeItem.tsx
@@ -11,9 +11,9 @@ import {
 import { DroppableNodeTree } from "./DroppableNodeTree";
 import { NavigationEventType, useExplorer } from "../ExplorerContext";
 import { useModal } from "@openfun/cunningham-react";
-import { ExplorerEditWorkspaceModal } from "../modals/workspaces/ExplorerEditWorkspaceModal";
 import { ExplorerTreeItemActions } from "./ExplorerTreeItemActions";
 import { itemIsWorkspace } from "@/features/drivers/utils";
+import { ExplorerEditWorkspaceModal } from "../modals/workspaces/ExplorerEditWorkspaceModal";
 
 type ExplorerTreeItemProps = NodeRendererProps<TreeDataItem<TreeItem>>;
 

--- a/src/frontend/apps/drive/src/features/explorer/components/tree/ExplorerTreeItemActions.tsx
+++ b/src/frontend/apps/drive/src/features/explorer/components/tree/ExplorerTreeItemActions.tsx
@@ -12,6 +12,7 @@ import { WorkspaceShareModal } from "../modals/share/WorkspaceShareModal";
 import { itemIsWorkspace } from "@/features/drivers/utils";
 import { useDeleteTreeNode } from "./hooks/useDeleteTreeNode";
 import { ExplorerCreateFolderModal } from "../modals/ExplorerCreateFolderModal";
+import { ExplorerRenameItemModal } from "../modals/ExplorerRenameItemModal";
 export type ExplorerTreeItemActionsProps = {
   item: Item;
 };
@@ -27,7 +28,7 @@ export const ExplorerTreeItemActions = ({
   const isWorkspace = itemIsWorkspace(item);
   const { deleteTreeNode } = useDeleteTreeNode();
   const createFolderModal = useModal();
-
+  const renameModal = useModal();
   return (
     <>
       <div
@@ -59,15 +60,24 @@ export const ExplorerTreeItemActions = ({
               },
               {
                 icon: <img src={settingsSvg.src} alt="" />,
-                label: t("explorer.tree.workspace.options.settings"),
-
+                label: isWorkspace
+                  ? t("explorer.tree.workspace.options.settings_workspace")
+                  : t("explorer.grid.actions.rename"),
                 value: "settings",
                 isHidden: !item.abilities.update || item.main_workspace,
-                callback: editWorkspaceModal.open,
+                callback: () => {
+                  if (isWorkspace) {
+                    editWorkspaceModal.open();
+                  } else {
+                    renameModal.open();
+                  }
+                },
               },
               {
                 icon: <span className="material-icons">delete</span>,
-                label: t("explorer.tree.workspace.options.delete"),
+                label: !isWorkspace
+                  ? t("explorer.tree.workspace.options.delete_folder")
+                  : t("explorer.tree.workspace.options.delete_workspace"),
                 value: "delete",
                 isHidden: !item.abilities.destroy || item.main_workspace,
                 callback: () =>
@@ -116,6 +126,10 @@ export const ExplorerTreeItemActions = ({
       )}
       {createFolderModal.isOpen && (
         <ExplorerCreateFolderModal {...createFolderModal} parentId={item.id} />
+      )}
+
+      {renameModal.isOpen && (
+        <ExplorerRenameItemModal {...renameModal} item={item} key={item.id} />
       )}
     </>
   );

--- a/src/frontend/apps/drive/src/features/i18n/translations.json
+++ b/src/frontend/apps/drive/src/features/i18n/translations.json
@@ -100,8 +100,10 @@
           "workspace": {
             "options": {
               "info": "Information",
-              "settings": "Workspace settings",
-              "delete": "Delete workspace",
+              "settings_workspace": "Workspace settings",
+              "settings_folder": "Folder settings",
+              "delete_workspace": "Delete workspace",
+              "delete_folder": "Delete folder",
               "share": "Share workspace",
               "share_view": "View shares"
             },
@@ -138,6 +140,20 @@
           "delete": "Delete",
           "reset_selection": "Reset selection"
         },
+        "folders": {
+          "edit": {
+            "title": "Edit folder",
+            "description": "Edit folder information",
+            "cancel": "Cancel",
+            "submit": "Edit"
+          },
+          "form": {
+            "title": "Folder name",
+            "description": "Description",
+            "cancel": "Cancel",
+            "submit": "Edit"
+          }
+        },
         "workspaces": {
           "mainWorkspace": "My workspace",
           "form": {
@@ -157,40 +173,49 @@
             "cancel": "Cancel",
             "submit": "Edit"
           }
-        }
-      },
-      "actions": {
-        "createFolder": {
-          "modal": {
-            "title": "Create folder",
-            "label": "Folder name",
-            "placeholder": "Enter folder name",
-            "cancel": "Cancel",
-            "submit": "Create"
+        },
+        "actions": {
+          "createFolder": {
+            "modal": {
+              "title": "Create folder",
+              "label": "Folder name",
+              "placeholder": "Enter folder name",
+              "cancel": "Cancel",
+              "submit": "Create"
+            }
+          },
+          "upload": {
+            "toast": "Drop your files here to transfer them in {{title}}",
+            "toast_no_rights": "You don't have the necessary rights to transfer files in {{title}}",
+            "files": {
+              "description_one": "{{count}} file being transferred",
+              "description_other": "{{count}} files being transferred",
+              "description_done_one": "{{count}} file transferred",
+              "description_done_other": "{{count}} files transferred"
+            }
+          },
+          "delete": {
+            "toast_one": "Item deleted",
+            "toast_other": "{{count}} items deleted",
+            "low_rights_toast": "Vous ne pouvez pas restaurer ces éléments car vous n'avez pas les droits nécessaires."
+          },
+          "rename": {
+            "modal": {
+              "cancel": "Cancel",
+              "label": "New name",
+              "placeholder": "Enter the new name",
+              "submit": "Rename",
+              "title": "Rename"
+            }
+          },
+          "restore": {
+            "toast_one": "Item restored",
+            "toast_other": "{{count}} items restored"
+          },
+          "move": {
+            "toast_one": "{{count}} item moved",
+            "toast_other": "{{count}} items moved"
           }
-        },
-        "upload": {
-          "toast": "Drop your files here to transfer them in {{title}}",
-          "toast_no_rights": "You don't have the necessary rights to transfer files in {{title}}",
-          "files": {
-            "description_one": "{{count}} file being transferred",
-            "description_other": "{{count}} files being transferred",
-            "description_done_one": "{{count}} file transferred",
-            "description_done_other": "{{count}} files transferred"
-          }
-        },
-        "delete": {
-          "toast_one": "Item deleted",
-          "toast_other": "{{count}} items deleted",
-          "low_rights_toast": "Vous ne pouvez pas restaurer ces éléments car vous n'avez pas les droits nécessaires."
-        },
-        "restore": {
-          "toast_one": "Item restored",
-          "toast_other": "{{count}} items restored"
-        },
-        "move": {
-          "toast_one": "{{count}} item moved",
-          "toast_other": "{{count}} items moved"
         }
       },
       "time": {
@@ -250,10 +275,12 @@
       "explorer": {
         "rightPanel": {
           "multipleSelection": {
-            "text": "Plusieurs fichiers sélectionnés"
+            "text": "Plusieurs fichiers sélectionnés",
+            "alt": "Image de plusieurs fichiers sélectionnés"
           },
           "empty": {
-            "text": "Aucun fichier sélectionné"
+            "text": "Aucun fichier sélectionné",
+            "alt": "Image d'un fichier sélectionné"
           },
           "sharing": "Partage",
           "share": "Partager",
@@ -313,8 +340,10 @@
           "workspace": {
             "options": {
               "info": "Informations",
-              "settings": "Paramètre de l'espace",
-              "delete": "Supprimer l'espace",
+              "settings_workspace": "Paramètre de l'espace",
+              "settings_folder": "Paramètres du dossier",
+              "delete_workspace": "Supprimer l'espace",
+              "delete_folder": "Supprimer le dossier",
               "share": "Partager",
               "share_view": "Voir les accès"
             },
@@ -346,6 +375,20 @@
           "move": "Déplacer",
           "delete": "Supprimer",
           "reset_selection": "Réinitialiser la sélection"
+        },
+        "folders": {
+          "edit": {
+            "title": "Modifier le dossier",
+            "description": "Modifier les informations du dossier",
+            "cancel": "Annuler",
+            "submit": "Mettre à jour"
+          },
+          "form": {
+            "title": "Nom du dossier",
+            "description": "Description",
+            "cancel": "Annuler",
+            "submit": "Mettre à jour"
+          }
         },
         "workspaces": {
           "mainWorkspace": "Mon espace",


### PR DESCRIPTION
## Purpose

- The item in which we drop an item remains in its surrounded version and with its border after having dropped
- We get the workspace menu when clicking on "..." of a folder
- translations for explorer actions
- Can't select range + ctrl key #150



