### PR TITLE
Create ItemAccess when children are created via the API

### DIFF
--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -898,6 +898,11 @@ class ItemViewSet(
                     parent=item,
                     **serializer.validated_data,
                 )
+                models.ItemAccess.objects.create(
+                    item=child_item,
+                    user=request.user,
+                    role=models.RoleChoices.OWNER,
+                )
 
             # Set the created instance to the serializer
             serializer.instance = child_item


### PR DESCRIPTION
## Purpose

When children of a directory are created via the `POST /api/v1.0/items/{id}/children/` endpoint, no `ItemAccess` is created. This is inconsistent with the `POST /api/v1.0/items/` behaviour, where the `ItemAccess` **is** created.

Missing the `ItemAccess` of course causes issues down the line, for instance the user not being able to delete objects they just created.

## Proposal
Make creation of child items consistent with the creation of non-child items, by creating an `ItemAccess` record.
