### PR TITLE
🐛(front) fix workspace link react cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 ### Fixed
 
 - 🔧(nginx) fix trash route #309
+- 🐛(front) fix workspace link react cache #310
 
 ## [v0.2.0] - 2025-08-18
 

--- a/src/frontend/apps/drive/src/features/explorer/components/modals/share/WorkspaceShareModal.tsx
+++ b/src/frontend/apps/drive/src/features/explorer/components/modals/share/WorkspaceShareModal.tsx
@@ -25,6 +25,7 @@ import {
   HorizontalSeparator,
   ShareModal,
   ShareModalCopyLinkFooter,
+  useTreeContext,
 } from "@gouvfr-lasuite/ui-kit";
 import { useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo, useRef, useState } from "react";
@@ -44,7 +45,7 @@ export const WorkspaceShareModal = ({
   const { t } = useTranslation();
   const queryClient = useQueryClient();
   const copyToClipboard = useClipboard();
-
+  const treeContext = useTreeContext<Item>();
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
   const [queryValue, setQueryValue] = useState("");
   const previousSearchResult = useRef<User[]>([]);
@@ -226,10 +227,19 @@ export const WorkspaceShareModal = ({
       ]}
       linkReach={item.link_reach}
       onUpdateLinkReach={(value) => {
-        updateItem.mutate({
-          id: item.id,
-          link_reach: value as LinkReach,
-        });
+        updateItem.mutate(
+          {
+            id: item.id,
+            link_reach: value as LinkReach,
+          },
+          {
+            onSuccess: () => {
+              treeContext?.treeData.updateNode(item.id, {
+                link_reach: value as LinkReach,
+              });
+            },
+          }
+        );
       }}
       canView={item.abilities.accesses_view}
     >


### PR DESCRIPTION
Update the left tree in order to get the most up to date field value possible. It was keeping the old value when reopening the modal.
