### PR TITLE
Enhance item admin panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 ### Added
 
 - ✨(backend) add more info on the item detail in the admin
+- ✨(backend) add an admin action to trigger new file analysis
 
 ## [v0.9.0] - 2025-12-02
 

--- a/src/backend/core/admin.py
+++ b/src/backend/core/admin.py
@@ -4,6 +4,8 @@ from django.contrib import admin
 from django.contrib.auth import admin as auth_admin
 from django.utils.translation import gettext_lazy as _
 
+from lasuite.malware_detection import malware_detection
+
 from . import models
 
 
@@ -171,6 +173,16 @@ class ItemAdmin(admin.ModelAdmin):
     search_fields = ("id", "title", "creator__email")
     list_filter = ("upload_state", "link_reach", "link_role")
     show_facets = admin.ShowFacets.ALWAYS
+    actions = ("trigger_file_analysis",)
+
+    def trigger_file_analysis(self, request, queryset):
+        """Reanalyse the file of the items."""
+
+        for item in queryset:
+            if item.type == models.ItemTypeChoices.FILE:
+                malware_detection.analyse_file(item.file_key, item_id=item.id)
+
+        self.message_user(request, "The files have been scheduled for a new analysis.")
 
 
 @admin.register(models.Invitation)


### PR DESCRIPTION
## Purpose

We need more info in the admin about items. Like the size, the malware_detection info is provided by the malware detection backend if an analysis has failed.
Also, we added an action allowing you to trigger from the beginning a new file analysis.


## Proposal

- [x] ✨(backend) add more info on the item detail in the admin
- [x] ✨(backend) add an admin action to trigger new file analysis
