### PR TITLE
♻️(back) restore item with ancestors deleted in the highest ancestor

### DIFF
--- a/bin/Tiltfile
+++ b/bin/Tiltfile
@@ -7,7 +7,7 @@ docker_build(
     context='..',
     dockerfile='../Dockerfile',
     only=['./src/backend', './src/mail', './docker'],
-    target = 'backend-production',
+    target='backend-production',
     live_update=[
         sync('../src/backend', '/app'),
         run(
@@ -22,14 +22,15 @@ docker_build(
     context='..',
     dockerfile='../src/frontend/Dockerfile',
     only=['./src/frontend', './docker', './.dockerignore'],
-    target = 'drive',
+    target='drive',
     live_update=[
         sync('../src/frontend', '/home/frontend'),
     ]
 )
 
 k8s_resource('drive-backend-migrate', resource_deps=['postgres-postgresql'])
-k8s_resource('drive-backend-createsuperuser', resource_deps=['drive-backend-migrate'])
+k8s_resource('drive-backend-createsuperuser', 
+             resource_deps=['drive-backend-migrate'])
 k8s_resource('drive-backend', resource_deps=['drive-backend-migrate'])
 k8s_yaml(local('cd ../src/helm && helmfile -n drive -e dev template .'))
 
@@ -39,11 +40,13 @@ set -eu
 POD_NAME="$(tilt get kubernetesdiscovery drive-backend -ojsonpath='{.status.pods[0].name}')"
 kubectl -n drive exec "$POD_NAME" -- python manage.py makemigrations
 '''
-cmd_button('Make migration',
-           argv=['sh', '-c', migration],
-           resource='drive-backend',
-           icon_name='developer_board',
-           text='Run makemigration',
+
+cmd_button(
+    'Make migration',
+    argv=['sh', '-c', migration],
+    resource='drive-backend',
+    icon_name='developer_board',
+    text='Run makemigration',
 )
 
 pod_migrate = '''
@@ -52,6 +55,12 @@ set -eu
 POD_NAME="$(tilt get kubernetesdiscovery drive-backend -ojsonpath='{.status.pods[0].name}')"
 kubectl -n drive exec "$POD_NAME" -- python manage.py migrate --no-input
 '''
+
+cmd_button(
+    'Migrate db',
+    argv=['sh', '-c', pod_migrate],
+    resource='drive-backend',
+    icon_name='developer_board',
 cmd_button('Migrate db',
            argv=['sh', '-c', pod_migrate],
            resource='drive-backend',

--- a/src/backend/core/tests/test_models_items.py
+++ b/src/backend/core/tests/test_models_items.py
@@ -898,8 +898,9 @@ def test_models_items_restore_complex():
     )
     item = factories.ItemFactory(parent=parent, type=models.ItemTypeChoices.FOLDER)
 
-    child1 = factories.ItemFactory(parent=item)
-    child2 = factories.ItemFactory(parent=item)
+    child1, child2 = factories.ItemFactory.create_batch(2, parent=item)
+
+    assert item.parent() == parent
 
     # Soft delete first the item
     item.soft_delete()
@@ -934,10 +935,10 @@ def test_models_items_restore_complex():
     child2.refresh_from_db()
     grand_parent.refresh_from_db()
     assert item.deleted_at is None
-    assert item.ancestors_deleted_at == grand_parent.deleted_at
-    # child 1 and child 2 should now have the same ancestors_deleted_at as the grand parent
-    assert child1.ancestors_deleted_at == grand_parent.deleted_at
-    assert child2.ancestors_deleted_at == grand_parent.deleted_at
+    assert item.ancestors_deleted_at is None
+    assert child1.ancestors_deleted_at is None
+    assert child2.ancestors_deleted_at is None
+    assert item.parent() == grand_parent
 
 
 def test_models_items_restore_complex_bis():


### PR DESCRIPTION
## Purpose

When an item is restored and has ancestors deleted, instead of restoring it at its initial depth, we move it in the top level workspace.

## Proposal

- [x] ♻️(back) restore item with ancestors deleted in the highest ancestor

Fix #158 