### PR TITLE
🌐(front) fix share item wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to
 - 🔧(nginx) fix trash route #309
 - 🐛(front) fix workspace link react cache #310
 - 🐛(backend) allow item partial update without modifying title #316
+- 🌐(front) fix share item wording #315
 
 ## [v0.2.0] - 2025-08-18
 

--- a/src/frontend/apps/drive/src/features/i18n/translations.json
+++ b/src/frontend/apps/drive/src/features/i18n/translations.json
@@ -166,7 +166,7 @@
               "settings_folder": "Folder settings",
               "delete_workspace": "Delete workspace",
               "delete_folder": "Delete folder",
-              "share": "Share workspace",
+              "share": "Share",
               "share_view": "View shares"
             },
             "move": {


### PR DESCRIPTION
Align the enlish wording on the french one, without specifying "workspace".

Fixes #313
