### PR TITLE
♻️(back) manage title uniqueness by generating new one if existing

### DIFF
--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -292,18 +292,9 @@ class ItemSerializer(ListItemSerializer):
 
     def update(self, instance, validated_data):
         """Validate that the title is unique in the current path."""
-        if (
-            instance.title != validated_data.get("title")
-            and instance.depth > 1
-            and instance.is_item_title_existing(validated_data.get("title"))
-        ):
-            raise serializers.ValidationError(
-                {
-                    "title": _(
-                        "An item with this title already exists in the current path."
-                    )
-                },
-                code="item_update_title_already_exists",
+        if instance.title != validated_data.get("title") and instance.depth > 1:
+            validated_data["title"] = instance.manage_unique_title(
+                validated_data.get("title")
             )
 
         return super().update(instance, validated_data)

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -30,6 +30,8 @@ from django_ltree.managers import TreeManager, TreeQuerySet
 from django_ltree.models import TreeModel
 from timezone_field import TimeZoneField
 
+from core.utils.item_title import manage_unique_title as manage_unique_title_utils
+
 logger = getLogger(__name__)
 
 
@@ -418,20 +420,6 @@ class ItemQuerySet(TreeQuerySet):
         return self.filter(models.Q(link_reach=LinkReachChoices.PUBLIC))
 
 
-def _is_item_title_existing(queryset, title):
-    """Check if the title is unique in the same path."""
-    return (
-        queryset.filter(title=title)
-        .filter(
-            models.Q(
-                models.Q(deleted_at__isnull=True)
-                | models.Q(ancestors_deleted_at__isnull=True)
-            )
-        )
-        .exists()
-    )
-
-
 class ItemManager(TreeManager):
     """Custom manager for Item model overriding create_child method."""
 
@@ -461,19 +449,9 @@ class ItemManager(TreeManager):
                         )
                     }
                 )
-
-            if _is_item_title_existing(
-                self.children(parent.path),
-                kwargs.get("title"),
-            ):
-                raise ValidationError(
-                    {
-                        "title": ValidationError(
-                            _("title already exists in this folder."),
-                            code="item_create_child_title_already_exists",
-                        )
-                    }
-                )
+            kwargs["title"] = manage_unique_title_utils(
+                self.children(parent.path), kwargs.get("title")
+            )
 
         if not kwargs.get("id"):
             kwargs["id"] = str(uuid.uuid4())
@@ -645,9 +623,9 @@ class Item(TreeModel, BaseModel):
         """Generate a unique cache key for each item."""
         return f"item_{self.id!s}_nb_accesses"
 
-    def is_item_title_existing(self, title):
+    def manage_unique_title(self, title):
         """Check if the title is unique in the same path."""
-        return _is_item_title_existing(
+        return manage_unique_title_utils(
             self.siblings(),
             title,
         )

--- a/src/backend/core/tests/items/test_api_items_children_create.py
+++ b/src/backend/core/tests/items/test_api_items_children_create.py
@@ -335,8 +335,8 @@ def test_api_items_children_create_not_a_folder():
 
 def test_api_items_children_create_title_already_existing_at_the_same_level():
     """
-    It should not be possible to create a nested item with a title that already exists
-    at the same level.
+    Creating a nested item with a title that already exists at the same level should
+    automatically add a number to the title.
     """
     user = factories.UserFactory()
     client = APIClient()
@@ -358,17 +358,8 @@ def test_api_items_children_create_title_already_existing_at_the_same_level():
         format="json",
     )
 
-    assert response.status_code == 400
-    assert response.json() == {
-        "errors": [
-            {
-                "attr": "title",
-                "code": "item_create_child_title_already_exists",
-                "detail": "title already exists in this folder.",
-            },
-        ],
-        "type": "validation_error",
-    }
+    assert response.status_code == 201
+    assert response.json()["title"] == "my item_1"
 
 
 def test_api_items_children_create_item_soft_deleted_with_same_title_exists():

--- a/src/backend/core/tests/items/test_api_items_update.py
+++ b/src/backend/core/tests/items/test_api_items_update.py
@@ -403,23 +403,14 @@ def test_api_items_update_title_unique_in_current_path():
         users=[(user, models.RoleChoices.OWNER)],
     )
 
-    # update child1 to rename it to child2 should fails
+    # update child1 to rename it to child2 should automatically add a number to the title
     response = client.put(
         f"/api/v1.0/items/{child.id!s}/",
         {"title": "child2"},
         format="json",
     )
-    assert response.status_code == 400
-    assert response.json() == {
-        "errors": [
-            {
-                "attr": "title",
-                "code": "item_update_title_already_exists",
-                "detail": "An item with this title already exists in the current path.",
-            },
-        ],
-        "type": "validation_error",
-    }
+    assert response.status_code == 200
+    assert response.json()["title"] == "child2_1"
 
 
 def test_api_items_update_title_unique_in_current_path_soft_deleted():

--- a/src/backend/core/tests/test_models_items.py
+++ b/src/backend/core/tests/test_models_items.py
@@ -735,7 +735,7 @@ def test_models_items_title_must_be_set():
 
 
 def test_models_items_unique_title_in_current_path():
-    """Check title unicity in the current path."""
+    """Check title management in the current path."""
     parent = factories.ItemFactory(type=models.ItemTypeChoices.FOLDER, title="folder")
     parent2 = factories.ItemFactory(
         type=models.ItemTypeChoices.FOLDER, title="an other one"
@@ -763,24 +763,40 @@ def test_models_items_unique_title_in_current_path():
         filename="file.txt",
     )
 
-    with pytest.raises(ValidationError) as exc_info:
-        factories.ItemFactory(
-            parent=parent, title="folder", type=models.ItemTypeChoices.FOLDER
-        )
-        assert exc_info.value.message_dict == {
-            "title": "title already exists in this folder."
-        }
+    modified_folder_title = factories.ItemFactory(
+        parent=parent, title="folder", type=models.ItemTypeChoices.FOLDER
+    )
 
-    with pytest.raises(ValidationError) as exc_info:
-        factories.ItemFactory(
-            parent=parent,
-            title="file.txt",
-            type=models.ItemTypeChoices.FILE,
-            filename="file.txt",
-        )
-        assert exc_info.value.message_dict == {
-            "title": "title already exists in this folder."
-        }
+    assert modified_folder_title.title == "folder_1"
+
+    factories.ItemFactory(
+        parent=parent,
+        title="file_1.txt",
+        type=models.ItemTypeChoices.FILE,
+        filename="file_1.txt",
+    )
+
+    factories.ItemFactory(
+        parent=parent,
+        title="file_2.txt",
+        type=models.ItemTypeChoices.FILE,
+        filename="file_2.txt",
+    )
+
+    factories.ItemFactory(
+        parent=parent,
+        title="file_10.txt",
+        type=models.ItemTypeChoices.FILE,
+        filename="file_10.txt",
+    )
+
+    modified_file_title = factories.ItemFactory(
+        parent=parent,
+        title="file.txt",
+        type=models.ItemTypeChoices.FILE,
+        filename="file.txt",
+    )
+    assert modified_file_title.title == "file_11.txt"
 
 
 def test_models_items_unique_title_in_current_path_soft_deleted():

--- a/src/backend/core/utils/item_title.py
+++ b/src/backend/core/utils/item_title.py
@@ -1,0 +1,76 @@
+"""Module to manage item title uniqueness."""
+
+from os.path import splitext
+
+from django.db import models
+
+
+def _get_non_deleted_filter():
+    """Return a Q object for filtering non-deleted items."""
+    return models.Q(
+        models.Q(deleted_at__isnull=True) | models.Q(ancestors_deleted_at__isnull=True)
+    )
+
+
+def _is_item_title_existing(queryset, title):
+    """Check if the title is unique in the same path."""
+    return queryset.filter(title=title).filter(_get_non_deleted_filter()).exists()
+
+
+def _extract_number_from_title(title):
+    """Extract the numeric suffix from a title with the given base."""
+    base, _ = splitext(title)
+    try:
+        return int(base.split("_")[-1])
+    except (ValueError, IndexError):
+        return 0
+
+
+def _build_numbered_title_regex(base_title, ext):
+    """Build a regex pattern to match numbered versions of a title."""
+    escaped_base = base_title.replace("(", r"\(").replace(")", r"\)")
+    pattern = rf"^{escaped_base}_\d+"
+    if ext:
+        escaped_ext = ext.replace(".", r"\.")
+        pattern += rf"{escaped_ext}$"
+    else:
+        pattern += r"$"
+    return pattern
+
+
+def _get_next_available_number(queryset, base_title, ext):
+    """Get the next available number for a duplicate title."""
+    title_regex = _build_numbered_title_regex(base_title, ext)
+
+    # Get all numbered versions (no ordering needed since we iterate through all)
+    # Ordering is not made using order_by nor python list sorting function because
+    # the result is not what we expect. For example file_1.txt, file_2.txt, file_10.txt
+    # will be sorted as file_1.txt, file_10.txt, file_2.txt.
+    existing_titles = (
+        queryset.filter(title__regex=title_regex)
+        .filter(_get_non_deleted_filter())
+        .values_list("title", flat=True)
+    )
+
+    if not existing_titles:
+        return 1
+
+    # Extract numbers and find the maximum
+    max_number = 0
+    for title in existing_titles:
+        number = _extract_number_from_title(title)
+        max_number = max(max_number, number)
+
+    return max_number + 1
+
+
+def manage_unique_title(queryset, title):
+    """Manage the unique title in the same path."""
+    # Return original title if it doesn't exist
+    if not _is_item_title_existing(queryset, title):
+        return title
+
+    # Handle duplicate by adding numeric suffix
+    base_title, ext = splitext(title)
+    next_number = _get_next_available_number(queryset, base_title, ext)
+    return f"{base_title}_{next_number}{ext}"


### PR DESCRIPTION
## Purpose

For now it wasn't possible to create twice an item with the same title in the same path and an exception was raised. We change it by incrementing a version number in the item title. It is still not possible to have twice the same title but the item is created with a different one.

## Proposal

- [x] ♻️(back) manage title uniqueness by generating new one if existing

## Note

This is a first iteration that does not need design. An other iteration will be made with #289 
