### PR TITLE
🐛(backend) stop renaming file when no title is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to
 - 🐛(scalingo) fix deploy scalingo with yarn
 - 🐛(front) fix responsive gaufre
 - 🐛(docker-hub) fix mistake in docker user
+- 🐛(backend) stop renaming file when no title is provided
 
 ## [v0.10.1] - 2025-12-05
 

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -595,8 +595,9 @@ class ItemViewSet(
         """Override to check if a file is renamed in order to rename file on storage."""
         instance = serializer.instance
         if instance.type == models.ItemTypeChoices.FILE:
-            if instance.title != serializer.validated_data.get("title"):
-                rename_file.delay(instance.id, serializer.validated_data.get("title"))
+            title = serializer.validated_data.get("title")
+            if title and instance.title != title:
+                rename_file.delay(instance.id, title)
         serializer.save()
 
     @drf.decorators.action(detail=True, methods=["delete"], url_path="hard-delete")

--- a/src/backend/core/tasks/item.py
+++ b/src/backend/core/tasks/item.py
@@ -51,6 +51,11 @@ def process_item_deletion(item_id):
 @app.task
 def rename_file(item_id, new_title):
     """Rename the file of an item. Update the filename and then rename the file on storage."""
+
+    if not new_title:
+        logger.error("New title is empty, skipping rename file")
+        return
+
     try:
         item = Item.objects.get(id=item_id)
     except Item.DoesNotExist:


### PR DESCRIPTION
## Purpose

In the ItemViewset::perfom_update method, we trigger the rename_file task when the title of the item has changed. On a PATCH request, the title can be absent in the payload leading to renaming the file with a None value. We have to chank first of the title is present in the validated_data and also check first in the renamin task if the provided value is not empty or None.


## Proposal

Description...

- [x] 🐛(backend) stop renaming file when no title is provided

Fix #477