### PR TITLE
♻️(backend) set item read only in the mirror item admin detail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to
 ### Changed
 
 - ✨(backend) allow root item creation on the external API by default
+- ♻️(backend) set item read only in the mirror item admin detail
 
 ## [v0.13.0] - 2026-02-18
 

--- a/src/backend/core/admin.py
+++ b/src/backend/core/admin.py
@@ -233,6 +233,7 @@ class MirrorItemTaskAdmin(admin.ModelAdmin):
     )
     readonly_fields = (
         "id",
+        "item",
         "created_at",
         "updated_at",
     )


### PR DESCRIPTION
## Purpose

There is no reason to change the item in the mirror item task in the detail view. So we set it in the readonly_fields


## Proposal

- [x] ♻️(backend) set item read only in the mirror item admin detail
