### PR TITLE
🐛(backend) manage file renaming when filename has not changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to
 
 - 🏗️(core) migrate from pip to uv
 
+### Fixed
+
+- 🐛(backend) manage file renaming when filename has not changed
+
 ## [v0.8.1] - 2025-11-24
 
 

--- a/src/backend/core/tasks/item.py
+++ b/src/backend/core/tasks/item.py
@@ -68,6 +68,13 @@ def rename_file(item_id, new_title):
     new_filename = f"{new_title}{extension}"
     from_file_key = item.file_key
 
+    if item.filename == new_filename:
+        logger.info(
+            "Item %s filename has not changed, no need to move it on storage",
+            item_id,
+        )
+        return
+
     item.filename = new_filename
     item.save(update_fields=["filename", "updated_at"])
 


### PR DESCRIPTION
## Purpose

The rename feature does not check if the filename is effectly changed before renaming the file on the storage. This behavior leads to an error because it is not alloed to copy an object using the same name without modifying its metadata. We now check if the filename is hcanged.



## Proposal

- [x] 🐛(backend) manage file renaming when filename has not changed

Fixes #435 