### PR TITLE
🐛(front) fix folders return value in AppExplorerGrid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to
 - 🐛(front) fix workspace link react cache #310
 - 🐛(backend) allow item partial update without modifying title #316
 - 🌐(front) fix share item wording #315
+- 🐛(front) fix left tree glitch #323
 
 
 ## [v0.2.0] - 2025-08-18

--- a/src/frontend/apps/drive/src/features/explorer/components/app-view/AppExplorerGrid.tsx
+++ b/src/frontend/apps/drive/src/features/explorer/components/app-view/AppExplorerGrid.tsx
@@ -43,7 +43,7 @@ export const AppExplorerGrid = (props: AppExplorerProps) => {
 
   const folders = useMemo(() => {
     if (!props.childrenItems) {
-      return [];
+      return undefined;
     }
 
     return props.childrenItems.filter((item) => item.type === ItemType.FOLDER);
@@ -59,6 +59,10 @@ export const AppExplorerGrid = (props: AppExplorerProps) => {
 
   // Sets the children of the item in the tree.
   useEffect(() => {
+    if (!folders) {
+      return;
+    }
+
     const itemFilters = filters ?? {};
 
     if (!treeIsInitialized || !itemId || Object.keys(itemFilters).length > 0) {

--- a/src/frontend/apps/drive/src/features/explorer/components/app-view/AppExplorerInner.tsx
+++ b/src/frontend/apps/drive/src/features/explorer/components/app-view/AppExplorerInner.tsx
@@ -55,6 +55,11 @@ export const AppExplorerInner = (props: AppExplorerProps) => {
     },
   }: SelectionEvent) => {
     setRightPanelForcedItem(undefined);
+
+    if (added.length == 0 && removed.length == 0) {
+      return;
+    }
+
     setSelectedItems((prev) => {
       let next = [...prev];
 


### PR DESCRIPTION


## Purpose

Changed the return value of the folders variable from an empty array to undefined when there are no children items. Additionally, added a guard clause in the useEffect to prevent execution if folders is undefined.



close #268 
