### PR TITLE
🐛(nginx) add trash route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to
 ### Fixed
 
 - 🐛(front) set the correct move icon
+- 🐛(nginx) add trash route
 
 ## [v0.1.1] - 2025-07-30
 

--- a/src/frontend/apps/drive/conf/default.conf
+++ b/src/frontend/apps/drive/conf/default.conf
@@ -23,6 +23,10 @@ server {
       try_files $uri /sdk.html;
   }
 
+  location ~ "^/trash/?$" {
+    try_files $uri /explorer/trash.html;
+  }
+
   location ~ "^/401/?$" {
     try_files $uri /401.html;
   }

--- a/src/nginx/servers.conf.erb
+++ b/src/nginx/servers.conf.erb
@@ -79,6 +79,10 @@ server {
         try_files $uri /sdk.html;
     }
 
+    location ~ "^/trash/?$" {
+        try_files $uri /explorer/trash.html;
+    }
+
     location ~ "^/401/?$" {
         try_files $uri /401.html;
     }


### PR DESCRIPTION
The trash route was not registered so it was giving a 404 when going to /trash url directly.

Fixes #259
