### PR TITLE
🔧(conf) update FRONTEND_THEME default value

### DIFF
--- a/env.d/development/common.dist
+++ b/env.d/development/common.dist
@@ -47,7 +47,7 @@ OIDC_REDIRECT_ALLOWED_HOSTS="http://localhost:8083,http://localhost:3000"
 OIDC_AUTH_REQUEST_EXTRA_PARAMS={"acr_values": "eidas1"}
 
 # Frontend
-FRONTEND_THEME=dsfr
+FRONTEND_THEME=default
 FRONTEND_MORE_LINK=https://docs.numerique.gouv.fr/docs/fa0aba15-e119-4185-b466-a4b37ad95950/
 FRONTEND_FEEDBACK_BUTTON_SHOW=True
 FRONTEND_FEEDBACK_BUTTON_IDLE=False


### PR DESCRIPTION
The dsfr value does not work now that we implemented its usage on the frontend side. It was causing a crash.
