### PR TITLE
♻️(backend) change message logged for suspicious item

### DIFF
--- a/src/backend/core/malware_detection.py
+++ b/src/backend/core/malware_detection.py
@@ -40,12 +40,13 @@ def malware_detection_callback(file_path, status, error_info, **kwargs):
             item.save(update_fields=["upload_state"])
             return
 
-    security_logger.warning(
-        "File %s for Item %s is suspicious. Error info: %s",
-        file_path,
-        item_id,
-        error_info,
-    )
+    if status == ReportStatus.UNSAFE:
+        security_logger.warning(
+            "File %s for Item %s is suspicious. Error info: %s",
+            file_path,
+            item_id,
+            error_info,
+        )
 
     item.malware_detection_info = error_info
     item.upload_state = ItemUploadStateChoices.SUSPICIOUS

--- a/src/backend/core/tests/test_malware_detection.py
+++ b/src/backend/core/tests/test_malware_detection.py
@@ -10,54 +10,79 @@ from core.models import ItemTypeChoices, ItemUploadStateChoices
 pytestmark = pytest.mark.django_db
 
 
-def test_malware_detection_callback_safe():
+def test_malware_detection_callback_safe(caplog):
     """Test malware detection callback for safe file"""
     item = factories.ItemFactory(
         update_upload_state=ItemUploadStateChoices.ANALYZING,
         type=ItemTypeChoices.FILE,
         filename="test.txt",
     )
-    malware_detection_callback(item.file_key, ReportStatus.SAFE, None, item_id=item.id)
+    with caplog.at_level("INFO", logger="core.malware_detection"):
+        malware_detection_callback(
+            item.file_key, ReportStatus.SAFE, None, item_id=item.id
+        )
+        assert f"File {item.file_key} is safe" in caplog.text
     item.refresh_from_db()
     assert item.upload_state == ItemUploadStateChoices.READY
 
 
-def test_malware_detection_callback_unsafe():
+def test_malware_detection_callback_unsafe(caplog):
     """Test malware detection callback for unsafe file"""
     item = factories.ItemFactory(
         update_upload_state=ItemUploadStateChoices.ANALYZING,
         type=ItemTypeChoices.FILE,
         filename="test.txt",
     )
-    malware_detection_callback(
-        item.file_key,
-        ReportStatus.UNSAFE,
-        error_info={"error": "test", "error_code": 4001},
-        item_id=item.id,
-    )
+    with caplog.at_level("WARNING", logger="drive.security"):
+        error_info = {"error": "test", "error_code": 4001}
+        malware_detection_callback(
+            item.file_key,
+            ReportStatus.UNSAFE,
+            error_info=error_info,
+            item_id=item.id,
+        )
+        assert (
+            f"File {item.file_key} for Item {item.id} is suspicious. Error info: {error_info}"
+            in caplog.text
+        )
+        assert (
+            f"File {item.file_key} for Item {item.id} has an unknown"
+            f" reportstatus. Error info: {error_info}" not in caplog.text
+        )
+
     item.refresh_from_db()
     assert item.upload_state == ItemUploadStateChoices.SUSPICIOUS
     assert item.malware_detection_info == {"error": "test", "error_code": 4001}
 
 
-def test_malware_detection_callback_file_too_large():
+def test_malware_detection_callback_file_too_large(caplog):
     """Test malware detection callback for file too large"""
     item = factories.ItemFactory(
         update_upload_state=ItemUploadStateChoices.ANALYZING,
         type=ItemTypeChoices.FILE,
         filename="test.txt",
     )
-    malware_detection_callback(
-        item.file_key,
-        ReportStatus.UNKNOWN,
-        error_info={"error": "test", "error_code": 413},
-        item_id=item.id,
-    )
+    with caplog.at_level("INFO", logger="core.malware_detection"):
+        error_info = {"error": "test", "error_code": 413}
+        malware_detection_callback(
+            item.file_key,
+            ReportStatus.UNKNOWN,
+            error_info=error_info,
+            item_id=item.id,
+        )
+        assert (
+            f"File {item.file_key} for Item {item.id} is suspicious. Error info: {error_info}"
+            not in caplog.text
+        )
+        assert (
+            f"File {item.file_key} for Item {item.id} has an unknown"
+            f" reportstatus. Error info: {error_info}" in caplog.text
+        )
     item.refresh_from_db()
     assert item.upload_state == ItemUploadStateChoices.FILE_TOO_LARGE_TO_ANALYZE
 
 
-def test_malware_detection_callback_unknown_report_status():
+def test_malware_detection_callback_unknown_report_status(caplog):
     """Test malware detection callback for unknown report status.
     The file should be set to suspicious.
     """
@@ -66,12 +91,22 @@ def test_malware_detection_callback_unknown_report_status():
         type=ItemTypeChoices.FILE,
         filename="test.txt",
     )
-    malware_detection_callback(
-        item.file_key,
-        ReportStatus.UNKNOWN,
-        error_info={},
-        item_id=item.id,
-    )
+    with caplog.at_level("WARNING", logger="drive.security"):
+        error_info = {}
+        malware_detection_callback(
+            item.file_key,
+            ReportStatus.UNKNOWN,
+            error_info=error_info,
+            item_id=item.id,
+        )
+        assert (
+            f"File {item.file_key} for Item {item.id} is suspicious. Error info: {error_info}"
+            not in caplog.text
+        )
+        assert (
+            f"File {item.file_key} for Item {item.id} has an unknown"
+            f" reportstatus. Error info: {error_info}" in caplog.text
+        )
     item.refresh_from_db()
     assert item.upload_state == ItemUploadStateChoices.SUSPICIOUS
     assert item.malware_detection_info == {}


### PR DESCRIPTION
## Purpose

In the malware_detection callback, there was no distinction between a report status unknown and unsafe. We want to have 2 different logs based on the reportstatus code.



## Proposal

- [x] ♻️(backend) change message logged for suspicious item