### PR TITLE
🐛(back) import debug_toolbar_urls only in debug mode

### DIFF
--- a/src/backend/drive/urls.py
+++ b/src/backend/drive/urls.py
@@ -6,7 +6,6 @@ from django.contrib import admin
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.urls import include, path, re_path
 
-from debug_toolbar.toolbar import debug_toolbar_urls
 from drf_spectacular.views import (
     SpectacularJSONAPIView,
     SpectacularRedocView,
@@ -19,6 +18,8 @@ urlpatterns = [
 ]
 
 if settings.DEBUG:
+    from debug_toolbar.toolbar import debug_toolbar_urls
+
     urlpatterns = (
         urlpatterns
         + staticfiles_urlpatterns()


### PR DESCRIPTION
## Purpose

The debug_toolbar package is now a dev dependency. So the module can't be imported in other environment than the dev one. To avoid missing module error, we import it only in debug mode.


## Proposal

- [x] 🐛(back) import debug_toolbar_urls only in debug mode
