### PR TITLE
🚑️(config) update legal links in theme configuration

### DIFF
--- a/src/backend/drive/configuration/theme/default.json
+++ b/src/backend/drive/configuration/theme/default.json
@@ -27,15 +27,15 @@
       "legalLinks": [
         {
           "label": "Legal Notice",
-          "href": "#"
+          "href": "https://docs.suite.anct.gouv.fr/docs/7a961249-d86c-49e7-b086-bc809727b293/"
         },
         {
-          "label": "Personal data and cookies",
-          "href": "#"
+          "label": "Privacy Policy",
+          "href": "https://docs.suite.anct.gouv.fr/docs/60a5f113-9359-4183-be38-01051bf02db9/"
         },
         {
           "label": "Accessibility: non compliant",
-          "href": "#"
+          "href": "https://docs.suite.anct.gouv.fr/docs/c664bb58-1985-40c0-af06-cfc0a15f5e59/"
         }
       ],
       "license": {
@@ -50,15 +50,15 @@
       "legalLinks": [
         {
           "label": "Mentions légales",
-          "href": "#"
+          "href": "https://docs.suite.anct.gouv.fr/docs/7a961249-d86c-49e7-b086-bc809727b293/"
         },
         {
-          "label": "Données personnelles et cookies",
-          "href": "#"
+          "label": "Politique de confidentialité",
+          "href": "https://docs.suite.anct.gouv.fr/docs/60a5f113-9359-4183-be38-01051bf02db9/"
         },
         {
           "label": "Accessibilité: non conforme",
-          "href": "#"
+          "href": "https://docs.suite.anct.gouv.fr/docs/c664bb58-1985-40c0-af06-cfc0a15f5e59/"
         }
       ],
       "license": {


### PR DESCRIPTION

## Purpose

Replaced placeholder URLs with actual links for legal notice, privacy policy, and accessibility compliance in the default theme configuration. This enhances the accuracy and accessibility of legal information provided to users. Use as hotfix and no merge in main





