### PR TITLE
🐛(backend) remove folders in the recents view

### DIFF
--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -1117,8 +1117,13 @@ class ItemViewSet(
         )
         if not filterset.is_valid():
             raise drf.exceptions.ValidationError(filterset.errors)
+        filter_data = filterset.form.cleaned_data
 
-        queryset = filterset.filter_queryset(queryset)
+        # Filter as early as possible on fields that are available on the model
+        for field in ["title"]:
+            queryset = filterset.filters[field].filter(queryset, filter_data[field])
+
+        queryset = queryset.filter(type=models.ItemTypeChoices.FILE)
 
         queryset = queryset.annotate_is_favorite(user)
         queryset = queryset.annotate_user_roles(user)


### PR DESCRIPTION
## Purpose

The recents view should only return files. We have to explicitely filter on type=file and exlude filtering on the type column.


## Proposal


- [x] 🐛(backend) remove folders in the recents view