### PR TITLE
🔒️(backend) prevent mismatch mimetype between object storage and app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,15 @@ and this project adheres to
 
 ### Added
 
-- 🏗️ (ds_proxy) introduce how to use ds_proxy with Drive
+- 🏗️(ds_proxy) introduce how to use ds_proxy with Drive
 
 ### Changed
 
 - 🔥(backend) remove usage of atomic transaction for item creation
+
+### Security
+
+- 🔒️(backend) prevent mismatch mimetype between object storage and application
 
 ## [v0.11.1] - 2026-01-13
 

--- a/src/backend/core/api/utils.py
+++ b/src/backend/core/api/utils.py
@@ -1,5 +1,6 @@
 """Util to generate S3 authorization headers for object storage access control"""
 
+import logging
 import mimetypes
 from datetime import datetime
 
@@ -9,6 +10,8 @@ from django.core.files.storage import default_storage
 import boto3
 import botocore
 import magic
+
+logger = logging.getLogger(__name__)
 
 
 def flat_to_nested(items):
@@ -187,6 +190,9 @@ def detect_mimetype(file_buffer: bytes, filename: str | None = None) -> str:
         # Use mimetypes module to guess from extension
         # Use guess_file_type (Python 3.13+) instead of deprecated guess_type
         mimetype_from_extension, _ = mimetypes.guess_file_type(filename, strict=False)
+
+    logger.info("detect_mimetype: mimetype_from_content: %s", mimetype_from_content)
+    logger.info("detect_mimetype: mimetype_from_extension: %s", mimetype_from_extension)
 
     # Strategy: Prefer content-based detection, but use extension if:
     # 1. Content detection returns generic types (application/octet-stream, text/plain)


### PR DESCRIPTION
## Purpose

If there is a mismatch mimetype between the object in the object storage and items in the application, this can lead to previewing files in the browser that are not allowed. We want to prevent this, the mimetype in the object storage is overridden in that case.

## Proposal

- [x] 🔒️(backend) prevent mismatch mimetype between object storage and app
