### PR TITLE
fix(trash): show appropriate empty placeholder for trash page

### DIFF
--- a/src/frontend/apps/drive/src/features/explorer/components/app-view/AppExplorer.tsx
+++ b/src/frontend/apps/drive/src/features/explorer/components/app-view/AppExplorer.tsx
@@ -26,6 +26,8 @@ export interface AppExplorerProps {
   isLoading?: boolean;
   isMinimalLayout?: boolean;
   showFilters?: boolean;
+  // Custom empty placeholder when no items
+  emptyPlaceholder?: React.ReactNode;
 }
 
 export type AppExplorerType = AppExplorerProps;

--- a/src/frontend/apps/drive/src/features/explorer/components/app-view/AppExplorerGrid.tsx
+++ b/src/frontend/apps/drive/src/features/explorer/components/app-view/AppExplorerGrid.tsx
@@ -62,6 +62,10 @@ export const AppExplorerGrid = (props: AppExplorerProps) => {
       return <Loader aria-label={tc("components.datagrid.loader_aria")} />;
     }
     if (isEmpty) {
+      // Use custom empty placeholder if provided
+      if (props.emptyPlaceholder) {
+        return props.emptyPlaceholder;
+      }
       return (
         <div className="c__datagrid__empty-placeholder fs-h3 clr-greyscale-900 fw-bold">
           <img

--- a/src/frontend/apps/drive/src/features/i18n/translations.json
+++ b/src/frontend/apps/drive/src/features/i18n/translations.json
@@ -250,6 +250,10 @@
         "trash": {
           "title": "Trash",
           "description": "Automatic deletion after 30 days",
+          "empty": {
+            "caption": "Your trash is empty",
+            "cta": "Deleted items will appear here"
+          },
           "navigate": {
             "modal": {
               "title": "This folder is in the trash",
@@ -656,6 +660,10 @@
         "trash": {
           "title": "Corbeille",
           "description": "Suppression automatique après 30 jours",
+          "empty": {
+            "caption": "Votre corbeille est vide",
+            "cta": "Les éléments supprimés apparaîtront ici"
+          },
           "navigate": {
             "modal": {
               "title": "Ce dossier est dans la corbeille",
@@ -1068,6 +1076,10 @@
         "trash": {
           "title": "Prullenbak",
           "description": "Automatisch verwijderen na 30 dagen",
+          "empty": {
+            "caption": "Uw prullenbak is leeg",
+            "cta": "Verwijderde items verschijnen hier"
+          },
           "navigate": {
             "modal": {
               "title": "Deze map bevindt zich in de prullenbak",

--- a/src/frontend/apps/drive/src/pages/explorer/trash/index.tsx
+++ b/src/frontend/apps/drive/src/pages/explorer/trash/index.tsx
@@ -18,11 +18,34 @@ import { useQuery } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import undoIcon from "@/assets/icons/undo_blue.svg";
 import cancelIcon from "@/assets/icons/cancel_blue.svg";
+import trashIcon from "@/assets/icons/trash.svg";
 import { useGlobalExplorer } from "@/features/explorer/components/GlobalExplorerContext";
 import { ItemFilters } from "@/features/drivers/Driver";
 import { useState } from "react";
 import { HardDeleteConfirmationModal } from "@/features/explorer/components/modals/HardDeleteConfirmationModal";
 import { messageModalTrashNavigate } from "@/features/explorer/components/trash/utils";
+
+const TrashEmptyPlaceholder = () => {
+  const { t } = useTranslation();
+  return (
+    <div className="c__datagrid__empty-placeholder fs-h3 clr-greyscale-900 fw-bold">
+      <img
+        src={trashIcon.src}
+        alt=""
+        className="explorer__grid__empty__image"
+        style={{ width: 64, height: 64 }}
+      />
+      <div className="explorer__grid__empty">
+        <div className="explorer__grid__empty__caption">
+          {t("explorer.trash.empty.caption")}
+        </div>
+        <div className="explorer__grid__empty__cta">
+          {t("explorer.trash.empty.cta")}
+        </div>
+      </div>
+    </div>
+  );
+};
 export default function TrashPage() {
   const { t } = useTranslation();
   const [filters, setFilters] = useState<ItemFilters>({});
@@ -58,6 +81,7 @@ export default function TrashPage() {
       onNavigate={() => {
         messageModalTrashNavigate(modals);
       }}
+      emptyPlaceholder={<TrashEmptyPlaceholder />}
     />
   );
 }


### PR DESCRIPTION
- Add emptyPlaceholder prop to AppExplorer and AppExplorerGrid
- Create TrashEmptyPlaceholder component with trash icon
- Add trash empty state translations (en, fr, nl)
- Shows 'Your trash is empty' instead of 'Drop your files here'

Fixes #461

