### PR TITLE
📝 Fix documentation and comment typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -209,7 +209,7 @@ and this project adheres to
 
 ### Fixed
 
-- 🐛(wopi) force updated_at udpate in the viewset
+- 🐛(wopi) force updated_at update in the viewset
 - 🐛(front) fix large uploads progress
 - ♻️(back) improve uploaded ended performance
 - (front) fix large uploads progress
@@ -230,7 +230,7 @@ and this project adheres to
 
 ### Added
 
-- ✨(backend) create wopi applcation #2
+- ✨(backend) create wopi application #2
 - ✨(backend) expose url_preview on item object #355
 - ✨(front) add messages widget #357
 

--- a/README.md
+++ b/README.md
@@ -152,4 +152,4 @@ While Drive is a public driven initiative our licence choice is an invitation fo
 
 ## Credits ❤️
 
-Docs is built on top of [Django Rest Framework](https://www.django-rest-framework.org/), [Next.js](https://nextjs.org/). We thank the contributors of all these projects for their awesome work!
+Drive is built on top of [Django Rest Framework](https://www.django-rest-framework.org/), [Next.js](https://nextjs.org/). We thank the contributors of all these projects for their awesome work!

--- a/docs/examples/helm/drive.values.yaml
+++ b/docs/examples/helm/drive.values.yaml
@@ -86,7 +86,7 @@ backend:
       mountPath: /usr/local/lib/python3.12/site-packages/certifi/cacert.pem
       subPath: cacert.pem
 
-  # Exra volumes to manage our local custom CA and avoid to set ssl_verify: false
+  # Extra volumes to manage our local custom CA and avoid to set ssl_verify: false
   extraVolumes:
     - name: certs
       configMap:

--- a/docs/installation/kubernetes.md
+++ b/docs/installation/kubernetes.md
@@ -265,4 +265,4 @@ minio-dev-backend-minio-console   <none>   drive-minio-console.127.0.0.1.nip.io 
 
 ```
 
-You can use Drive at https://drive.127.0.0.1.nip.io. The provisionning user in keycloak is drive/drive.
+You can use Drive at https://drive.127.0.0.1.nip.io. The provisioning user in keycloak is drive/drive.

--- a/src/backend/core/templatetags/extra_tags.py
+++ b/src/backend/core/templatetags/extra_tags.py
@@ -1,4 +1,4 @@
-"""Custom template tags for the core application of People."""
+"""Custom template tags for the core application of Drive."""
 
 import base64
 

--- a/src/helm/drive/values.yaml
+++ b/src/helm/drive/values.yaml
@@ -37,7 +37,7 @@ ingress:
   ## @param ingress.hosts Additional host to configure for the Ingress
   hosts: []
   #  - chart-example.local
-  ## @param ingress.tls.enabled Weather to enable TLS for the Ingress
+  ## @param ingress.tls.enabled Whether to enable TLS for the Ingress
   ## @param ingress.tls.secretName Secret name for TLS config
   ## @skip ingress.tls.additional
   ## @extra ingress.tls.additional[].secretName Secret name for additional TLS config
@@ -62,7 +62,7 @@ ingressAdmin:
   ## @param ingressAdmin.hosts Additional host to configure for the Ingress
   hosts: []
   #  - chart-example.local
-  ## @param ingressAdmin.tls.enabled Weather to enable TLS for the Ingress
+  ## @param ingressAdmin.tls.enabled Whether to enable TLS for the Ingress
   ## @param ingressAdmin.tls.secretName Secret name for TLS config
   ## @skip ingressAdmin.tls.additional
   ## @extra ingressAdmin.tls.additional[].secretName Secret name for additional TLS config
@@ -84,7 +84,7 @@ ingressMedia:
   ## @param ingressMedia.hosts Additional host to configure for the Ingress
   hosts: []
   #  - chart-example.local
-  ## @param ingressMedia.tls.enabled Weather to enable TLS for the Ingress
+  ## @param ingressMedia.tls.enabled Whether to enable TLS for the Ingress
   ## @param ingressMedia.tls.secretName Secret name for TLS config
   ## @skip ingressMedia.tls.additional
   ## @extra ingressMedia.tls.additional[].secretName Secret name for additional TLS config
@@ -118,7 +118,7 @@ ingressMediaPreview:
   ## @param ingressMediaPreview.hosts Additional host to configure for the Ingress
   hosts: []
   #  - chart-example.local
-  ## @param ingressMediaPreview.tls.enabled Weather to enable TLS for the Ingress
+  ## @param ingressMediaPreview.tls.enabled Whether to enable TLS for the Ingress
   ## @param ingressMediaPreview.tls.secretName Secret name for TLS config
   ## @skip ingressMediaPreview.tls.additional
   ## @extra ingressMediaPreview.tls.additional[].secretName Secret name for additional TLS config
@@ -435,7 +435,7 @@ frontend:
   ## @param frontend.replicas Amount of frontend replicas
   replicas: 3
 
-  ## @param frontend.shareProcessNamespace Enable share process namefrontend between containers
+  ## @param frontend.shareProcessNamespace Enable share process namespace between containers
   shareProcessNamespace: false
 
   ## @param frontend.sidecars Add sidecars containers to frontend deployment


### PR DESCRIPTION
## Summary

Fix typos found in documentation and code comments across the codebase.

### Documentation
- `Docs is built` → `Drive is built` (README.md - copy-paste error)
- `udpate` → `update` (CHANGELOG.md)
- `applcation` → `application` (CHANGELOG.md)
- `provisionning` → `provisioning` (kubernetes.md)

### Helm chart comments
- `Weather` → `Whether` (values.yaml, 4 occurrences)
- `namefrontend` → `namespace` (values.yaml)
- `Exra` → `Extra` (drive.values.yaml example)

### Docstrings
- `People` → `Drive` (extra_tags.py)

All changes are in comments and documentation only — no functional impact.

## Files changed
- 6 files
- 11 lines