### PR TITLE
🐛(backend) sanitize filename to be compatible with filesystems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to
 
 - 🐛(backend) allow inviting external person on item with no direct access
 - 🐛(backend) stop storing numchild in database use annotation instead
+- 🐛(backend) sanitize filename to be compatible with filesystems
 
 ## [v0.14.0] - 2026-02-25
 

--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -511,14 +511,18 @@ class ItemSerializer(ListItemSerializer):
 
     def update(self, instance, validated_data):
         """Validate that the title is unique in the current path."""
-        if (
-            validated_data.get("title")
-            and instance.title != validated_data.get("title")
-            and instance.depth > 1
+        if validated_data.get("title") and instance.title != validated_data.get(
+            "title"
         ):
-            validated_data["title"] = instance.manage_unique_title(
-                validated_data.get("title")
-            )
+            if instance.depth > 1:
+                validated_data["title"] = instance.manage_unique_title(
+                    validated_data.get("title")
+                )
+
+            if instance.type == models.ItemTypeChoices.FILE:
+                # Just check for validation, the real filename
+                # will be use later in the rename_file task
+                utils.sanitize_filename(validated_data["title"])
 
         return super().update(instance, validated_data)
 
@@ -643,14 +647,13 @@ class CreateItemSerializer(ItemSerializer):
                         {"filename": _("This field is required for files.")},
                         code="item_create_file_filename_required",
                     )
-
                 if settings.RESTRICT_UPLOAD_FILE_TYPE:
-                    _root, ext = splitext(attrs["filename"])
-                    if ext.lower() not in settings.FILE_EXTENSIONS_ALLOWED:
+                    _root, extension = splitext(attrs["filename"])
+                    if extension.lower() not in settings.FILE_EXTENSIONS_ALLOWED:
                         logger.info(
                             "create_item: file extension not allowed %s "
                             "for filename %s",
-                            ext,
+                            extension,
                             attrs["filename"],
                         )
                         raise serializers.ValidationError(
@@ -660,6 +663,8 @@ class CreateItemSerializer(ItemSerializer):
 
                 # When it's a file we force the title with the filename
                 attrs["title"] = attrs["filename"]
+                # Use the sanitize_filename utils
+                attrs["filename"] = utils.sanitize_filename(attrs["filename"])
 
         if (
             attrs["type"] == models.ItemTypeChoices.FOLDER

--- a/src/backend/core/api/utils.py
+++ b/src/backend/core/api/utils.py
@@ -2,9 +2,13 @@
 
 import logging
 import mimetypes
+import re
+import unicodedata
 from datetime import datetime
+from os.path import splitext
 
 from django.conf import settings
+from django.core.exceptions import ValidationError
 from django.core.files.storage import default_storage
 
 import boto3
@@ -220,3 +224,28 @@ def detect_mimetype(file_buffer: bytes, filename: str | None = None) -> str:
 
     # Default to content-based detection (most reliable)
     return mimetype_from_content or "application/octet-stream"
+
+
+def sanitize_filename(filename):
+    """
+    Sanitize a filename to be compliant to use on filesystem.
+
+    """
+    name, extension = splitext(filename)
+    #  Convert to ASCII. Taken from the django slugify helper.
+    # Remove unwanted characters like emoji.
+    name = unicodedata.normalize("NFKD", name).encode("ascii", "ignore").decode("ascii")
+
+    # Remove leading and trailing spaces; convert other spaces to
+    # underscores; and remove anything that is not an alphanumeric, dash,
+    # underscore, or dot.
+    # Taken from get_valid_filename django helper.
+    name = name.strip().replace(" ", "_")
+    name = re.sub(r"(?u)[^-\w.]", "", name)
+    # strip control characters (0x00–0x1f, 0x7f)
+    name = re.sub(r"[\x00-\x1f\x7f]", "", name)
+
+    if not name:
+        raise ValidationError("filename is empty once sanitized and it is not allowed")
+
+    return name + extension.strip()

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -616,11 +616,12 @@ class ItemViewSet(
     def perform_update(self, serializer):
         """Override to check if a file is renamed in order to rename file on storage."""
         instance = serializer.instance
+        old_title = instance.title
+        serializer.save()
         if instance.type == models.ItemTypeChoices.FILE:
             title = serializer.validated_data.get("title")
-            if title and instance.title != title:
+            if title and old_title != title:
                 rename_file.delay(instance.id, title)
-        serializer.save()
 
     @drf.decorators.action(detail=True, methods=["delete"], url_path="hard-delete")
     def hard_delete(self, request, *args, **kwargs):

--- a/src/backend/core/tasks/item.py
+++ b/src/backend/core/tasks/item.py
@@ -8,6 +8,7 @@ from os.path import splitext
 
 from django.core.files.storage import default_storage
 
+from core.api.utils import sanitize_filename
 from core.models import Item, ItemTypeChoices, ItemUploadStateChoices
 
 from drive.celery_app import app
@@ -69,7 +70,7 @@ def rename_file(item_id, new_title):
 
     _, extension = splitext(item.filename)
 
-    new_filename = f"{new_title}{extension}"
+    new_filename = sanitize_filename(f"{new_title}{extension}")
     from_file_key = item.file_key
 
     if item.filename == new_filename:

--- a/src/backend/core/tests/items/test_api_items_children_create.py
+++ b/src/backend/core/tests/items/test_api_items_children_create.py
@@ -15,6 +15,7 @@ from freezegun import freeze_time
 from rest_framework.test import APIClient
 
 from core import factories
+from core.api.utils import sanitize_filename
 from core.models import Item, ItemTypeChoices, LinkReachChoices, LinkRoleChoices
 
 pytestmark = pytest.mark.django_db
@@ -596,3 +597,105 @@ def test_api_items_children_create_entitlements_backend_returns_falsy(
             }
         ],
     }
+
+
+@mock.patch(
+    "core.api.serializers.utils.sanitize_filename", side_effect=sanitize_filename
+)
+def test_api_items_children_create_related_success_sanitize_filename(
+    mock_sanitize_filename,
+):
+    """
+    Authenticated users with a specific write access on an item should be
+    able to create a nested item.
+    When the filename is not well formated, it should be sanitizes in order to be used with a
+    filesystem.
+    """
+    user = factories.UserFactory()
+
+    client = APIClient()
+    client.force_login(user)
+
+    item = factories.ItemFactory(
+        link_reach="restricted", type=ItemTypeChoices.FOLDER, users=[(user, "owner")]
+    )
+
+    now = timezone.now()
+    with freeze_time(now):
+        response = client.post(
+            f"/api/v1.0/items/{item.id!s}/children/",
+            {
+                "type": ItemTypeChoices.FILE,
+                "filename": "><img src=x onerror=alert()>␊.txt",
+            },
+        )
+
+    assert response.status_code == 201
+    child = Item.objects.get(id=response.json()["id"])
+    assert child.title == "><img src=x onerror=alert()>␊.txt"
+    assert child.filename == "img_srcx_onerroralert.txt"
+    assert child.computed_link_reach == "restricted"
+    assert child.link_reach is None
+    assert not child.accesses.filter(role="owner", user=user).exists()
+
+    mock_sanitize_filename.assert_called_once_with("><img src=x onerror=alert()>␊.txt")
+
+    assert response.json().get("policy") is not None
+
+    policy = response.json()["policy"]
+
+    policy_parsed = urlparse(policy)
+
+    assert policy_parsed.scheme == "http"
+    assert policy_parsed.netloc == "localhost:9000"
+    assert (
+        policy_parsed.path
+        == f"/drive-media-storage/item/{child.id!s}/img_srcx_onerroralert.txt"
+    )
+
+    query_params = parse_qs(policy_parsed.query)
+
+    assert query_params.pop("X-Amz-Algorithm") == ["AWS4-HMAC-SHA256"]
+    assert query_params.pop("X-Amz-Credential") == [
+        f"drive/{now.strftime('%Y%m%d')}/eu-east-1/s3/aws4_request"
+    ]
+    assert query_params.pop("X-Amz-Date") == [now.strftime("%Y%m%dT%H%M%SZ")]
+    assert query_params.pop("X-Amz-Expires") == ["60"]
+    assert query_params.pop("X-Amz-SignedHeaders") == ["host;x-amz-acl"]
+    assert query_params.pop("X-Amz-Signature") is not None
+
+    assert len(query_params) == 0
+
+
+@mock.patch(
+    "core.api.serializers.utils.sanitize_filename", side_effect=sanitize_filename
+)
+def test_api_items_children_create_related_invalid_filename(
+    mock_sanitize_filename,
+):
+    """
+    Authenticated users with a specific write access on an item should be
+    able to create a nested item.
+    When the filename is invalid, the request should be rejected.
+    """
+    user = factories.UserFactory()
+
+    client = APIClient()
+    client.force_login(user)
+
+    item = factories.ItemFactory(
+        link_reach="restricted", type=ItemTypeChoices.FOLDER, users=[(user, "owner")]
+    )
+
+    now = timezone.now()
+    with freeze_time(now):
+        response = client.post(
+            f"/api/v1.0/items/{item.id!s}/children/",
+            {
+                "type": ItemTypeChoices.FILE,
+                "filename": "!@#$%^&*().txt",
+            },
+        )
+
+    assert response.status_code == 400
+    mock_sanitize_filename.assert_called_once_with("!@#$%^&*().txt")

--- a/src/backend/core/tests/items/test_api_items_create.py
+++ b/src/backend/core/tests/items/test_api_items_create.py
@@ -378,3 +378,57 @@ def test_api_items_create_item_race_condition():
 
         assert response1.status_code == 201
         assert response2.status_code == 201
+
+
+def test_api_items_create_file_authenticated_success_invalid_filename():
+    """
+    Authenticated users should be able to create a file item and must provide a filename.
+    When the filename is invalid it should be sanitize in order to be used with a filesystem.
+    """
+    user = factories.UserFactory()
+
+    client = APIClient()
+    client.force_login(user)
+
+    now = timezone.now()
+    with freeze_time(now):
+        response = client.post(
+            "/api/v1.0/items/",
+            {
+                "type": ItemTypeChoices.FILE,
+                "filename": "><img src=x onerror=alert()>␊.txt",
+            },
+            format="json",
+        )
+    assert response.status_code == 201
+    item = Item.objects.get()
+    assert item.title == "><img src=x onerror=alert()>␊.txt"
+    assert item.link_reach == "restricted"
+    assert item.accesses.filter(role="owner", user=user).exists()
+    assert item.type == ItemTypeChoices.FILE
+    assert item.filename == "img_srcx_onerroralert.txt"
+
+    assert response.json().get("policy") is not None
+
+    policy = response.json()["policy"]
+    policy_parsed = urlparse(policy)
+
+    assert policy_parsed.scheme == "http"
+    assert policy_parsed.netloc == "localhost:9000"
+    assert (
+        policy_parsed.path
+        == f"/drive-media-storage/item/{item.id!s}/img_srcx_onerroralert.txt"
+    )
+
+    query_params = parse_qs(policy_parsed.query)
+
+    assert query_params.pop("X-Amz-Algorithm") == ["AWS4-HMAC-SHA256"]
+    assert query_params.pop("X-Amz-Credential") == [
+        f"drive/{now.strftime('%Y%m%d')}/eu-east-1/s3/aws4_request"
+    ]
+    assert query_params.pop("X-Amz-Date") == [now.strftime("%Y%m%dT%H%M%SZ")]
+    assert query_params.pop("X-Amz-Expires") == ["60"]
+    assert query_params.pop("X-Amz-SignedHeaders") == ["host;x-amz-acl"]
+    assert query_params.pop("X-Amz-Signature") is not None
+
+    assert len(query_params) == 0

--- a/src/backend/core/tests/items/test_api_items_update.py
+++ b/src/backend/core/tests/items/test_api_items_update.py
@@ -624,6 +624,38 @@ def test_api_items_update_file_rename():
     rename_file_mock.assert_called_once_with(item.id, "new_title")
 
 
+def test_api_items_update_file_rename_invalid_filename():
+    """
+    Test the rename of a file.
+    """
+    user = factories.UserFactory()
+    client = APIClient()
+    client.force_login(user)
+
+    item = factories.ItemFactory(
+        title="old_title",
+        type=models.ItemTypeChoices.FILE,
+        filename="old_title.txt",
+        update_upload_state=models.ItemUploadStateChoices.READY,
+        creator=user,
+        users=[(user, models.RoleChoices.OWNER)],
+    )
+
+    default_storage.save(item.file_key, BytesIO(b"my prose"))
+
+    assert item.filename == "old_title.txt"
+    assert default_storage.exists(item.file_key)
+
+    with mock.patch.object(rename_file, "delay") as rename_file_mock:
+        response = client.patch(
+            f"/api/v1.0/items/{item.id!s}/",
+            {"title": "!@#$%^&*()"},
+            format="json",
+        )
+    rename_file_mock.assert_not_called()
+    assert response.status_code == 400
+
+
 def test_api_items_update_no_title_should_not_rename_file():
     """
     Test the update of a file without title should not rename the file.

--- a/src/backend/core/tests/tasks/items/test_rename_file.py
+++ b/src/backend/core/tests/tasks/items/test_rename_file.py
@@ -53,6 +53,27 @@ def test_rename_file_origin_extension_is_kept():
     assert not default_storage.exists(f"{item.key_base}/old_title.txt")
 
 
+def test_rename_filename_invalid_filename():
+    """filename should be sanitize in order to be used with a filesystem."""
+    user = factories.UserFactory()
+    item = factories.ItemFactory(
+        title="new_title",
+        type=models.ItemTypeChoices.FILE,
+        filename="old_title.txt",
+        update_upload_state=models.ItemUploadStateChoices.READY,
+        creator=user,
+        users=[(user, models.RoleChoices.OWNER)],
+    )
+
+    default_storage.save(item.file_key, BytesIO(b"my prose"))
+
+    rename_file(item.id, "><img src=x onerror=alert()>␊")
+    item.refresh_from_db()
+    assert item.filename == "img_srcx_onerroralert.txt"
+    assert default_storage.exists(item.file_key)
+    assert not default_storage.exists(f"{item.key_base}/old_title.txt")
+
+
 def test_rename_file_filename_has_not_changed():
     """The filename has not changed, no need to move it on storage."""
     user = factories.UserFactory()

--- a/src/backend/core/tests/test_api_utils_sanitize_filename.py
+++ b/src/backend/core/tests/test_api_utils_sanitize_filename.py
@@ -1,0 +1,58 @@
+"""Test for the sanitize_filename function in the api utils module."""
+
+from django.core.exceptions import ValidationError
+
+import pytest
+
+from core.api.utils import sanitize_filename
+
+
+@pytest.mark.parametrize(
+    "filename,expected_filename",
+    [
+        # no change,
+        ("hello.txt", "hello.txt"),
+        # XSS / HTML injection
+        ("><img src=x onerror=alert()>␊.txt", "img_srcx_onerroralert.txt"),
+        # Path traversal
+        ("../../etc/passwd.txt", "....etcpasswd.txt"),  # every / are renmoved
+        # Null bytes
+        ("file\x00name.txt", "filename.txt"),
+        # Unicode / homoglyph
+        ("filеname.txt", "filname.txt"),  # Cyrillic 'е'
+        # remove white spaces
+        ("my file name.txt", "my_file_name.txt"),
+        # accent are removed
+        ("héllo.txt", "hello.txt"),
+        ("wörld.txt", "world.txt"),
+        ("café résumé.txt", "cafe_resume.txt"),
+        # special characters are removed
+        ("my*file?.doc", "myfile.doc"),
+        # strip whitespaces
+        (" my_file.txt ", "my_file.txt"),
+        ("my_file.txt ", "my_file.txt"),
+        (" my_file.txt", "my_file.txt"),
+    ],
+)
+def test_api_utils_sanitize_filename(filename, expected_filename):
+    """test filename sanitize function."""
+
+    assert sanitize_filename(filename) == expected_filename
+
+
+@pytest.mark.parametrize("illegal_char", ["\\", "/", ":", "*", "?", '"', "<", ">", "|"])
+def test_api_utils_sanitize_filename_illegal_chars_replaced(illegal_char):
+    """remove illegal chars"""
+    result = sanitize_filename(f"my{illegal_char}file.txt")
+    assert illegal_char not in result
+    assert result == "myfile.txt"
+
+
+@pytest.mark.parametrize("filename", ["!@#$%^&*().txt", "   .md", "  "])
+def test_api_utils_sanitize_filename_resulting_in_empty_name_raise_an_exception(
+    filename,
+):
+    """Test filename empyt once sanitize should raise an exception"""
+
+    with pytest.raises(ValidationError):
+        sanitize_filename(filename)


### PR DESCRIPTION
## Purpose

Filename were used as it, provided by the user. We want to force sanitization on them to ensure they will be always compatible with filesystems.

## Proposal

- [x] 🐛(backend) sanitize filename to be compatible with filesystems

Fix #555 