### PR TITLE
⏪️(back) use posthog with django lasuite integration

### DIFF
--- a/src/backend/core/authentication/views.py
+++ b/src/backend/core/authentication/views.py
@@ -1,0 +1,23 @@
+"""Drive core authentication views."""
+
+from django.http import HttpResponseRedirect
+
+from lasuite.oidc_login.views import (
+    OIDCAuthenticationCallbackView as LaSuiteOIDCAuthenticationCallbackView,
+)
+
+from core.authentication.exceptions import EmailNotAlphaAuthorized
+
+
+class OIDCAuthenticationCallbackView(LaSuiteOIDCAuthenticationCallbackView):
+    """
+    Custom view for handling the authentication callback from the OpenID Connect (OIDC) provider.
+    Handles the callback after authentication from the identity provider (OP).
+    Verifies the state parameter and performs necessary authentication actions.
+    """
+
+    def get(self, request):
+        try:
+            return super().get(request)
+        except EmailNotAlphaAuthorized:
+            return HttpResponseRedirect(self.failure_url + "?auth_error=alpha")

--- a/src/backend/core/tests/authentication/test_views.py
+++ b/src/backend/core/tests/authentication/test_views.py
@@ -1,0 +1,172 @@
+"""Unit tests for the Authentication Views."""
+
+from unittest import mock
+
+from django.contrib.sessions.middleware import SessionMiddleware
+from django.test import RequestFactory
+from django.test.utils import override_settings
+
+import posthog
+import pytest
+from mozilla_django_oidc.auth import (
+    OIDCAuthenticationBackend as MozillaOIDCAuthenticationBackend,
+)
+
+from core import factories
+from core.authentication.backends import OIDCAuthenticationBackend
+from core.authentication.views import (
+    OIDCAuthenticationCallbackView,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+@override_settings(
+    FEATURES_ALPHA=True,
+    LOGIN_REDIRECT_URL_FAILURE="/auth/failure",
+    LOGIN_REDIRECT_URL="/auth/success",
+)
+@mock.patch.object(
+    MozillaOIDCAuthenticationBackend,
+    "get_token",
+    return_value={"id_token": "mocked_id_token", "access_token": "mocked_access_token"},
+)
+@mock.patch.object(
+    MozillaOIDCAuthenticationBackend, "verify_token", return_value={"not": "needed"}
+)
+@mock.patch.object(
+    OIDCAuthenticationBackend,
+    "get_userinfo",
+    return_value={"sub": "mocked_sub", "email": "not_allowed@example.com"},
+)
+@mock.patch.object(posthog, "feature_enabled", return_value=False)
+def test_view_login_callback_alpha_not_authorized(
+    mocked_feature_enabled, mocked_get_userinfo, mocked_verify_token, mocked_get_token
+):
+    """When FEATURE_ALPHA is enabled, non-alpha authorized users via posthog should
+    be redirected with auth error.
+    """
+
+    user = factories.UserFactory(email="not_allowed@example.com")
+
+    request = RequestFactory().get(
+        "/callback/", data={"state": "mocked_state", "code": "mocked_code"}
+    )
+    request.user = user
+
+    middleware = SessionMiddleware(get_response=lambda x: x)
+    middleware.process_request(request)
+
+    mocked_state = "mocked_state"
+    request.session["oidc_states"] = {mocked_state: {"nonce": "mocked_nonce"}}
+    request.session.save()
+
+    callback_view = OIDCAuthenticationCallbackView.as_view()
+
+    response = callback_view(request)
+    mocked_get_token.assert_called_once()
+    mocked_verify_token.assert_called_once()
+    mocked_get_userinfo.assert_called_once()
+    mocked_feature_enabled.assert_called_once()
+    assert response.status_code == 302
+    assert response.url == "/auth/failure?auth_error=alpha"
+
+
+@override_settings(
+    FEATURES_ALPHA=True,
+    LOGIN_REDIRECT_URL_FAILURE="/auth/failure",
+    LOGIN_REDIRECT_URL="/auth/success",
+)
+@mock.patch.object(
+    MozillaOIDCAuthenticationBackend,
+    "get_token",
+    return_value={"id_token": "mocked_id_token", "access_token": "mocked_access_token"},
+)
+@mock.patch.object(
+    MozillaOIDCAuthenticationBackend, "verify_token", return_value={"not": "needed"}
+)
+@mock.patch.object(
+    OIDCAuthenticationBackend,
+    "get_userinfo",
+    return_value={"sub": "mocked_sub", "email": "allowed@example.com"},
+)
+@mock.patch.object(posthog, "feature_enabled", return_value=True)
+def test_view_login_callback_alpha_authorized(
+    mocked_feature_enabled, mocked_get_userinfo, mocked_verify_token, mocked_get_token
+):
+    """When FEATURE_ALPHA is enabled, alpha authorized users via posthog should
+    be authorized to login.
+    """
+
+    user = factories.UserFactory(email="allowed@example.com")
+
+    request = RequestFactory().get(
+        "/callback/", data={"state": "mocked_state", "code": "mocked_code"}
+    )
+    request.user = user
+
+    middleware = SessionMiddleware(get_response=lambda x: x)
+    middleware.process_request(request)
+
+    mocked_state = "mocked_state"
+    request.session["oidc_states"] = {mocked_state: {"nonce": "mocked_nonce"}}
+    request.session.save()
+
+    callback_view = OIDCAuthenticationCallbackView.as_view()
+
+    response = callback_view(request)
+    mocked_get_token.assert_called_once()
+    mocked_verify_token.assert_called_once()
+    mocked_get_userinfo.assert_called_once()
+    mocked_feature_enabled.assert_called_once()
+    assert response.status_code == 302
+    assert response.url == "/auth/success"
+
+
+@override_settings(
+    FEATURES_ALPHA=False,
+    LOGIN_REDIRECT_URL_FAILURE="/auth/failure",
+    LOGIN_REDIRECT_URL="/auth/success",
+)
+@mock.patch.object(
+    MozillaOIDCAuthenticationBackend,
+    "get_token",
+    return_value={"id_token": "mocked_id_token", "access_token": "mocked_access_token"},
+)
+@mock.patch.object(
+    MozillaOIDCAuthenticationBackend, "verify_token", return_value={"not": "needed"}
+)
+@mock.patch.object(
+    OIDCAuthenticationBackend,
+    "get_userinfo",
+    return_value={"sub": "mocked_sub", "email": "allowed@example.com"},
+)
+@mock.patch.object(posthog, "feature_enabled", return_value=False)
+def test_view_login_callback_alpha_authorized_by_default(
+    mocked_feature_enabled, mocked_get_userinfo, mocked_verify_token, mocked_get_token
+):
+    """By default, all users are authorized to login."""
+
+    user = factories.UserFactory(email="allowed@example.com")
+
+    request = RequestFactory().get(
+        "/callback/", data={"state": "mocked_state", "code": "mocked_code"}
+    )
+    request.user = user
+
+    middleware = SessionMiddleware(get_response=lambda x: x)
+    middleware.process_request(request)
+
+    mocked_state = "mocked_state"
+    request.session["oidc_states"] = {mocked_state: {"nonce": "mocked_nonce"}}
+    request.session.save()
+
+    callback_view = OIDCAuthenticationCallbackView.as_view()
+
+    response = callback_view(request)
+    mocked_get_token.assert_called_once()
+    mocked_verify_token.assert_called_once()
+    mocked_get_userinfo.assert_called_once()
+    mocked_feature_enabled.assert_not_called()
+    assert response.status_code == 302
+    assert response.url == "/auth/success"

--- a/src/backend/drive/settings.py
+++ b/src/backend/drive/settings.py
@@ -435,6 +435,7 @@ class Base(Configuration):
         default=True,
         environ_name="OIDC_CREATE_USER",
     )
+    OIDC_CALLBACK_CLASS = "core.authentication.views.OIDCAuthenticationCallbackView"
     OIDC_RP_SIGN_ALGO = values.Value(
         "RS256", environ_name="OIDC_RP_SIGN_ALGO", environ_prefix=None
     )

--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -41,7 +41,7 @@ ENV NEXT_PUBLIC_S3_DOMAIN_REPLACE=${S3_DOMAIN_REPLACE}
 RUN yarn build
 
 # ---- Front-end image ----
-FROM nginxinc/nginx-unprivileged:1.26-alpine AS frontend-production
+FROM nginxinc/nginx-unprivileged:alpine3.21 AS frontend-production
 
 # Un-privileged user running the application
 ARG DOCKER_USER


### PR DESCRIPTION
## Purpose

During the refacto replacing the usage of mozillaOIDC library to django lasuite library, I removed the usage of postog allowing to filter to a limited list of the user the access to posthog. This PR revert this removal and integrates it with django lasuite

## Proposal

- [x] ⏪️(back) use posthog with django lasuite integration
