### PR TITLE
fix(a11y): add level 1 heading for accessibility

### DIFF
--- a/src/frontend/apps/drive/src/features/layouts/components/header/Header.tsx
+++ b/src/frontend/apps/drive/src/features/layouts/components/header/Header.tsx
@@ -12,9 +12,12 @@ import { Gaufre } from "@/features/ui/components/gaufre/Gaufre";
 import { UserProfile } from "@/features/ui/components/user/UserProfile";
 
 export const HeaderIcon = () => {
+  const { t } = useTranslation();
   return (
     <div className="drive__header__left">
-      <div className="drive__header__logo" />
+      <h1 className="drive__header__logo">
+        <span className="sr-only">{t("app_title")}</span>
+      </h1>
       <Feedback />
     </div>
   );

--- a/src/frontend/apps/drive/src/pages/index.scss
+++ b/src/frontend/apps/drive/src/pages/index.scss
@@ -36,18 +36,18 @@ $tablet: map.get($themes, "default", "globals", "breakpoints", "tablet");
         align-items: flex-start;
         max-width: 600px;
 
-        > h2 {
+        >h2 {
           text-align: left;
           font-size: 48px;
           line-height: 50px;
         }
 
-        > span {
+        >span {
           text-align: left;
         }
       }
 
-      > img {
+      >img {
         @media (max-width: $tablet) {
           display: none;
         }
@@ -76,7 +76,7 @@ $tablet: map.get($themes, "default", "globals", "breakpoints", "tablet");
       }
 
       .c__header__right {
-        > * {
+        >* {
           display: none !important;
         }
       }
@@ -116,6 +116,24 @@ $tablet: map.get($themes, "default", "globals", "breakpoints", "tablet");
   background-size: contain;
   background-repeat: no-repeat;
   background-position: center;
+  // Reset h1 default styles when used as heading
+  margin: 0;
+  padding: 0;
+  font-size: inherit;
+  font-weight: inherit;
+}
+
+// Screen reader only - visually hidden but accessible to assistive technologies
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .drive__logo-icon {

--- a/src/frontend/apps/drive/src/pages/index.tsx
+++ b/src/frontend/apps/drive/src/pages/index.tsx
@@ -116,19 +116,26 @@ HomePage.getLayout = function getLayout(page: React.ReactElement) {
           enableResize
           hideLeftPanelOnDesktop={true}
           leftPanelContent={<LeftPanelMobile />}
-          icon={
-            <div className="drive__header__left">
-              <img src={logoGouv.src} alt="" />
-              <div className="drive__header__logo" />
-              <Feedback />
-            </div>
-          }
+          icon={<HomeHeaderIcon />}
           rightHeaderContent={<HeaderRight />}
         >
           {page}
           <Toaster />
         </MainLayout>
       </GlobalLayout>
+    </div>
+  );
+};
+
+const HomeHeaderIcon = () => {
+  const { t } = useTranslation();
+  return (
+    <div className="drive__header__left">
+      <img src={logoGouv.src} alt="" aria-hidden="true" />
+      <h1 className="drive__header__logo">
+        <span className="sr-only">{t("app_title")}</span>
+      </h1>
+      <Feedback />
     </div>
   );
 };


### PR DESCRIPTION
- Change logo div to h1 element in Header.tsx and index.tsx
- Add screen reader only text for app title using sr-only class
- Add sr-only CSS utility class for visually hidden accessible text
- Reset h1 default styles on logo to maintain visual appearance

Fixes #432
