### PR TITLE
🔖(minor) bump release version 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [v0.13.0] - 2026-02-18
+
 ### Added
 
 - ✨(backend) allow configuring celery task routes via `CELERY_TASK_ROUTES`
@@ -290,7 +292,8 @@ and this project adheres to
 - 🌐(front) add english translation for rename modal
 - 🐛(global) fix wrong Content-Type on specific s3 implementations
 
-[unreleased]: https://github.com/suitenumerique/drive/compare/v0.12.0...main
+[unreleased]: https://github.com/suitenumerique/drive/compare/v0.13.0...main
+[v0.13.0]: https://github.com/suitenumerique/drive/releases/v0.13.0
 [v0.12.0]: https://github.com/suitenumerique/drive/releases/v0.12.0
 [v0.11.1]: https://github.com/suitenumerique/drive/releases/v0.11.1
 [v0.11.0]: https://github.com/suitenumerique/drive/releases/v0.11.0

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "uv_build"
 
 [project]
 name = "drive"
-version = "0.12.0"
+version = "0.13.0"
 authors = [{ "name" = "DINUM", "email" = "dev@mail.numerique.gouv.fr" }]
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/src/backend/uv.lock
+++ b/src/backend/uv.lock
@@ -632,7 +632,7 @@ wheels = [
 
 [[package]]
 name = "drive"
-version = "0.12.0"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/frontend/apps/drive/package.json
+++ b/src/frontend/apps/drive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drive",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "main",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "private": true,
   "workspaces": [
     "apps/*",

--- a/src/helm/drive/Chart.yaml
+++ b/src/helm/drive/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 type: application
 name: drive
-version: 0.13.0-beta.1
+version: 0.13.0
 appVersion: latest

--- a/src/mail/package.json
+++ b/src/mail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mail_mjml",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "An util to generate html and text django's templates from mjml templates",
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
### Added

- ✨(backend) allow configuring celery task routes via `CELERY_TASK_ROUTES`
- ✨(global) implement advanced shared management system
- ✨(global) add release notes
- ✨(front) show root page in breadcrumbs when navigating
- ✨(front) filter recent items to only show files

### Changed

- 🚸(oidc) ignore case when fallback on email #535

### Fixed

- 🐛(backend) manage ole2 compound document format
- ♻️(backend) increase user short_name field length
- 🐛(helm) reverse liveness and readiness for backend deployment

### Removed

- 🔥(global) remove notion of workspace
- ⚰️(scalingo) remove scalingo pgdump