### PR TITLE
⬆️(backend) upgrade django to version 5.2.7

### DIFF
--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "dj-database-url==3.0.1",
     "celery[redis]==5.5.3",
     "defusedxml==0.7.1",
-    "django==5.2.6",
+    "django==5.2.7",
     "django-celery-beat==2.8.1",
     "django-configurations==2.5.1",
     "django-cors-headers==4.9.0",


### PR DESCRIPTION
## Purpose

Upgrade to django 5.2.7
It is a security release with a fix for 2 CVE
https://docs.djangoproject.com/en/5.2/releases/5.2.7/

## Proposal

- [x] ⬆️(backend) upgrade django to version 5.2.7