### PR TITLE
⚡️(ci) use setup-python cache option

### DIFF
--- a/.github/workflows/crowdin_upload.yml
+++ b/.github/workflows/crowdin_upload.yml
@@ -21,9 +21,10 @@ jobs:
         uses: actions/checkout@v4
       # Backend i18n
       - name: Install Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12.6"
+          cache: 'pip'
       - name: Upgrade pip and setuptools
         run: pip install --upgrade pip setuptools
       - name: Install development dependencies

--- a/.github/workflows/drive.yml
+++ b/.github/workflows/drive.yml
@@ -105,9 +105,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Install Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12.6"
+          cache: 'pip'
       - name: Upgrade pip and setuptools
         run: pip install --upgrade pip setuptools
       - name: Install development dependencies
@@ -200,9 +201,10 @@ jobs:
             mc version enable drive/drive-media-storage"
 
       - name: Install Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12.6"
+          cache: 'pip'
 
       - name: Install development dependencies
         run: pip install --user .[dev]


### PR DESCRIPTION
## Purpose

The setup-python action is able to cache the dependencies and reuse this
cache while the pyproject file has not changed. It is easy to setup,
juste the package manager used has to be declared in the cache settings.


## Proposal

- [x] ⚡️(ci) use setup-python cache option
