### PR TITLE
🐛(front) fix computedStyleMap usage

### DIFF
--- a/src/frontend/apps/drive/src/features/ui/components/responsive/ResponsiveDivs.tsx
+++ b/src/frontend/apps/drive/src/features/ui/components/responsive/ResponsiveDivs.tsx
@@ -8,10 +8,8 @@ export const ResponsiveDivs = () => {
 
 export const isTablet = () => {
   return (
-    document
-      .querySelector("#responsive-tablet")
-      ?.computedStyleMap()
-      .get("display")
-      ?.toString() === "block"
+    getComputedStyle(
+      document.querySelector("#responsive-tablet")!
+    ).getPropertyValue("display") === "block"
   );
 };


### PR DESCRIPTION
This function is not available on Firefox, so I decided to switch to getComputedStyle that seem to achieve the same result.

