### PR TITLE
✨(backend) allow item creation on the external API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to
 - ✨(frontend) sync backend user language to browser on load
 - 🐛(backend) fix WOPI PutFile to check stored file size
 
+### Changed
+
+- ✨(backend) allow root item creation on the external API by default
 
 ## [v0.13.0] - 2026-02-18
 
@@ -321,4 +324,5 @@ and this project adheres to
 [v0.2.0]: https://github.com/suitenumerique/drive/releases/v0.2.0
 [v0.1.1]: https://github.com/suitenumerique/drive/releases/v0.1.1
 [v0.1.0]: https://github.com/suitenumerique/drive/releases/v0.1.0
+
 ## [v0.11.1] - 2026-01-13

--- a/src/backend/drive/settings.py
+++ b/src/backend/drive/settings.py
@@ -1293,7 +1293,7 @@ class Base(Configuration):
         default={
             "items": {
                 "enabled": True,
-                "actions": ["list", "retrieve", "children", "upload_ended"],
+                "actions": ["create", "list", "retrieve", "children", "upload_ended"],
             },
             "item_access": {
                 "enabled": False,


### PR DESCRIPTION
## Summary

- Enable the `create` action on the external API items endpoint so resource servers can upload files at root level
- Add an e2e test covering the full flow: create item at root + upload-ended