### PR TITLE
🔧(nginx) fix trash route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- 🔧(nginx) fix trash route #309
+
 ## [v0.2.0] - 2025-08-18
 
 ### Added

--- a/src/frontend/apps/drive/conf/default.conf
+++ b/src/frontend/apps/drive/conf/default.conf
@@ -23,7 +23,7 @@ server {
       try_files $uri /sdk.html;
   }
 
-  location ~ "^/trash/?$" {
+  location ~ "^/explorer/trash/?$" {
     try_files $uri /explorer/trash.html;
   }
 

--- a/src/nginx/servers.conf.erb
+++ b/src/nginx/servers.conf.erb
@@ -79,7 +79,7 @@ server {
         try_files $uri /sdk.html;
     }
 
-    location ~ "^/trash/?$" {
+    location ~ "^/explorer/trash/?$" {
         try_files $uri /explorer/trash.html;
     }
 


### PR DESCRIPTION
The previous fix was missing to explorer part.

