### PR TITLE
🧑‍💻(keycloak) do not require ssl for dev server

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -190,7 +190,7 @@ services:
       - env.d/development/kc_postgresql
 
   keycloak:
-    image: quay.io/keycloak/keycloak:20.0.1
+    image: quay.io/keycloak/keycloak:26.3.2
     volumes:
       - ./docker/auth/realm.json:/opt/keycloak/data/import/realm.json
     command:
@@ -198,10 +198,8 @@ services:
       - --features=preview
       - --import-realm
       - --proxy=edge
-      - --hostname-url=http://localhost:8083
-      - --hostname-admin-url=http://localhost:8083/
+      - --hostname=http://localhost:8083
       - --hostname-strict=false
-      - --hostname-strict-https=false
     environment:
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin

--- a/docker/auth/realm.json
+++ b/docker/auth/realm.json
@@ -1,3 +1,8 @@
+[{
+  "realm": "master",
+  "sslRequired": "none",
+  "enabled" : true
+},
 {
   "id": "ccf4fd40-4286-474d-854a-4714282a8bec",
   "realm": "drive",
@@ -26,7 +31,7 @@
   "oauth2DeviceCodeLifespan": 600,
   "oauth2DevicePollingInterval": 5,
   "enabled": true,
-  "sslRequired": "external",
+  "sslRequired": "none",
   "registrationAllowed": true,
   "registrationEmailAsUsername": false,
   "rememberMe": true,
@@ -2278,4 +2283,4 @@
   "clientPolicies": {
     "policies": []
   }
-}
+}]


### PR DESCRIPTION
## Purpose

Set `sslRequired` to `none` for all realms in the keycloak dev service. By default this settings is set to `external` and only local IPs are granted to access to the server without SSL. But sometimes, with docker (desktop?) it appears the network configuration may keycloak to consider the accessing ip as not local.

We also took opportunity of this change to use the latest keycloak image version