### PR TITLE
🔖(minor) bump release version 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [v0.14.0] - 2026-02-25
+
 ### Added
 
 - 👷(docker) add arm64 platform support for image builds
@@ -20,6 +22,11 @@ and this project adheres to
 - ✨(frontend) stop upload if file higher than DATA_UPLOAD_MAX_MEMORY_SIZE
 - ✨(backend) reject uploaded file higher than DATA_UPLOAD_MAX_MEMORY_SIZE
 
+### Changed
+
+- ✨(backend) allow root item creation on the external API by default
+- ♻️(backend) set item read only in the mirror item admin detail
+
 ### Fixed
 
 - ✨(frontend) sync backend user language to browser on load
@@ -28,11 +35,6 @@ and this project adheres to
 - 🐛(backend) fix OIDC redirect allowed hosts format in dev config
 - 🐛(global) update ui when renaming file from wopi editor
 - 🐛(frontend) fix clipboard copy-paste in WOPI editor iframe
-
-### Changed
-
-- ✨(backend) allow root item creation on the external API by default
-- ♻️(backend) set item read only in the mirror item admin detail
 
 ## [v0.13.0] - 2026-02-18
 
@@ -321,7 +323,8 @@ and this project adheres to
 - 🌐(front) add english translation for rename modal
 - 🐛(global) fix wrong Content-Type on specific s3 implementations
 
-[unreleased]: https://github.com/suitenumerique/drive/compare/v0.13.0...main
+[unreleased]: https://github.com/suitenumerique/drive/compare/v0.14.0...main
+[v0.14.0]: https://github.com/suitenumerique/drive/releases/v0.13.0
 [v0.13.0]: https://github.com/suitenumerique/drive/releases/v0.13.0
 [v0.12.0]: https://github.com/suitenumerique/drive/releases/v0.12.0
 [v0.11.1]: https://github.com/suitenumerique/drive/releases/v0.11.1

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "uv_build"
 
 [project]
 name = "drive"
-version = "0.13.0"
+version = "0.14.0"
 authors = [{ "name" = "DINUM", "email" = "dev@mail.numerique.gouv.fr" }]
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/src/backend/uv.lock
+++ b/src/backend/uv.lock
@@ -632,7 +632,7 @@ wheels = [
 
 [[package]]
 name = "drive"
-version = "0.13.0"
+version = "0.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/frontend/apps/drive/package.json
+++ b/src/frontend/apps/drive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drive",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "main",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "private": true,
   "workspaces": [
     "apps/*",

--- a/src/helm/drive/Chart.yaml
+++ b/src/helm/drive/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 type: application
 name: drive
-version: 0.13.0
+version: 0.14.0
 appVersion: latest

--- a/src/helm/helmfile.yaml.gotmpl
+++ b/src/helm/helmfile.yaml.gotmpl
@@ -1,7 +1,7 @@
 environments:
   dev:
     values:
-      - version: 0.13.0-beta.1
+      - version: 0.14.0
 ---
 repositories:
 - name: dev-backends

--- a/src/mail/package.json
+++ b/src/mail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mail_mjml",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "An util to generate html and text django's templates from mjml templates",
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
### Added

- 👷(docker) add arm64 platform support for image builds
- ✨(global) add create file from template feature
- ✨(global) add FRONTEND_CSS_URL and FRONTEND_JS_URL settings
- ✨(backend) add a download action returning the media url
- ✨(frontend) add right click feature
- ✨(backend) allow customization of wopi parameters
- ✨(backend) expose DATA_UPLOAD_MAX_MEMORY_SIZE in the config endpoint
- ✨(frontend) stop upload if file higher than DATA_UPLOAD_MAX_MEMORY_SIZE
- ✨(backend) reject uploaded file higher than DATA_UPLOAD_MAX_MEMORY_SIZE

### Changed

- ✨(backend) allow root item creation on the external API by default
- ♻️(backend) set item read only in the mirror item admin detail

### Fixed

- ✨(frontend) sync backend user language to browser on load
- 🐛(backend) fix WOPI PutFile to check stored file size
- 🐛(frontend) fix 401 page infinite redirect loop after login
- 🐛(backend) fix OIDC redirect allowed hosts format in dev config
- 🐛(global) update ui when renaming file from wopi editor
- 🐛(frontend) fix clipboard copy-paste in WOPI editor iframe
