### PR TITLE
🌐(front) set html lang attribute on language change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to
 
 - ✨(backend) add async indexation of items on save (or access save)
 - ✨(backend) add throttle mechanism to limit indexation job
+- 🌐(front) set html lang attribute on language change
 
 ### Changed
 

--- a/src/frontend/apps/drive/src/features/i18n/initI18n.ts
+++ b/src/frontend/apps/drive/src/features/i18n/initI18n.ts
@@ -17,12 +17,14 @@ import resources from "./translations.json";
  * This way we ensure that we use the most probable language of the user.
  */
 
+const fallbackLng = "en";
+
 i18n
   .use(LanguageDetector)
   .use(initReactI18next)
   .init({
     resources,
-    fallbackLng: "en",
+    fallbackLng,
     detection: {
       order: ["cookie", "navigator"],
       caches: ["cookie"],
@@ -38,6 +40,14 @@ i18n
     },
     preload: LANGUAGES_ALLOWED,
   })
+  .then(() => {
+    if (typeof document !== "undefined") {
+      document.documentElement.setAttribute(
+        "lang",
+        i18n.language || fallbackLng
+      );
+    }
+  })
   .catch(() => {
     throw new Error("i18n initialization failed");
   });
@@ -45,6 +55,7 @@ i18n
 // Save language in local storage
 i18n.on("languageChanged", (lng) => {
   if (typeof window !== "undefined") {
+    document.documentElement.setAttribute("lang", lng);
     localStorage.setItem(LANGUAGE_LOCAL_STORAGE, lng);
   }
 });

--- a/src/frontend/apps/drive/src/pages/_document.tsx
+++ b/src/frontend/apps/drive/src/pages/_document.tsx
@@ -2,7 +2,7 @@ import { Html, Head, Main, NextScript } from "next/document";
 
 export default function Document() {
   return (
-    <Html lang="en">
+    <Html>
       <Head />
       <body>
         <Main />


### PR DESCRIPTION
Currently the html lang attribute is always set to `en`, we want to update it when application language is changed.

