### PR TITLE
🐛(front) prevent updates before tree initialization

### DIFF
--- a/src/frontend/apps/drive/src/features/explorer/components/tree/ExplorerTree.tsx
+++ b/src/frontend/apps/drive/src/features/explorer/components/tree/ExplorerTree.tsx
@@ -153,6 +153,10 @@ export const ExplorerTree = () => {
 
   // When the language changes, we update the tree titles to be sure they are translated
   useEffect(() => {
+    if (!treeIsInitialized) {
+      return;
+    }
+
     treeContext?.treeData.updateNode("PERSONAL_SPACE", {
       headerTitle: t("explorer.workspaces.mainWorkspace"),
     });
@@ -160,7 +164,7 @@ export const ExplorerTree = () => {
     treeContext?.treeData.updateNode("SHARED_SPACE", {
       headerTitle: t("explorer.tree.sharedSpace"),
     });
-  }, [i18n.language, t]);
+  }, [i18n.language, t, treeIsInitialized]);
 
   const createFolderModal = useModal();
   const createWorkspaceModal = useModal();


### PR DESCRIPTION
## Purpose

Added a check in the ExplorerTree component to ensure that tree updates translations  only occur after the tree has been initialized.

