### PR TITLE
🔖(patch) bump release version 0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [v0.8.1] - 2025-11-24
+
 ### Fixed
 
 - 🐛(front) fix the issue of not being able to put spaces in a folder name

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "drive"
-version = "0.8.0"
+version = "0.8.1"
 authors = [{ "name" = "DINUM", "email" = "dev@mail.numerique.gouv.fr" }]
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/src/frontend/apps/drive/package.json
+++ b/src/frontend/apps/drive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drive",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "main",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "workspaces": [
     "apps/*",

--- a/src/helm/drive/Chart.yaml
+++ b/src/helm/drive/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 type: application
 name: drive
-version: 0.9.0-beta.1
+version: 0.8.1
 appVersion: latest

--- a/src/helm/helmfile.yaml
+++ b/src/helm/helmfile.yaml
@@ -1,7 +1,7 @@
 environments:
   dev:
     values:
-      - version: 0.8.0
+      - version: 0.8.1
 ---
 repositories:
 - name: dev-backends

--- a/src/mail/package.json
+++ b/src/mail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mail_mjml",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "An util to generate html and text django's templates from mjml templates",
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
### Fixed

- 🐛(front) fix the issue of not being able to put spaces in a folder name
- 🐛(front) heic files are not supported yet
- 🐛(front) update API error handling
- 🐛(front) enhance mimeTypes utility with known extensions and validation
- 🐛(front) fix drag leave behavior in upload zone
- 🐛(front) fix style on hover and empty grid svg
- 🐛(front) fix grid focus and keyboard navigation when a modal is open