### PR TITLE
🔧(cron): add pgdump cron on scalingo deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to
 - ✨(front) add PDF, Audio, Video, Image viewers
 - ✨(front) make frontend themable
 - ✨(global) Add File Picker SDK
+- 🔧(cron) add pgdump cron on scalingo deployment #264
 
 ## Changed
 

--- a/bin/scalingo_pgdump.sh
+++ b/bin/scalingo_pgdump.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+mkdir -p /tmp/pgdump
+cd /tmp/pgdump
+
+RESTIC_VERSION=0.18.0
+curl -fsSL --remote-name-all "https://github.com/restic/restic/releases/download/v${RESTIC_VERSION}/restic_${RESTIC_VERSION}_linux_amd64.bz2" \
+  "https://github.com/restic/restic/releases/download/v${RESTIC_VERSION}/SHA256SUMS" \
+  "https://github.com/restic/restic/releases/download/v${RESTIC_VERSION}/SHA256SUMS.asc"
+
+curl -fsSLo - https://restic.net/gpg-key-alex.asc | gpg --import
+gpg --verify SHA256SUMS.asc SHA256SUMS
+grep _linux_amd64.bz2 SHA256SUMS | sha256sum -c
+bzip2 -d restic_${RESTIC_VERSION}_linux_amd64.bz2
+mv restic_${RESTIC_VERSION}_linux_amd64 restic
+chmod +x ./restic
+
+# Download postgresql client binaries
+dbclient-fetcher pgsql
+
+# Actually dump and upload to scaleway s3
+FILENAME="${APP}_pgdump.sql"
+
+pg_dump --clean --if-exists --format c --dbname "${SCALINGO_POSTGRESQL_URL}" --no-owner --no-privileges --no-comments --exclude-schema 'information_schema' --exclude-schema '^pg_*' --file "${FILENAME}"
+
+export AWS_ACCESS_KEY_ID=${BACKUP_PGSQL_S3_KEY}
+export AWS_SECRET_ACCESS_KEY=${BACKUP_PGSQL_S3_SECRET}
+export RESTIC_PASSWORD=${BACKUP_PGSQL_ENCRYPTION_PASS}
+export RESTIC_REPOSITORY=s3:https://s3.fr-par.scw.cloud/${BACKUP_PGSQL_S3_BUCKET}/${APP}
+
+./restic snapshots -q || ./restic init
+
+./restic backup ${FILENAME}
+./restic forget --keep-daily 30

--- a/cron.json
+++ b/cron.json
@@ -1,0 +1,7 @@
+{
+  "jobs": [
+    {
+      "command": "0 0 * * * bin/scalingo_pgdump.sh"
+    }
+  ]
+}


### PR DESCRIPTION
add scalingo_pgdump script to dump the database and upload it to scaleway s3.
add cron.json to schedule pgdump everyday at noon UTC.