### PR TITLE
🔧(backend) allow `DATA_DIR` to be configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,4 +12,6 @@ and this project adheres to
 
 ## Changed
 
+- 🔧(backend) allow `DATA_DIR` to be configurable #200 
+
 ## Deleted

--- a/src/backend/drive/settings.py
+++ b/src/backend/drive/settings.py
@@ -23,7 +23,7 @@ from sentry_sdk.integrations.django import DjangoIntegration
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-DATA_DIR = os.path.join("/", "data")
+DATA_DIR = os.getenv("DATA_DIR", os.path.join("/", "data"))
 
 
 def get_release():


### PR DESCRIPTION
`DATA_DIR` was always set to `/data`