### PR TITLE
fix(mobile): Add actions dropdown button to mobile grid view

### DIFF
--- a/src/frontend/apps/drive/src/features/explorer/components/embedded-explorer/EmbeddedExplorer.scss
+++ b/src/frontend/apps/drive/src/features/explorer/components/embedded-explorer/EmbeddedExplorer.scss
@@ -60,11 +60,13 @@ $tablet: map.get($themes, "default", "globals", "breakpoints", "tablet");
       align-items: center;
       gap: 8px;
       height: 48px;
+      width: 100%;
 
       &__info {
         display: flex;
         flex-direction: column;
         overflow: hidden;
+        flex: 1;
 
         &__title {
           display: flex;
@@ -82,6 +84,12 @@ $tablet: map.get($themes, "default", "globals", "breakpoints", "tablet");
           color: var(--c--contextuals--content--semantic--neutral--secondary);
         }
       }
+
+      &__actions {
+        flex-shrink: 0;
+        display: flex;
+        align-items: center;
+      }
     }
 
     &__name {
@@ -95,7 +103,7 @@ $tablet: map.get($themes, "default", "globals", "breakpoints", "tablet");
         max-width: 100%;
       }
 
-      > img {
+      >img {
         // Need to set width and height to prevent layout shift
         // and to make overflow calculations work correctly before
         // the image is loaded
@@ -164,6 +172,7 @@ $tablet: map.get($themes, "default", "globals", "breakpoints", "tablet");
       color: var(--c--contextuals--content--semantic--neutral--primary);
       font-weight: 700;
     }
+
     &__cta {
       font-size: 12px;
       color: var(--c--contextuals--content--semantic--neutral--secondary);
@@ -206,6 +215,7 @@ $tablet: map.get($themes, "default", "globals", "breakpoints", "tablet");
         border-top-left-radius: 4px;
         border-bottom-left-radius: 4px;
       }
+
       tr td:last-child {
         border-top-right-radius: 4px;
         border-bottom-right-radius: 4px;
@@ -216,21 +226,15 @@ $tablet: map.get($themes, "default", "globals", "breakpoints", "tablet");
       }
 
       tr.selected {
-        box-shadow: inset 0 0 0 1px
-          var(--c--contextuals--border--semantic--brand--tertiary);
+        box-shadow: inset 0 0 0 1px var(--c--contextuals--border--semantic--brand--tertiary);
         border-radius: 4px;
-        background-color: var(
-          --c--contextuals--background--semantic--brand--tertiary
-        );
+        background-color: var(--c--contextuals--background--semantic--brand--tertiary);
       }
 
       tr.over {
-        background-color: var(
-          --c--contextuals--background--semantic--brand--tertiary
-        );
+        background-color: var(--c--contextuals--background--semantic--brand--tertiary);
         border-radius: 4px;
-        box-shadow: inset 0 0 0 2px
-          var(--c--contextuals--border--semantic--brand--primary);
+        box-shadow: inset 0 0 0 2px var(--c--contextuals--border--semantic--brand--primary);
       }
 
       tr {
@@ -242,6 +246,7 @@ $tablet: map.get($themes, "default", "globals", "breakpoints", "tablet");
 
   @media (max-width: $tablet) {
     table {
+
       tr td:first-child,
       tr th:first-child {
         padding-left: 0;
@@ -253,6 +258,7 @@ $tablet: map.get($themes, "default", "globals", "breakpoints", "tablet");
       }
 
       thead {
+
         // We can't just simply hide the columns because the table
         // column will not size properly. We want the first column
         // to grow to fill the space.
@@ -265,13 +271,9 @@ $tablet: map.get($themes, "default", "globals", "breakpoints", "tablet");
         }
 
         th:nth-child(2),
-        th:nth-child(3) {
-          display: none;
-        }
-
+        th:nth-child(3),
         th:nth-child(4) {
-          display: table-cell;
-          width: 40px;
+          display: none;
         }
       }
 
@@ -281,12 +283,9 @@ $tablet: map.get($themes, "default", "globals", "breakpoints", "tablet");
         }
 
         td:nth-child(2),
-        td:nth-child(3) {
-          display: none;
-        }
-
+        td:nth-child(3),
         td:nth-child(4) {
-          height: 48px;
+          display: none;
         }
       }
     }
@@ -302,6 +301,7 @@ $tablet: map.get($themes, "default", "globals", "breakpoints", "tablet");
       th {
         height: 0;
         line-height: 0;
+
         div {
           height: 0;
           line-height: 0;

--- a/src/frontend/apps/drive/src/features/explorer/components/embedded-explorer/EmbeddedExplorerGridMobileCell.tsx
+++ b/src/frontend/apps/drive/src/features/explorer/components/embedded-explorer/EmbeddedExplorerGridMobileCell.tsx
@@ -1,14 +1,27 @@
 import { CellContext } from "@tanstack/react-table";
+import { useState } from "react";
 import { Item } from "@/features/drivers/types";
 import { ItemIcon } from "@/features/explorer/components/icons/ItemIcon";
 import { timeAgo } from "@/features/explorer/utils/utils";
 import { removeFileExtension } from "../../utils/mimeTypes";
+import { ItemActionDropdown } from "../item-actions/ItemActionDropdown";
+import { Button } from "@openfun/cunningham-react";
+import { useTranslation } from "react-i18next";
+import { useEmbeddedExplorerGirdContext } from "./EmbeddedExplorerGrid";
+
 type EmbeddedExplorerGridMobileCellProps = CellContext<Item, unknown>;
 
 export const EmbeddedExplorerGridMobileCell = (
   params: EmbeddedExplorerGridMobileCellProps
 ) => {
   const item = params.row.original;
+  const { t } = useTranslation();
+  const [isOpen, setIsOpen] = useState(false);
+  const { setIsActionModalOpen } = useEmbeddedExplorerGirdContext();
+
+  const handleModalOpenChange = (value: boolean) => {
+    setIsActionModalOpen(value);
+  };
 
   return (
     <div className="explorer__grid__item__mobile">
@@ -22,6 +35,34 @@ export const EmbeddedExplorerGridMobileCell = (
         <div className="explorer__grid__item__mobile__info__meta">
           <span>{timeAgo(new Date(item.updated_at))}</span>
         </div>
+      </div>
+      <div
+        className="explorer__grid__item__mobile__actions"
+        role="presentation"
+        onClick={(e) => {
+          e.stopPropagation();
+        }}
+        onKeyDown={(e) => {
+          e.stopPropagation();
+        }}
+      >
+        <ItemActionDropdown
+          item={item}
+          isOpen={isOpen}
+          setIsOpen={setIsOpen}
+          onModalOpenChange={handleModalOpenChange}
+          trigger={
+            <Button
+              variant="tertiary"
+              size="small"
+              onClick={() => setIsOpen(!isOpen)}
+              aria-label={t("explorer.grid.actions.button_aria_label", {
+                name: item.title,
+              })}
+              icon={<span className="material-icons">more_vert</span>}
+            />
+          }
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
Fixes #366 - Users can now access the actions menu (share, info, delete, etc.) on mobile devices without needing hover functionality.

Changes:
- Added ItemActionDropdown to EmbeddedExplorerGridMobileCell
- Added vertical 3-dot menu icon (more_vert) for mobile
- Added CSS styling for mobile actions button layout
- Used same pattern as desktop EmbeddedExplorerGridActionsCell

