### PR TITLE
Developper Experience : improve frontend developpement experience for newcomers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ and this project adheres to
 ### Changed
 
 - 🐛(email) add missing email logo
-- 📝(devexp) fix and document how to run the project locally
+- 📝(dx) fix and document how to run the project locally
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ You can then login with sub `admin@example.com` and password `admin`.
 #### Locally
 To run the frontend locally :
 
-`cd src/frontend/apps/drive && yarn && yarn build-theme && yarn dev`
+`cd src/frontend/ && yarn && yarn build-theme && yarn dev`
 
 #### With Docker
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -66,7 +66,6 @@ services:
     environment:
       - PYLINTHOME=/app/.pylint.d
       - DJANGO_CONFIGURATION=Development
-      - CORS_ALLOW_ALL_ORIGINS=true
     env_file:
       - env.d/development/common
       - env.d/development/postgresql

--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -22,12 +22,10 @@ FROM frontend-deps AS drive-dev
 
 WORKDIR /home/frontend/apps/drive
 
-# Add local node_modules/.bin to PATH
-ENV PATH="/home/frontend/apps/drive/node_modules/.bin:$PATH"
-
 EXPOSE 3000
 
-RUN yarn && yarn build-theme && yarn dev
+RUN yarn build-theme
+CMD ["yarn", "dev"]
 
 # Tilt will rebuild drive target so, we dissociate drive and drive-builder 
 # to avoid rebuilding the app at every changes.

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "dev": "yarn workspace drive run dev",
     "build": "yarn workspace drive run build",
-    "lint": "yarn workspace drive run lint"
+    "lint": "yarn workspace drive run lint",
+    "build-theme": "yarn workspace drive build-theme"
   },
   "resolutions": {},
   "devDependencies": {


### PR DESCRIPTION
## Purpose

Many small things meant I couldn't make the project run locally when trying to contribute for the first time. Here are some fixes.

- fix docker image (there was a PATH issue that made next fail to run + the theme was not installed at startup)
- document in the README how to run the front without Docker
- fix a config variable that was set to dsfr instead of default
- fix a CORS issue in docker-compose
