### PR TITLE
🐛(global) fix wrong Content-Type on specific s3 implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,5 +24,6 @@ and this project adheres to
 
 - 🐛(i18n) fix language detection and rendering
 - 🌐(front) add english translation for rename modal
+- 🐛(global) fix wrong Content-Type on specific s3 implementations
 
 ## Deleted

--- a/src/backend/core/api/utils.py
+++ b/src/backend/core/api/utils.py
@@ -110,6 +110,7 @@ def generate_upload_policy(item):
         Conditions=[
             {"acl": "private"},
             ["content-length-range", 0, settings.ITEM_FILE_MAX_SIZE],
+            ["starts-with", "$Content-Type", ""],
         ],
         ExpiresIn=settings.AWS_S3_UPLOAD_POLICY_EXPIRATION,
     )

--- a/src/frontend/apps/drive/src/features/drivers/implementations/StandardDriver.ts
+++ b/src/frontend/apps/drive/src/features/drivers/implementations/StandardDriver.ts
@@ -252,6 +252,9 @@ export class StandardDriver extends Driver {
     Object.entries(fields).forEach(([key, value]) => {
       formData.append(key, value);
     });
+    // IMPORTANT !!! The Content-Type must be BEFORE file, otherwise it will be ignored by
+    // Scaleway object storage. Order matters !!!
+    formData.append("Content-Type", file.type);
     formData.append("file", file);
 
     let urlObject = new URL(url);


### PR DESCRIPTION
## Issue

When requesting file from the Scaleway object storage the Content-Type in the response header contain value like `multipart/form-data; boundary=----WebKitFormBoundaryP....` instead of expected values containing mime type like `application/pdf`. 

This was causing issue when previewing pdf, it was triggering a download instead of the browser native preview. 

This was only happening on Scaleway object storage, it is totally fine with MinIO which seems to guess itself the Content-Type based on Claude conversation. 

## Proposal

In its example here ( https://www.scaleway.com/en/docs/object-storage/api-cli/post-object/#examples ) we need to include Content-Type in the form data fields BEFORE ( ⚠️⚠️⚠️⚠️ ) the `file` field ( otherwise it doesn't work ) and also include a blank condition `["starts-with", "$Content-Type", ""]` when generating the policy otherwise it fails. 

This approach works both with MinIO and Scaleway object storage.