### PR TITLE
🚸(oidc) ignore case when fallback on email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to
 - ✨(backend) allow configuring celery task routes via `CELERY_TASK_ROUTES`
 - ✨(global) implement advanced shared management system
 
+### Changed
+
+- 🚸(oidc) ignore case when fallback on email #535
+
 ### Removed
 
 - 🔥(global) remove notion of workspace

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -146,11 +146,11 @@ class UserManager(auth_models.UserManager):
 
             if settings.OIDC_FALLBACK_TO_EMAIL_FOR_IDENTIFICATION:
                 try:
-                    return self.get(email=email)
+                    return self.get(email__iexact=email)
                 except self.model.DoesNotExist:
                     pass
             elif (
-                self.filter(email=email).exists()
+                self.filter(email__iexact=email).exists()
                 and not settings.OIDC_ALLOW_DUPLICATE_EMAILS
             ):
                 raise DuplicateEmailError(
@@ -1391,7 +1391,7 @@ class Invitation(BaseModel):
 
         # Check if an identity already exists for the provided email
         if (
-            User.objects.filter(email=self.email).exists()
+            User.objects.filter(email__iexact=self.email).exists()
             and not settings.OIDC_ALLOW_DUPLICATE_EMAILS
         ):
             raise ValidationError(


### PR DESCRIPTION
## Purpose

Some identity providers might change the case, but in our products we don't consider case variation to be consider as different email addresses.

Next step would be to normalize the DB value of email to be lower-case.


## Proposal

- [x] ignore email case in OIDC login fallback
- [x] ignore email case in invitations
