### PR TITLE
🐛(backend) use sub claim instead of internal id for external APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to
 ### Changed
 
 - 🔥(backend) remove usage of atomic transaction for item creation
+- ♻️(backend) use sub claim instead of internal id for external anct APIs
 
 ### Fixed
 

--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -30,7 +30,7 @@ class UsageMetricSerializer(serializers.BaseSerializer):
         output = {
             "account": {
                 "type": "user",
-                "id": instance.id,
+                "id": instance.sub,
                 "email": instance.email,
             },
             "metrics": {

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -1751,7 +1751,7 @@ class UsageMetricViewset(drf.mixins.ListModelMixin, viewsets.GenericViewSet):
         queryset = self.queryset
 
         if self.request.query_params.get("account_id"):
-            queryset = queryset.filter(id=self.request.query_params.get("account_id"))
+            queryset = queryset.filter(sub=self.request.query_params.get("account_id"))
 
         return queryset
 

--- a/src/backend/core/entitlements/anct_entitlements_backend.py
+++ b/src/backend/core/entitlements/anct_entitlements_backend.py
@@ -67,7 +67,7 @@ class ANCTEntitlementsBackend(EntitlementsBackend):
             params={
                 "siret": siret,
                 "account_type": "user",
-                "account_id": user.id,
+                "account_id": user.sub,
                 "service_id": parameters["service_id"],
             },
             headers={"X-Service-Auth": f"Bearer {parameters['token']}"},

--- a/src/backend/core/tests/external_api/metrics/test_external_api_usage_metrics.py
+++ b/src/backend/core/tests/external_api/metrics/test_external_api_usage_metrics.py
@@ -101,7 +101,7 @@ def test_usage_metrics_list(api_key):
             {
                 "account": {
                     "type": "user",
-                    "id": str(user1.id),
+                    "id": str(user1.sub),
                     "email": user1.email,
                 },
                 "metrics": {
@@ -111,7 +111,7 @@ def test_usage_metrics_list(api_key):
             {
                 "account": {
                     "type": "user",
-                    "id": str(user2.id),
+                    "id": str(user2.sub),
                     "email": user2.email,
                 },
                 "metrics": {
@@ -134,7 +134,7 @@ def test_usage_metrics_list_filter_by_account_id(api_key):
     factories.ItemFactory(creator=user1, size=100)
 
     response = client.get(
-        f"/external_api/v1.0/metrics/usage/?account_id={user1.id}",
+        f"/external_api/v1.0/metrics/usage/?account_id={user1.sub}",
         HTTP_AUTHORIZATION=f"Api-Key {api_key}",
     )
     assert response.status_code == 200
@@ -146,7 +146,7 @@ def test_usage_metrics_list_filter_by_account_id(api_key):
             {
                 "account": {
                     "type": "user",
-                    "id": str(user1.id),
+                    "id": str(user1.sub),
                     "email": user1.email,
                 },
                 "metrics": {
@@ -184,7 +184,7 @@ def test_usage_metrics_exposed_claims(api_key):
             {
                 "account": {
                     "type": "user",
-                    "id": str(user1.id),
+                    "id": str(user1.sub),
                     "email": user1.email,
                 },
                 "iss": "https://example.com",
@@ -196,7 +196,7 @@ def test_usage_metrics_exposed_claims(api_key):
             {
                 "account": {
                     "type": "user",
-                    "id": str(user2.id),
+                    "id": str(user2.sub),
                     "email": user2.email,
                 },
                 "iss": "https://example2.com",

--- a/src/backend/core/tests/test_api_entitlements_anct.py
+++ b/src/backend/core/tests/test_api_entitlements_anct.py
@@ -81,7 +81,7 @@ def test_api_entitlements_anct_get_entitlements_both_true():
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url.startswith(ENTITLEMENTS_URL)
     assert "siret" in responses.calls[0].request.url
-    assert f"account_id={user.id}" in responses.calls[0].request.url
+    assert f"account_id={user.sub}" in responses.calls[0].request.url
     assert "service_id=8" in responses.calls[0].request.url
     assert responses.calls[0].request.headers["X-Service-Auth"] == (
         f"Bearer {ENTITLEMENTS_BACKEND_PARAMETERS['token']}"
@@ -125,7 +125,7 @@ def test_api_entitlements_anct_get_entitlements_can_upload_false():
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url.startswith(ENTITLEMENTS_URL)
     assert "siret" in responses.calls[0].request.url
-    assert f"account_id={user.id}" in responses.calls[0].request.url
+    assert f"account_id={user.sub}" in responses.calls[0].request.url
     assert "service_id=8" in responses.calls[0].request.url
     assert responses.calls[0].request.headers["X-Service-Auth"] == (
         f"Bearer {ENTITLEMENTS_BACKEND_PARAMETERS['token']}"
@@ -169,7 +169,7 @@ def test_api_entitlements_anct_get_entitlements_can_access_false():
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url.startswith(ENTITLEMENTS_URL)
     assert "siret" in responses.calls[0].request.url
-    assert f"account_id={user.id}" in responses.calls[0].request.url
+    assert f"account_id={user.sub}" in responses.calls[0].request.url
     assert "service_id=8" in responses.calls[0].request.url
     assert responses.calls[0].request.headers["X-Service-Auth"] == (
         f"Bearer {ENTITLEMENTS_BACKEND_PARAMETERS['token']}"
@@ -213,7 +213,7 @@ def test_api_entitlements_anct_get_entitlements_cache():
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url.startswith(ENTITLEMENTS_URL)
     assert "siret" in responses.calls[0].request.url
-    assert f"account_id={user.id}" in responses.calls[0].request.url
+    assert f"account_id={user.sub}" in responses.calls[0].request.url
     assert "service_id=8" in responses.calls[0].request.url
     assert responses.calls[0].request.headers["X-Service-Auth"] == (
         f"Bearer {ENTITLEMENTS_BACKEND_PARAMETERS['token']}"


### PR DESCRIPTION
The external entitlements API and usage metrics endpoints were using the internal database id as user identifier. This should be the OIDC sub claim, which is the stable external identifier for users across services.
