### PR TITLE
🔧(helm) allow to configure more probes for every deployment

### DIFF
--- a/src/helm/drive/templates/_helpers.tpl
+++ b/src/helm/drive/templates/_helpers.tpl
@@ -128,6 +128,8 @@ httpGet:
 {{- end }}
 initialDelaySeconds: {{ .initialDelaySeconds | eq nil | ternary 0 .initialDelaySeconds }}
 timeoutSeconds: {{ .timeoutSeconds | eq nil | ternary 1 .timeoutSeconds }}
+periodSeconds: {{ .periodSeconds | eq nil | ternary 1 .periodSeconds }}
+failureThreshold: {{ .failureThreshold | eq nil | ternary 1 .failureThreshold }}
 {{- end }}
 
 {{/*

--- a/src/helm/drive/values.yaml
+++ b/src/helm/drive/values.yaml
@@ -296,8 +296,10 @@ backend:
                 "-c",
                 "celery -A drive.celery_app inspect ping -d drive@$HOSTNAME",
               ]
-          initialDelaySeconds: 60
-          timeoutSeconds: 5
+          initialDelaySeconds: 30
+          periodSeconds: 60
+          timeoutSeconds: 15
+          failureThreshold: 3
         readiness:
           exec:
             command:
@@ -306,8 +308,10 @@ backend:
                 "-c",
                 "celery -A drive.celery_app inspect ping -d drive@$HOSTNAME",
               ]
-          initialDelaySeconds: 15
-          timeoutSeconds: 5
+          initialDelaySeconds: 20
+          periodSeconds: 30
+          timeoutSeconds: 15
+          failureThreshold: 3
 
   ## @param backend.celeryBeat.replicas Amount of celery replicas
   ## @param backend.celeryBeat.enabled Enable or disable the celery beat deployment
@@ -339,13 +343,17 @@ backend:
       liveness:
         exec:
           command: ["/bin/sh", "-c", "celery -A drive.celery_app inspect ping"]
-        initialDelaySeconds: 60
-        timeoutSeconds: 5
+        initialDelaySeconds: 30
+        periodSeconds: 60
+        timeoutSeconds: 15
+        failureThreshold: 3
       readiness:
         exec:
           command: ["/bin/sh", "-c", "celery -A drive.celery_app inspect ping"]
-        initialDelaySeconds: 15
-        timeoutSeconds: 5
+        initialDelaySeconds: 20
+        periodSeconds: 30
+        timeoutSeconds: 15
+        failureThreshold: 3
 
   ## @param backend.probes.liveness.path [nullable] Configure path for backend HTTP liveness probe
   ## @param backend.probes.liveness.targetPort [nullable] Configure port for backend HTTP liveness probe


### PR DESCRIPTION
## Purpose

In the probes some parameters like periodSeconds or failureThreshold were not configurable. We want allow their configuration


## Proposal

- [x] 🔧(helm) allow to configure more probes for every deployment
