### PR TITLE
🐛(front) fix rename modal

### DIFF
--- a/src/frontend/apps/drive/src/features/explorer/components/embedded-explorer/EmbeddedExplorerGridActionsCell.tsx
+++ b/src/frontend/apps/drive/src/features/explorer/components/embedded-explorer/EmbeddedExplorerGridActionsCell.tsx
@@ -141,14 +141,14 @@ export const EmbeddedExplorerGridActionsCell = (
         {renameModal.isOpen && (
           <ExplorerRenameItemModal {...renameModal} item={item} key={item.id} />
         )}
-        {canShareWorkspace && (
+        {canShareWorkspace && shareWorkspaceModal.isOpen && (
           <WorkspaceShareModal
             {...shareWorkspaceModal}
             item={item}
             key={item.id}
           />
         )}
-        {canShareFile && (
+        {canShareFile && shareFileModal.isOpen && (
           <FileShareModal {...shareFileModal} item={item} key={item.id} />
         )}
       </Draggable>

--- a/src/frontend/apps/drive/src/features/explorer/components/modals/ExplorerRenameItemModal.tsx
+++ b/src/frontend/apps/drive/src/features/explorer/components/modals/ExplorerRenameItemModal.tsx
@@ -10,7 +10,6 @@ import { Item } from "@/features/drivers/types";
 import { RhfInput } from "@/features/forms/components/RhfInput";
 import { useMutationRenameItem } from "../../hooks/useMutations";
 import { useRef } from "react";
-import { getExtension } from "../../utils/utils";
 import { useTreeContext } from "@gouvfr-lasuite/ui-kit";
 
 type Inputs = {
@@ -83,12 +82,7 @@ export const ExplorerRenameItemModal = (
               inputRegister.ref(e);
               if (!inputRef.current) {
                 e?.focus();
-                const ext = getExtension(props.item, true);
-                if (ext) {
-                  e?.setSelectionRange(0, e.value.length - ext.length - 1);
-                } else {
-                  e?.setSelectionRange(0, e.value.length);
-                }
+                e?.setSelectionRange(0, e.value.length);
                 // We only set the ref once because it sometimes call this function with e === null, don't know why,
                 // but it causes setSelectionRange to be called frenetically.
                 inputRef.current = e;


### PR DESCRIPTION
## Purpose

Before the release, we noticed a few minor issues:

- The rename window wouldn't close.
- The extension was present in the rename window.

