### PR TITLE
🐛(backend) fix hard delete of files created by other users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- 🐛(backend) fix hard delete of files created by other users
+
 ## [v0.15.0] - 2026-03-16
 
 ### Added

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -818,7 +818,7 @@ class Item(TreeModel, BaseModel):
         # Characteristics that are based only on specific access
         is_owner = role == RoleChoices.OWNER
         is_deleted = self.ancestors_deleted_at
-        is_owner_or_admin = (is_owner or role == RoleChoices.ADMIN) and not is_deleted
+        is_owner_or_admin = is_owner or role == RoleChoices.ADMIN
 
         # Compute access roles before adding link roles because we don't
         # want anonymous users to access versions (we wouldn't know from
@@ -843,6 +843,7 @@ class Item(TreeModel, BaseModel):
             role = RoleChoices.max(role, link_definition["link_role"])
         can_get = bool(role) and not is_deleted
         retrieve = can_get or is_owner
+        can_manage = is_owner_or_admin and not is_deleted
         can_update = (is_owner_or_admin or role == RoleChoices.EDITOR) and not is_deleted
         can_create_children = can_update and user.is_authenticated
         can_hard_delete = (
@@ -859,7 +860,7 @@ class Item(TreeModel, BaseModel):
         )
 
         return {
-            "accesses_manage": is_owner_or_admin,
+            "accesses_manage": can_manage,
             "accesses_view": has_access_role,
             "breadcrumb": can_get,
             "children_list": can_get,
@@ -869,10 +870,10 @@ class Item(TreeModel, BaseModel):
             "duplicate": can_duplicate,
             "hard_delete": can_hard_delete,
             "favorite": can_get and user.is_authenticated,
-            "link_configuration": is_owner_or_admin,
+            "link_configuration": can_manage,
             "invite_owner": is_owner and not is_deleted,
             "link_select_options": link_select_options,
-            "move": is_owner_or_admin and not is_deleted,
+            "move": can_manage,
             "restore": is_owner,
             "retrieve": retrieve,
             "tree": can_get,

--- a/src/backend/core/tests/items/test_api_items_hard_delete.py
+++ b/src/backend/core/tests/items/test_api_items_hard_delete.py
@@ -96,6 +96,34 @@ def test_api_items_hard_delete_authenticated_owner_already_hard_deleted_should_f
     assert response.status_code == 404
 
 
+def test_api_items_hard_delete_by_folder_owner_for_other_users_file():
+    """
+    A folder owner should be able to hard delete a file created by another user
+    if that file is in their trashbin (i.e. deleted within their folder).
+    """
+    folder_owner = factories.UserFactory()
+    other_user = factories.UserFactory()
+
+    folder = factories.ItemFactory(
+        type=models.ItemTypeChoices.FOLDER,
+        users=[(folder_owner, models.RoleChoices.OWNER), (other_user, models.RoleChoices.EDITOR)],
+    )
+    file = factories.ItemFactory(
+        type=models.ItemTypeChoices.FILE,
+        parent=folder,
+        creator=other_user,
+        users=[(other_user, models.RoleChoices.OWNER)],
+    )
+    file.soft_delete()
+
+    client = APIClient()
+    client.force_login(folder_owner)
+
+    response = client.delete(f"/api/v1.0/items/{file.id!s}/hard-delete/")
+    assert response.status_code == 204
+    assert not models.Item.objects.filter(id=file.id).exists()
+
+
 def test_api_items_hard_delete_suspicious_item_should_not_work_for_non_creator():
     """
     Non-creators should not be able to hard delete suspicious items.

--- a/src/backend/core/tests/test_models_items.py
+++ b/src/backend/core/tests/test_models_items.py
@@ -679,6 +679,82 @@ def test_models_items_not_root_get_abilities_reader_user(django_assert_num_queri
     )
 
 
+def test_models_items_get_abilities_hard_delete_non_root_by_non_creator(
+    django_assert_num_queries,
+):
+    """Check abilities for a folder owner on a child item created by another user."""
+    owner = factories.UserFactory()
+    other_user = factories.UserFactory()
+
+    folder = factories.ItemFactory(
+        type=models.ItemTypeChoices.FOLDER,
+        users=[
+            (owner, "owner"),
+            (other_user, "editor"),
+        ],
+    )
+    child = factories.ItemFactory(
+        type=models.ItemTypeChoices.FILE,
+        parent=folder,
+        creator=other_user,
+        users=[(other_user, "owner")],
+    )
+    link_select_options = LinkReachChoices.get_select_options(**child.ancestors_link_definition)
+    expected_abilities = {
+        "accesses_manage": True,
+        "accesses_view": True,
+        "breadcrumb": True,
+        "children_create": True,
+        "children_list": True,
+        "destroy": True,
+        "download": True,
+        "duplicate": False,
+        "hard_delete": True,
+        "favorite": True,
+        "invite_owner": True,
+        "link_configuration": True,
+        "link_select_options": link_select_options,
+        "media_auth": True,
+        "move": True,
+        "partial_update": True,
+        "restore": True,
+        "retrieve": True,
+        "tree": True,
+        "update": True,
+        "upload_ended": True,
+        "wopi": True,
+    }
+    with django_assert_num_queries(1):
+        assert child.get_abilities(owner) == expected_abilities
+
+    child.soft_delete()
+    child.refresh_from_db()
+    assert child.get_abilities(owner) == {
+        "accesses_manage": False,
+        "accesses_view": False,
+        "breadcrumb": False,
+        "children_create": False,
+        "children_list": False,
+        "destroy": False,
+        "download": False,
+        "duplicate": False,
+        "hard_delete": True,
+        "favorite": False,
+        "invite_owner": False,
+        "link_configuration": False,
+        "link_select_options": {},
+        "media_auth": False,
+        "move": False,
+        "partial_update": False,
+        "restore": True,
+        "retrieve": True,
+        "tree": False,
+        "update": False,
+        "upload_ended": False,
+        "wopi": False,
+    }
+
+
 def test_models_items__email_invitation__success():
     """
     The email invitation is sent successfully.


### PR DESCRIPTION

  ## Purpose

  Fix #604 — A folder owner/admin gets a 403 when trying to hard delete a trashed file created by another user.

  ## Proposal

  The `can_hard_delete` ability used `is_owner_or_admin` which included a `not is_deleted` condition, making it always `False` for trashed items.

  - [x] Extract `is_owner_or_admin` as a pure role check (owner or admin, regardless of deletion state)
  - [x] Introduce `can_manage` for operations that require the item to not be deleted
  - [x] Use `is_owner_or_admin` in `can_hard_delete` so owners/admins can hard delete trashed items
  - [x] Add test covering the scenario
