### PR TITLE
🔖(minor) bump release version 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [v0.5.0] - 2025-09-22
+
 ### Added
 
 - ✨(backend) search endpoint for ItemViewSet #312
@@ -19,16 +21,13 @@ and this project adheres to
 ### Changed
 
 - ♻️(tilt) use helm dev-backend chart
+- ♻️(front) refactor tree loading #326
+- ♻️(front) externalize FilePreview from EmbeddedExplorer + modalify #326
 
 ### Fixed
 
 - 🐛(front) fix the content when opening the right panel #328
 - 🐛(back) encode white spaces in item url #336
-
-### Patches
-
-- ♻️(front) refactor tree loading #326
-- ♻️(front) externalize FilePreview from EmbeddedExplorer + modalify #326
 
 ## [v0.4.0] - 2025-09-02
 
@@ -116,8 +115,9 @@ and this project adheres to
 - 🌐(front) add english translation for rename modal
 - 🐛(global) fix wrong Content-Type on specific s3 implementations
 
-[unreleased]: https://github.com/suitenumerique/drive/compare/v0.4.0...main
-[0.4.0]: https://github.com/suitenumerique/drive/releases/v0.3.0
+[unreleased]: https://github.com/suitenumerique/drive/compare/v0.5.0...main
+[0.5.0]: https://github.com/suitenumerique/drive/releases/v0.5.0
+[0.4.0]: https://github.com/suitenumerique/drive/releases/v0.4.0
 [0.3.0]: https://github.com/suitenumerique/drive/releases/v0.3.0
 [0.2.0]: https://github.com/suitenumerique/drive/releases/v0.2.0
 [0.1.1]: https://github.com/suitenumerique/drive/releases/v0.1.1

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "drive"
-version = "0.4.0"
+version = "0.5.0"
 authors = [{ "name" = "DINUM", "email" = "dev@mail.numerique.gouv.fr" }]
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/src/frontend/apps/drive/package.json
+++ b/src/frontend/apps/drive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drive",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "main",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "workspaces": [
     "apps/*",

--- a/src/helm/drive/Chart.yaml
+++ b/src/helm/drive/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 type: application
 name: drive
-version: 0.4.0
+version: 0.5.0
 appVersion: latest

--- a/src/mail/package.json
+++ b/src/mail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mail_mjml",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "An util to generate html and text django's templates from mjml templates",
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
Added

- ✨(backend) search endpoint for ItemViewSet #312
- 🔧(cron) pgdump: fix restic repository #282
- 🔧(backend) support \_FILE for secret environment variables #196
- ✨(front) add search modal #326
- ✨(front) add standalone file preview #337

Changed

- ♻️(tilt) use helm dev-backend chart
- ♻️(front) refactor tree loading #326
- ♻️(front) externalize FilePreview from EmbeddedExplorer + modalify #326

Fixed

- 🐛(front) fix the content when opening the right panel #328
- 🐛(back) encode white spaces in item url #336

