### PR TITLE
🔧(front) remove server info in nginx config

### DIFF
--- a/src/frontend/apps/drive/conf/default.conf
+++ b/src/frontend/apps/drive/conf/default.conf
@@ -3,6 +3,8 @@ server {
   listen 3000;
   server_name localhost;
 
+  server_tokens off;
+
   root /usr/share/nginx/html;
 
   add_header X-Frame-Options DENY always;


### PR DESCRIPTION
## Purpose

In the nginx config, the server_tokens directive is not set to False giving information like the nginx version. We have to set it to false.


## Proposal

- [x] 🔧(front) remove server info in nginx config