### PR TITLE
🌐(front) update Dutch translation for create label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Added
 
+- 🌐(frontend) update Dutch translation for create label
 - ✨(frontend) add create folder and import file actions
 - 🐛(frontend) add action menu to mobile breadcrumbs
 - 🐛(frontend) app stabilization

--- a/src/frontend/apps/drive/src/features/i18n/translations.json
+++ b/src/frontend/apps/drive/src/features/i18n/translations.json
@@ -1289,7 +1289,7 @@
         "tree": {
           "trash": "Prullenbak",
           "create": {
-            "label": "Nieuwe",
+            "label": "Nieuw",
             "folder": "Nieuwe map",
             "file": {
               "doc": "Nieuw tekstdocument",


### PR DESCRIPTION
## Purpose

Changed 'Nieuwe' to 'Nieuw' for the tree create label in the Dutch translations.