### PR TITLE
🐛(backend) manage ole2 compound document format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to
 
 - 🔥(global) remove notion of workspace
 
+### Fixed
+
+- 🐛(backend) manage ole2 compound document format
+
 ## [v0.12.0] - 2026-02-06
 
 ### Added

--- a/src/backend/core/api/utils.py
+++ b/src/backend/core/api/utils.py
@@ -202,6 +202,7 @@ def detect_mimetype(file_buffer: bytes, filename: str | None = None) -> str:
     # Generic/unreliable MIME types that we should try to improve
     generic_types = {
         "application/octet-stream",
+        "application/x-ole-storage",  # used by .xls, .doc and .ppt
         "application/zip",
         "text/plain",
     }

--- a/src/backend/core/tests/test_api_utils_detect_mimetype.py
+++ b/src/backend/core/tests/test_api_utils_detect_mimetype.py
@@ -144,3 +144,15 @@ def test_detect_mimetype_powerpoint_ppt():
         "application/vnd.ms-powerpoint",
         "application/mspowerpoint",
     ]
+
+
+def test_detect_mimetype_ole_storage():
+    """
+    Microsoft files .xls .doc .ppt can use the mimetype application/x-ole-storage
+    for Microsoft OLE2/Compound File Binary Format. In that case we want to rely on the extension
+    """
+
+    xls_ole_content = b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1"
+    mimetype = utils.detect_mimetype(xls_ole_content, filename="document.xls")
+
+    assert mimetype == "application/vnd.ms-excel"


### PR DESCRIPTION
## Purpose

Microsoft has a generic format for files like .xls .doc .ppt and the mimetype returned is application/x-ole-storage. We want to add it to generic type list in order to use the extension instead.

## Proposal

🐛(backend) manage ole2 compound document format