### PR TITLE
🐛(back) fix duplicated slash in media url

### DIFF
--- a/src/nginx/servers.conf.erb
+++ b/src/nginx/servers.conf.erb
@@ -54,7 +54,7 @@ server {
         add_header Content-Disposition "attachment";
     }
 
-    location /media/preview {
+    location /media/preview/ {
         # Auth request configuration
         auth_request /media-auth;
         auth_request_set $authHeader $upstream_http_authorization;


### PR DESCRIPTION
The /media/ and /media/preview/ should both have a trailing slash otherwise one of both will get a SignatureDoesNotMatch due to duplicated slash in proxied urls.

```xml
<Error>
    <Code>SignatureDoesNotMatch</Code>
    <Message>The request signature we calculated does not match the signature you provided. Check your key and signing method.</Message>
    <RequestId>X</RequestId>
    <HostId>X</HostId>
    <Resource>/bucket//item/<uid>/file.pdf</Resource>
</Error>

```