### PR TITLE
🔧(helm) configure jobs lifecycle

### DIFF
--- a/src/helm/drive/Chart.yaml
+++ b/src/helm/drive/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 type: application
 name: drive
-version: 0.8.0
+version: 0.9.0-beta.1
 appVersion: latest

--- a/src/helm/drive/templates/backend_job.yml
+++ b/src/helm/drive/templates/backend_job.yml
@@ -15,6 +15,8 @@ metadata:
   labels:
     {{- include "drive.common.labels" (list . $component) | nindent 4 }}
 spec:
+  ttlSecondsAfterFinished: {{ .Values.backend.jobs.ttlSecondsAfterFinished }}
+  backoffLimit: {{ .Values.backend.jobs.backoffLimit }}
   template:
     metadata:
       annotations:

--- a/src/helm/drive/templates/backend_job_configure_wopi.yaml
+++ b/src/helm/drive/templates/backend_job_configure_wopi.yaml
@@ -14,6 +14,8 @@ metadata:
   labels:
     {{- include "drive.common.labels" (list . $component) | nindent 4 }}
 spec:
+  ttlSecondsAfterFinished: {{ .Values.backend.jobs.ttlSecondsAfterFinished }}
+  backoffLimit: {{ .Values.backend.jobs.backoffLimit }}
   template:
     metadata:
       annotations:

--- a/src/helm/drive/templates/backend_job_createsuperuser.yaml
+++ b/src/helm/drive/templates/backend_job_createsuperuser.yaml
@@ -14,6 +14,8 @@ metadata:
   labels:
     {{- include "drive.common.labels" (list . $component) | nindent 4 }}
 spec:
+  ttlSecondsAfterFinished: {{ .Values.backend.jobs.ttlSecondsAfterFinished }}
+  backoffLimit: {{ .Values.backend.jobs.backoffLimit }}
   template:
     metadata:
       annotations:

--- a/src/helm/drive/templates/backend_job_migrate.yaml
+++ b/src/helm/drive/templates/backend_job_migrate.yaml
@@ -14,6 +14,8 @@ metadata:
   labels:
     {{- include "drive.common.labels" (list . $component) | nindent 4 }}
 spec:
+  ttlSecondsAfterFinished: {{ .Values.backend.jobs.ttlSecondsAfterFinished }}
+  backoffLimit: {{ .Values.backend.jobs.backoffLimit }}
   template:
     metadata:
       annotations:

--- a/src/helm/drive/values.yaml
+++ b/src/helm/drive/values.yaml
@@ -171,6 +171,12 @@ backend:
   ## @param backend.migrateJobAnnotations Annotations for the migrate job
   migrateJobAnnotations: {}
 
+  ## @param backend.jobs.ttlSecondsAfterFinished Period to wait before remove jobs
+  ## @param backend.jobs.backoffLimit Numbers of jobs retries
+  jobs:
+    ttlSecondsAfterFinished: 30
+    backoffLimit: 2
+
   ## @param backend.securityContext Configure backend Pod security context
   securityContext: null
 


### PR DESCRIPTION
## Purpose

The jobs don't have ttlSecondsAfterFinished and backoffLimit configured. So they can stay alive after they finish and argocd never ends its deployment.

## Proposal

- [x] 🔧(helm) configure jobs lifecycle
