### PR TITLE
Fix/boto3 version

### DIFF
--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -5,12 +5,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - 'main'
-    tags:
-      - 'v*'
-  pull_request:
-    branches:
-      - 'main'
+      - 'fix/boto3-version'
 
 env:
   DOCKER_USER: 1001:127

--- a/src/backend/drive/settings.py
+++ b/src/backend/drive/settings.py
@@ -147,6 +147,16 @@ class Base(Configuration):
         environ_name="AWS_STORAGE_BUCKET_NAME",
         environ_prefix=None,
     )
+    AWS_REQUEST_CHECKSUM_CALCULATION = values.Value(
+        "when_supported",
+        environ_name="AWS_REQUEST_CHECKSUM_CALCULATION",
+        environ_prefix=None,
+    )
+    AWS_RESPONSE_CHECKSUM_VALIDATION = values.Value(
+        "when_supported",
+        environ_name="AWS_RESPONSE_CHECKSUM_VALIDATION",
+        environ_prefix=None,
+    )
     AWS_S3_UPLOAD_POLICY_EXPIRATION = values.Value(
         24 * 60 * 60,  # 24h
         environ_name="AWS_S3_UPLOAD_POLICY_EXPIRATION",


### PR DESCRIPTION
## Purpose

Since version 1.36.0 the s3 client behavior has been updated to always
calculate the CRC32 checksum. This behavior is not always the default one
for solution implementing the s3 protocol. A workaround to this new
behavior is to configure the environment variables
AWS_REQUEST_CHECKSUM_CALCULATION and AWS_RESPONSE_CHECKSUM_VALIDATION
with the value `when_required`. The default value `when_supported` is
used in the settings.


## Proposal

- [x] 🔧(back) new settings to configure boto3 checksum validation