### PR TITLE
(ci) install playwright browser with local version

### DIFF
--- a/.github/workflows/drive-frontend.yml
+++ b/.github/workflows/drive-frontend.yml
@@ -61,7 +61,9 @@ jobs:
           fail-on-cache-miss: true
 
       - name: Install Playwright Browsers
-        run: npx playwright install --with-deps ${{matrix.browser}}
+        run: |
+          cd src/frontend/apps/e2e
+          npx playwright install --with-deps ${{matrix.browser}}
 
       - name: Start Docker services
         run: |


### PR DESCRIPTION
    Before the playwright browsers were installing the most
    up-to-date version, not the version of the repository.
    This was causing sometimes mismatch and ci crashes when
    playwright releases a new version.