### PR TITLE
Remove N+1 query patterns on items children view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to
 - ✨(api) modify items/search endpoint to use indexed items in Find
 - 🐛(email) avoid trying to send emails if no provider is configured
 - ♻️(backend) improve mimetype detection
+- ♻️(backend) remove N+1 query patterns on items children view
 
 ### Fixed
 

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -605,6 +605,26 @@ class Item(TreeModel, BaseModel):
 
         return super().save(*args, **kwargs)
 
+    def compute_ancestors_links_paths_mapping(self):
+        """
+        Compute the ancestors links for the current document up to the highest readable ancestor.
+        """
+        ancestors = (
+            (self.ancestors() | self._meta.model.objects.filter(pk=self.pk))
+            .filter(ancestors_deleted_at__isnull=True)
+            .order_by("path")
+        )
+        ancestors_links = []
+        paths_links_mapping = {}
+
+        for ancestor in ancestors:
+            ancestors_links.append(
+                {"link_reach": ancestor.link_reach, "link_role": ancestor.link_role}
+            )
+            paths_links_mapping[str(ancestor.path)] = ancestors_links.copy()
+
+        return paths_links_mapping
+
     def delete(self, using=None, keep_parents=False):
         if self.main_workspace:
             raise RuntimeError("The main workspace cannot be deleted.")


### PR DESCRIPTION
## Purpose

Our Drive instance is lacking snappiness and I noticed it was getting really slow with folders containing many items which is the symptom of unwanted N+1 query patterns on list views.

## Proposal

Remove N+1 query patterns on the items children list endpoint, which triggers 600+ database queries per request (3 extra queries  x 200 items returned).

- Avoid N+1 queries when serializing item creators by preloading the creator relation for all children.
  :point_right: @lunika do we really need the details of the creator on all list items? Returning just the ID would be even more efficient.

- Avoid N+1 queries when computing nb_accesses by precomputing the parent access count and annotating each child with its total number of accesses in the list query (parent count + direct count).

- Avoid N+1 queries when computing link reach and link role by precomputing ancestors link values once and passing it to serializers as a shared mapping.

This keeps the children view query count constant whatever the number of items returned (200 by default!) while preserving existing API behavior.

@NathanVss @PanchoutNathan for further snappiness optimization, I noticed that the frontend is making repeated queries to some list views. It doesn't seem normal and could use some cache or an optimized logic in the frontend?

That will be my first TGV pull request of the year :wink: HNY all! :tada: 
