### PR TITLE
🔧(helm) add missing default probes configuration

### DIFF
--- a/src/helm/drive/values.yaml
+++ b/src/helm/drive/values.yaml
@@ -358,22 +358,34 @@ backend:
   ## @param backend.probes.liveness.path [nullable] Configure path for backend HTTP liveness probe
   ## @param backend.probes.liveness.targetPort [nullable] Configure port for backend HTTP liveness probe
   ## @param backend.probes.liveness.initialDelaySeconds [nullable] Configure initial delay for backend liveness probe
-  ## @param backend.probes.liveness.initialDelaySeconds [nullable] Configure timeout for backend liveness probe
+  ## @param backend.probes.liveness.timeoutSeconds [nullable] Configure timeout for backend liveness probe
+  ## @param backend.probes.liveness.periodSeconds [nullable] Configure period for backend liveness probe
+  ## @param backend.probes.liveness.failureThreshold [nullable] Configure failure threshold for backend liveness probe
   ## @param backend.probes.startup.path [nullable] Configure path for backend HTTP startup probe
   ## @param backend.probes.startup.targetPort [nullable] Configure port for backend HTTP startup probe
   ## @param backend.probes.startup.initialDelaySeconds [nullable] Configure initial delay for backend startup probe
-  ## @param backend.probes.startup.initialDelaySeconds [nullable] Configure timeout for backend startup probe
+  ## @param backend.probes.startup.timeoutSeconds [nullable] Configure timeout for backend startup probe
+  ## @param backend.probes.startup.periodSeconds [nullable] Configure period for backend startup probe
+  ## @param backend.probes.startup.failureThreshold [nullable] Configure failure threshold for backend startup probe
   ## @param backend.probes.readiness.path [nullable] Configure path for backend HTTP readiness probe
   ## @param backend.probes.readiness.targetPort [nullable] Configure port for backend HTTP readiness probe
   ## @param backend.probes.readiness.initialDelaySeconds [nullable] Configure initial delay for backend readiness probe
-  ## @param backend.probes.readiness.initialDelaySeconds [nullable] Configure timeout for backend readiness probe
+  ## @param backend.probes.readiness.timeoutSeconds [nullable] Configure timeout for backend readiness probe
+  ## @param backend.probes.readiness.periodSeconds [nullable] Configure period for backend readiness probe
+  ## @param backend.probes.readiness.failureThreshold [nullable] Configure failure threshold for backend readiness probe
   probes:
     liveness:
       path: /__lbheartbeat__
       initialDelaySeconds: 10
+      periodSeconds: 10
+      failureThreshold: 3
+      timeoutSeconds: 1
     readiness:
       path: /__heartbeat__
       initialDelaySeconds: 10
+      periodSeconds: 10
+      failureThreshold: 3
+      timeoutSeconds: 1
 
   ## @param backend.resources Resource requirements for the backend container
   resources: {}


### PR DESCRIPTION
## Purpose

For the backend probes, some default value are missing. We need to add the periodSeconds, timeoutSeconds and the failureThreshold

## Proposal

- [x] 🔧(helm) add missing default probes configuration
