### PR TITLE
🐛(back) fix mail language and url

### DIFF
--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -1062,13 +1062,12 @@ class ItemAccessViewSet(
     def perform_create(self, serializer):
         """Add a new access to the item and send an email to the new added user."""
         access = serializer.save()
-        language = self.request.headers.get("Content-Language", "en-us")
 
         access.item.send_invitation_email(
             access.user.email,
             access.role,
             self.request.user,
-            language,
+            self.request.user.language or settings.LANGUAGE_CODE,
         )
 
 
@@ -1159,10 +1158,11 @@ class InvitationViewset(
         """Save invitation to a item then send an email to the invited user."""
         invitation = serializer.save()
 
-        language = self.request.headers.get("Content-Language", "en-us")
-
         invitation.item.send_invitation_email(
-            invitation.email, invitation.role, self.request.user, language
+            invitation.email,
+            invitation.role,
+            self.request.user,
+            self.request.user.language or settings.LANGUAGE_CODE,
         )
 
 

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -777,7 +777,7 @@ class Item(TreeModel, BaseModel):
                 "brandname": settings.EMAIL_BRAND_NAME,
                 "item": self,
                 "domain": domain,
-                "link": f"{domain}/items/{self.id}/",
+                "link": f"{domain}/explorer/items/{self.id}/",
                 "logo_img": settings.EMAIL_LOGO_IMG,
             }
         )

--- a/src/backend/core/tests/items/test_api_item_accesses_create.py
+++ b/src/backend/core/tests/items/test_api_item_accesses_create.py
@@ -4,6 +4,7 @@ Test item accesses API endpoints for users in drive's core app.
 
 import random
 
+from django.conf import settings
 from django.core import mail
 
 import pytest
@@ -114,7 +115,7 @@ def test_api_item_accesses_create_authenticated_administrator(via, mock_user_tea
     except for the "owner" role.
     An email should be sent to the accesses to notify them of the adding.
     """
-    user = factories.UserFactory()
+    user = factories.UserFactory(language=settings.LANGUAGE_CODE)
 
     client = APIClient()
     client.force_login(user)
@@ -197,7 +198,7 @@ def test_api_item_accesses_create_authenticated_owner(via, mock_user_teams):
     Owners of an item should be able to create item accesses whatever the role.
     An email should be sent to the accesses to notify them of the adding.
     """
-    user = factories.UserFactory()
+    user = factories.UserFactory(language=settings.LANGUAGE_CODE)
 
     client = APIClient()
     client.force_login(user)

--- a/src/backend/locale/fr_FR/LC_MESSAGES/django.po
+++ b/src/backend/locale/fr_FR/LC_MESSAGES/django.po
@@ -244,7 +244,7 @@ msgid "{name} invited you with the role \"{role}\" on the following item:"
 msgstr "{name} vous a invité avec le rôle \"{role}\" sur le item suivant:"
 
 #: core/models.py:820
-#, fuzzy, python-brace-format
+#, python-brace-format
 #| msgid "{name} shared an item with you: {title}"
 msgid "{name} shared an item with you: {title}"
 msgstr "{name} a partagé un item avec vous: {title}"
@@ -335,7 +335,7 @@ msgstr ""
 #: core/templates/mail/html/invitation.html:209
 #: core/templates/mail/text/invitation.txt:10
 msgid "Open"
-msgstr ""
+msgstr "Ouvrir"
 
 #: core/templates/mail/html/invitation.html:226
 #: core/templates/mail/text/invitation.txt:14
@@ -343,12 +343,14 @@ msgid ""
 " Drive, your new essential tool for organizing, sharing and collaborating as "
 "a team. "
 msgstr ""
+"Fichiers, votre outil essentiel pour organiser, partager et collaborer en "
+"équipe."
 
 #: core/templates/mail/html/invitation.html:233
 #: core/templates/mail/text/invitation.txt:16
 #, python-format
 msgid " Brought to you by %(brandname)s "
-msgstr ""
+msgstr " Proposé par %(brandname)s "
 
 #: drive/settings.py:250
 msgid "English"


### PR DESCRIPTION
The link in the link was not correct, also added french translation for the sent mails. The language used was not the language of the user, I replaced with the most up to date approach used on Docs.
