### PR TITLE
♻️(backend) use PUT presigned-url to upload files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to
 ### Changed
 
 - ♻️(tilt) use helm dev-backend chart
+- ♻️(backend) use PUT presigned-url to upload files
 
 ### Fixed
 

--- a/env.d/development/common
+++ b/env.d/development/common
@@ -26,6 +26,8 @@ STORAGES_STATICFILES_BACKEND=django.contrib.staticfiles.storage.StaticFilesStora
 AWS_S3_ENDPOINT_URL=http://minio:9000
 AWS_S3_ACCESS_KEY_ID=drive
 AWS_S3_SECRET_ACCESS_KEY=password
+AWS_S3_SIGNATURE_VERSION=s3v4
+AWS_S3_DOMAIN_REPLACE=http://localhost:9000
 MEDIA_BASE_URL=http://localhost:8083
 
 # OIDC

--- a/src/backend/core/api/utils.py
+++ b/src/backend/core/api/utils.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from django.conf import settings
 from django.core.files.storage import default_storage
 
+import boto3
 import botocore
 
 
@@ -101,17 +102,24 @@ def generate_upload_policy(item):
     # Generate a unique key for the item
     key = f"{item.key_base}/{item.filename}"
 
+    if settings.AWS_S3_DOMAIN_REPLACE:
+        s3_client = boto3.client(
+            "s3",
+            aws_access_key_id=settings.AWS_S3_ACCESS_KEY_ID,
+            aws_secret_access_key=settings.AWS_S3_SECRET_ACCESS_KEY,
+            endpoint_url=settings.AWS_S3_DOMAIN_REPLACE,
+            config=botocore.client.Config(
+                region_name=settings.AWS_S3_REGION_NAME,
+                signature_version=settings.AWS_S3_SIGNATURE_VERSION,
+            ),
+        )
+    else:
+        s3_client = default_storage.connection.meta.client
+
     # Generate the policy
-    s3_client = default_storage.connection.meta.client
-    policy = s3_client.generate_presigned_post(
-        default_storage.bucket_name,
-        key,
-        Fields={"acl": "private"},
-        Conditions=[
-            {"acl": "private"},
-            ["content-length-range", 0, settings.ITEM_FILE_MAX_SIZE],
-            ["starts-with", "$Content-Type", ""],
-        ],
+    policy = s3_client.generate_presigned_url(
+        ClientMethod="put_object",
+        Params={"Bucket": default_storage.bucket_name, "Key": key, "ACL": "private"},
         ExpiresIn=settings.AWS_S3_UPLOAD_POLICY_EXPIRATION,
     )
 

--- a/src/backend/drive/settings.py
+++ b/src/backend/drive/settings.py
@@ -149,9 +149,18 @@ class Base(Configuration):
         environ_name="AWS_STORAGE_BUCKET_NAME",
         environ_prefix=None,
     )
+    AWS_S3_SIGNATURE_VERSION = values.Value(
+        "s3v4",
+        environ_name="AWS_S3_SIGNATURE_VERSION",
+        environ_prefix=None,
+    )
     AWS_S3_UPLOAD_POLICY_EXPIRATION = values.Value(
-        24 * 60 * 60,  # 24h
+        60,  # 1 minute
         environ_name="AWS_S3_UPLOAD_POLICY_EXPIRATION",
+        environ_prefix=None,
+    )
+    AWS_S3_DOMAIN_REPLACE = values.Value(
+        environ_name="AWS_S3_DOMAIN_REPLACE",
         environ_prefix=None,
     )
 

--- a/src/frontend/apps/drive/src/features/drivers/implementations/StandardDriver.ts
+++ b/src/frontend/apps/drive/src/features/drivers/implementations/StandardDriver.ts
@@ -253,29 +253,41 @@ export class StandardDriver extends Driver {
       throw new Error("No policy found");
     }
 
-    const { url, fields } = item.policy!;
-    const formData = new FormData();
+    // const { url, fields } = item.policy!;
+    // const formData = new FormData();
 
-    // Add all the policy fields to the form data
-    Object.entries(fields).forEach(([key, value]) => {
-      formData.append(key, value);
-    });
-    // IMPORTANT !!! The Content-Type must be BEFORE file, otherwise it will be ignored by
-    // Scaleway object storage. Order matters !!!
-    formData.append("Content-Type", file.type);
-    formData.append("file", file);
+    // // Add all the policy fields to the form data
+    // Object.entries(fields).forEach(([key, value]) => {
+    //   formData.append(key, value);
+    // });
+    // // IMPORTANT !!! The Content-Type must be BEFORE file, otherwise it will be ignored by
+    // // Scaleway object storage. Order matters !!!
+    // formData.append("Content-Type", file.type);
+    // formData.append("file", file);
 
-    let urlObject = new URL(url);
-    if (process.env["NEXT_PUBLIC_S3_DOMAIN_REPLACE"]) {
-      urlObject = new URL(
-        urlObject.pathname,
-        process.env["NEXT_PUBLIC_S3_DOMAIN_REPLACE"]
-      );
-    }
+    // let urlObject = new URL(url);
+    // if (process.env["NEXT_PUBLIC_S3_DOMAIN_REPLACE"]) {
+    //   urlObject = new URL(
+    //     urlObject.pathname,
+    //     process.env["NEXT_PUBLIC_S3_DOMAIN_REPLACE"]
+    //   );
+    // }
 
-    await uploadFile(urlObject.toString(), formData, (progress) => {
-      progressHandler?.(progress);
-    });
+    // await uploadFile(urlObject.toString(), formData, (progress) => {
+    //   progressHandler?.(progress);
+    // });
+
+    // await fetchAPI(`items/${item.id}/upload-ended/`, {
+    //   method: "POST",
+    // });
+
+    await fetch(
+      item.policy,
+      {
+        method: "PUT",
+        body: file,
+      }
+    );
 
     await fetchAPI(`items/${item.id}/upload-ended/`, {
       method: "POST",

--- a/src/frontend/apps/drive/src/features/drivers/types.ts
+++ b/src/frontend/apps/drive/src/features/drivers/types.ts
@@ -70,16 +70,7 @@ export type Item = {
     update: boolean;
     upload_ended: boolean;
   };
-  policy?: {
-    url: string;
-    fields: {
-      AWSAccessKeyId: string;
-      acl: string;
-      policy: string;
-      key: string;
-      signature: string;
-    };
-  };
+  policy?: string;
 };
 
 export type TreeItemData = Omit<Item, "children"> & {

--- a/src/helm/env.d/dev/values.drive.yaml.gotmpl
+++ b/src/helm/env.d/dev/values.drive.yaml.gotmpl
@@ -57,10 +57,11 @@ backend:
     DB_PORT: 5432
     REDIS_URL: redis://user:pass@dev-backend-redis:6379/1
     DJANGO_CELERY_BROKER_URL: redis://user:pass@dev-backend-redis:6379/1
-    AWS_S3_ENDPOINT_URL: http://dev-backend-minio.drive.svc.cluster.local:9000
+    AWS_S3_ENDPOINT_URL: https://drive-minio.127.0.0.1.nip.io
     AWS_S3_ACCESS_KEY_ID: dinum
     AWS_S3_SECRET_ACCESS_KEY: password
     AWS_STORAGE_BUCKET_NAME: drive-media-storage
+    AWS_S3_SIGNATURE_VERSION: s3v4
     STORAGES_STATICFILES_BACKEND: django.contrib.staticfiles.storage.StaticFilesStorage
     MEDIA_BASE_URL: https://drive.127.0.0.1.nip.io
   migrate:
@@ -105,7 +106,6 @@ frontend:
   envVars:
     PORT: 8080
     NEXT_PUBLIC_API_ORIGIN: https://drive.127.0.0.1.nip.io
-    NEXT_PUBLIC_S3_DOMAIN_REPLACE: https://drive-minio.127.0.0.1.nip.io
 
   replicas: 1
   command:
@@ -142,9 +142,9 @@ ingressMedia:
   annotations:
     nginx.ingress.kubernetes.io/auth-url: https://drive.127.0.0.1.nip.io/api/v1.0/items/media-auth/
     nginx.ingress.kubernetes.io/auth-response-headers: "Authorization, X-Amz-Date, X-Amz-Content-SHA256"
-    nginx.ingress.kubernetes.io/upstream-vhost: dev-backend-minio.drive.svc.cluster.local:9000
+    nginx.ingress.kubernetes.io/upstream-vhost: drive-minio.127.0.0.1.nip.io
     nginx.ingress.kubernetes.io/rewrite-target: /drive-media-storage/$1
 
 serviceMedia:
   host: dev-backend-minio.drive.svc.cluster.local
-  port: 9000
+  port: 80

--- a/src/helm/helmfile.yaml
+++ b/src/helm/helmfile.yaml
@@ -12,7 +12,7 @@ releases:
   - name: dev-backend
     namespace: {{ .Namespace }}
     chart: dev-backends/dev-backend
-    version: 0.0.2
+    version: 0.0.3
     values:
       - postgres:
           enabled: true
@@ -47,6 +47,8 @@ releases:
             tls:
               enabled: true
               secretName: drive-tls
+          api:
+            port: 80
           username: dinum
           password: password
           bucket: drive-media-storage


### PR DESCRIPTION
## Purpose

The file upload to the object storage backend was made using a presigned
  post. But not many object storage solution implement this method. They
  all used presigned url combined with the put_object method. We choose to
  change to this method to be more widely compatible.

## Proposal

Description...

- [x] ♻️(backend) use PUT presigned-url to upload files
- [x] ♻️(helm) adapt tilt deployment to correctly signe presigned urls
- [x] 💩(front) use PUT method to upload files