### PR TITLE
🐛(front) enable meta key selection

### DIFF
--- a/src/frontend/apps/drive/src/features/explorer/components/grid/ExplorerGrid.tsx
+++ b/src/frontend/apps/drive/src/features/explorer/components/grid/ExplorerGrid.tsx
@@ -124,6 +124,7 @@ export const ExplorerGrid = (props: ExplorerProps) => {
         disableItemDragAndDrop={disableItemDragAndDrop}
         selectedItems={selectedItems}
         setSelectedItems={setSelectedItems}
+        enableMetaKeySelection={true}
       />
     );
   };


### PR DESCRIPTION
We want to be able to perform selection using shift and ctrl in the main explorer context. This was removed by mistake by the recent move modal refactor. #213


