### PR TITLE
✨(backend) enable full customization of external api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to
 - ✨(backend) add more info on the item detail in the admin
 - ✨(backend) add an admin action to trigger new file analysis
 - ✨(backend) add a command to update file_hash in malware_detection_info
+- ✨(backend) enable full customization of external api
 
 ### Fixed
 

--- a/docs/resource_server.md
+++ b/docs/resource_server.md
@@ -2,13 +2,15 @@
 
 Drive implements resource server, so it means it can be used from an external app to perform some operation using the dedicated API.
 
+> **Note:** This feature might be subject to future evolutions. The API endpoints, configuration options, and behavior may change in future versions.
+
 ## Prerequisites
 
 In order to activate the resource server on Drive you need to setup the following environement variables
 
 ```
 OIDC_RESOURCE_SERVER_ENABLED=True
-OIDC_OP_URL= 
+OIDC_OP_URL=
 OIDC_OP_INTROSPECTION_ENDPOINT=
 OIDC_RS_CLIENT_ID=
 OIDC_RS_CLIENT_SECRET=
@@ -17,6 +19,37 @@ OIDC_RS_ALLOWED_AUDIENCES=
 ```
 
 It implements the resource server using `django-lasuite`, see the [documentation](https://github.com/suitenumerique/django-lasuite/blob/main/documentation/how-to-use-oidc-resource-server-backend.md)
+
+## Customise allowed routes
+
+Configure the `EXTERNAL_API` setting to control which routes and actions are available in the external API. Set it via the `EXTERNAL_API` environment variable (as JSON) or in Django settings.
+
+Default configuration:
+
+```python
+EXTERNAL_API = {
+    "items": {
+        "enabled": True,
+        "actions": ["list", "retrieve", "children", "upload_ended"],
+    },
+    "item_access": {
+        "enabled": False,
+        "actions": [],
+    },
+    "item_invitation": {
+        "enabled": False,
+        "actions": [],
+    },
+}
+```
+
+**Endpoints:**
+
+- `items`: Controls `/external_api/v1.0/items/`. Available actions: `list`, `retrieve`, `create`, `update`, `partial_update`, `destroy`, `children`, `upload_ended`, `move`, `restore`, `trashbin`, `hard_delete`, `tree`, `breadcrumb`, `link_configuration`, `favorite`, `media_auth`, `wopi`
+- `item_access`: Controls `/external_api/v1.0/items/{id}/accesses/`. Available actions: `list`, `retrieve`, `create`, `update`, `partial_update`, `destroy`
+- `item_invitation`: Controls `/external_api/v1.0/items/{id}/invitations/`. Available actions: `list`, `retrieve`, `create`, `update`, `partial_update`, `destroy`
+
+Each endpoint has `enabled` (boolean) and `actions` (list of allowed actions). Only actions explicitly listed are accessible.
 
 ## Request Drive
 
@@ -37,7 +70,7 @@ Here is an example of a view that create a file on the main workspace in Drive.
 
         # Get the access token from the session
         access_token = request.session.get('oidc_access_token')
-        
+
         # Get the main workspace
         response = requests.get(
             f"{settings.DRIVE_API}/items/",
@@ -89,7 +122,7 @@ Here is an example of a view that create a file on the main workspace in Drive.
             headers={"Authorization": f"Bearer {access_token}", "Content-Type": "application/json"},
         )
         response.raise_for_status()
-        
+
         return drf.response.Response(data)
 ```
 

--- a/src/backend/core/external_api/viewsets.py
+++ b/src/backend/core/external_api/viewsets.py
@@ -1,20 +1,44 @@
 """Resource Server Viewsets for the Drive app."""
 
+from django.conf import settings
+
 from lasuite.oidc_resource_server.authentication import ResourceServerAuthentication
 
 from core.api.permissions import ItemAccessPermission
-from core.api.viewsets import ItemViewSet, UserViewSet
+from core.api.viewsets import (
+    InvitationViewset,
+    ItemAccessViewSet,
+    ItemViewSet,
+    UserViewSet,
+)
 from core.external_api.permissions import ResourceServerClientPermission
 
+# pylint: disable=too-many-ancestors
 
-class ResourceServerItemViewSet(ItemViewSet):
+
+class ResourceServerRestrictionMixin:
+    """
+    Mixin for Resource Server Viewsets to provide shortcut to get
+    configured actions for a given resource.
+    """
+
+    def _get_resource_server_actions(self, resource_name):
+        """Get resource_server_actions from settings."""
+        external_api_config = settings.EXTERNAL_API.get(resource_name, {})
+        return list(external_api_config.get("actions", []))
+
+
+class ResourceServerItemViewSet(ResourceServerRestrictionMixin, ItemViewSet):
     """Resource Server Viewset for the Drive app."""
 
     authentication_classes = [ResourceServerAuthentication]
 
     permission_classes = [ResourceServerClientPermission & ItemAccessPermission]
 
-    resource_server_actions = ["list", "retrieve", "children", "upload_ended"]
+    @property
+    def resource_server_actions(self):
+        """Build resource_server_actions from settings."""
+        return self._get_resource_server_actions("items")
 
 
 class ResourceServerUserViewSet(UserViewSet):
@@ -25,3 +49,33 @@ class ResourceServerUserViewSet(UserViewSet):
     permission_classes = [ResourceServerClientPermission]
 
     resource_server_actions = ["get_me"]
+
+
+class ResourceServerItemAccessViewSet(
+    ResourceServerRestrictionMixin, ItemAccessViewSet
+):
+    """Resource Server Viewset for ItemAccess."""
+
+    authentication_classes = [ResourceServerAuthentication]
+
+    permission_classes = [ResourceServerClientPermission & ItemAccessPermission]
+
+    @property
+    def resource_server_actions(self):
+        """Get resource_server_actions from settings."""
+        return self._get_resource_server_actions("item_access")
+
+
+class ResourceServerInvitationViewSet(
+    ResourceServerRestrictionMixin, InvitationViewset
+):
+    """Resource Server Viewset for Invitations."""
+
+    authentication_classes = [ResourceServerAuthentication]
+
+    permission_classes = [ResourceServerClientPermission & ItemAccessPermission]
+
+    @property
+    def resource_server_actions(self):
+        """Get resource_server_actions from settings."""
+        return self._get_resource_server_actions("item_invitation")

--- a/src/backend/drive/settings.py
+++ b/src/backend/drive/settings.py
@@ -666,6 +666,27 @@ class Base(Configuration):
         environ_prefix=None,
     )
 
+    # External API Configuration
+    # Configure available routes and actions for external_api endpoints
+    EXTERNAL_API = values.DictValue(
+        default={
+            "items": {
+                "enabled": True,
+                "actions": ["list", "retrieve", "children", "upload_ended"],
+            },
+            "item_access": {
+                "enabled": False,
+                "actions": [],
+            },
+            "item_invitation": {
+                "enabled": False,
+                "actions": [],
+            },
+        },
+        environ_name="EXTERNAL_API",
+        environ_prefix=None,
+    )
+
     OIDC_RS_PRIVATE_KEY_STR = values.Value(
         default=None,
         environ_name="OIDC_RS_PRIVATE_KEY_STR",


### PR DESCRIPTION
We have some instances that requires more open resource server features. This change adds a setting that allows to cherry-pick which api routes needs to be available or not.

