### PR TITLE
🐛(frontend) unselect items after a move

### DIFF
--- a/src/frontend/apps/drive/src/features/explorer/components/ExplorerDndProvider.tsx
+++ b/src/frontend/apps/drive/src/features/explorer/components/ExplorerDndProvider.tsx
@@ -105,6 +105,8 @@ export const ExplorerDndProvider = ({ children }: ExplorerDndProviderProps) => {
       {
         onSuccess: () => {
           addItemsMovedToast(ids.length);
+          // Reset the selected items after the move
+          setSelectedItems([]);
         },
       }
     );


### PR DESCRIPTION
## Purpose
Reset the selected items after a successful move operation to improve user experience.



