### PR TITLE
:bug:(frontend) fix bind-mount hiding node_modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+# - 🔧(frontend) fix bind-mount that hid node_modules in frontend-dev container #XYZ
+
 ## Added
 
 ## Changed

--- a/compose.yaml
+++ b/compose.yaml
@@ -141,7 +141,7 @@ services:
         S3_DOMAIN_REPLACE: "http://localhost:9000"
     image: drive:frontend-development
     volumes:
-      - ./src/frontend/:/home/frontend/
+      - ./src/frontend/apps/drive:/home/frontend/apps/drive
     ports:
       - "3000:3000"
 


### PR DESCRIPTION
Narrow the bind-mount to ./src/frontend/apps/drive so that the node_modules folder created during the image build remains available inside the container. Solves: /bin/sh: next: not found when running make run-with-frontend.

Closes: #189

---

## Purpose

Running the project with `make run-with-frontend` made the container
`drive-frontend-dev-1` exit immediately:

$ next dev
/bin/sh: next: not found

The full `./src/frontend → /home/frontend/` bind-mount hid the
`node_modules` directory produced during the Docker build stage, removing
`node_modules/.bin/next` from the container’s `PATH`.

---

## Proposal

Bind-mount **only** the sources that need hot reload (`apps/drive`) and
stop masking the dependencies installed in the image.

```yaml
# docker-compose.yml — service frontend-dev
volumes:
-  - ./src/frontend/:/home/frontend/
+  - ./src/frontend/apps/drive:/home/frontend/apps/drive
