### PR TITLE
🩹(backend) default CORS_ALLOW_ALL_ORIGINS to False

### DIFF
--- a/src/backend/drive/settings.py
+++ b/src/backend/drive/settings.py
@@ -401,7 +401,7 @@ class Base(Configuration):
 
     # CORS
     CORS_ALLOW_CREDENTIALS = True
-    CORS_ALLOW_ALL_ORIGINS = values.BooleanValue(True)
+    CORS_ALLOW_ALL_ORIGINS = values.BooleanValue(False)
     CORS_ALLOWED_ORIGINS = values.ListValue([])
     CORS_ALLOWED_ORIGIN_REGEXES = values.ListValue([])
 


### PR DESCRIPTION
## Purpose

The settings CORS_ALLOW_ALL_ORIGINS was set to True by default.

This error is inherited from a old mistake made back in the days while working on the initial impress demo.

This is not something we want, this should be only allowed in development. We change the value in all the manifests in order to have the desired behavior in non development environments.


## Proposal

- [x] 🩹(backend) default CORS_ALLOW_ALL_ORIGINS to False
