### PR TITLE
🐛(backend) fix files with # in filename causing SignatureDoesNotMatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to
 ### Fixed
 
 - 🐛(backend) correctly configure celery beat to run wopi configuration
+- 🐛(backend) fix files with # in filename causing SignatureDoesNotMatch
 
 ### Security
 

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -1340,12 +1340,12 @@ class ItemViewSet(
             logger.debug("Missing HTTP_X_ORIGINAL_URL header in subrequest")
             raise drf.exceptions.PermissionDenied()
 
-        parsed_url = urlparse(unquote(original_url))
-        match = pattern.search(parsed_url.path)
+        parsed_url = urlparse(original_url)
+        match = pattern.search(unquote(parsed_url.path))
 
         # If the path does not match the pattern, try to extract the parameters from the query
         if not match:
-            match = pattern.search(parsed_url.query)
+            match = pattern.search(unquote(parsed_url.query))
 
         if not match:
             logger.debug(


### PR DESCRIPTION
Calling unquote() before urlparse() decoded %23 to # which urlparse then treated as a fragment separator, truncating the file path. By parsing the URL first and only decoding the extracted path/query components, special characters like # no longer interfere with URL structure parsing.

Closes #449
