### PR TITLE
🐛(backend) allow item partial update without modifying title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to
 
 - 🔧(nginx) fix trash route #309
 - 🐛(front) fix workspace link react cache #310
+- 🐛(backend) allow item partial update without modifying title #316
 
 ## [v0.2.0] - 2025-08-18
 

--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -292,7 +292,11 @@ class ItemSerializer(ListItemSerializer):
 
     def update(self, instance, validated_data):
         """Validate that the title is unique in the current path."""
-        if instance.title != validated_data.get("title") and instance.depth > 1:
+        if (
+            validated_data.get("title")
+            and instance.title != validated_data.get("title")
+            and instance.depth > 1
+        ):
             validated_data["title"] = instance.manage_unique_title(
                 validated_data.get("title")
             )

--- a/src/backend/core/tests/items/test_api_items_update.py
+++ b/src/backend/core/tests/items/test_api_items_update.py
@@ -506,3 +506,88 @@ def test_api_items_update_empty_description():
 
     item.refresh_from_db()
     assert item.description == ""
+
+
+def test_api_items_update_link_reach():
+    """
+    Update file link_reach
+    """
+
+    user = factories.UserFactory()
+
+    client = APIClient()
+    client.force_login(user)
+
+    parent = factories.ItemFactory(
+        link_reach="restricted",
+        type=models.ItemTypeChoices.FOLDER,
+        creator=user,
+        users=[(user, models.RoleChoices.OWNER)],
+    )
+
+    item = factories.ItemFactory(
+        parent=parent,
+        link_reach="restricted",
+        type=models.ItemTypeChoices.FILE,
+        creator=user,
+    )
+
+    assert item.title is not None
+
+    response = client.patch(
+        f"/api/v1.0/items/{item.id!s}/",
+        {"link_reach": "public"},
+        format="json",
+    )
+    assert response.status_code == 200
+    assert response.json()["link_reach"] == "public"
+
+    item.refresh_from_db()
+    assert item.link_reach == "public"
+
+
+def test_api_items_update_empty_title():
+    """
+    Update file title
+    """
+
+    user = factories.UserFactory()
+
+    client = APIClient()
+    client.force_login(user)
+
+    parent = factories.ItemFactory(
+        link_reach="restricted",
+        type=models.ItemTypeChoices.FOLDER,
+        creator=user,
+        users=[(user, models.RoleChoices.OWNER)],
+    )
+
+    item = factories.ItemFactory(
+        parent=parent,
+        link_reach="restricted",
+        type=models.ItemTypeChoices.FILE,
+        creator=user,
+    )
+
+    assert item.title is not None
+
+    response = client.patch(
+        f"/api/v1.0/items/{item.id!s}/",
+        {"title": ""},
+        format="json",
+    )
+    assert response.json() == {
+        "errors": [
+            {
+                "attr": "title",
+                "code": "blank",
+                "detail": "This field may not be blank.",
+            },
+        ],
+        "type": "validation_error",
+    }
+    assert response.status_code == 400
+
+    item.refresh_from_db()
+    assert item.title is not None


### PR DESCRIPTION
## Purpose

Partially updating an item without specifying the title in the payload was always failing for item with a depth higher than 1. This is because the title is "sanitize" on a None value. To fix this, this sanitization is not made if the title is not sent in the payload.


## Proposal

- [x] 🐛(backend) allow item partial update without modifying title
