### PR TITLE
📝(docs) fix k8s local cluster installation guide

### DIFF
--- a/docs/examples/helm/drive.values.yaml
+++ b/docs/examples/helm/drive.values.yaml
@@ -64,6 +64,8 @@ backend:
     AWS_S3_SIGNATURE_VERSION: s3v4
     STORAGES_STATICFILES_BACKEND: django.contrib.staticfiles.storage.StaticFilesStorage
     MEDIA_BASE_URL: https://drive.127.0.0.1.nip.io
+    REQUESTS_CA_BUNDLE: /etc/ssl/certs/local-ca.pem
+    SSL_CERT_FILE: /etc/ssl/certs/local-ca.pem
   migrate:
     command:
       - "/bin/sh"
@@ -83,7 +85,7 @@ backend:
   # Extra volume mounts to manage our local custom CA and avoid to set ssl_verify: false
   extraVolumeMounts:
     - name: certs
-      mountPath: /usr/local/lib/python3.12/site-packages/certifi/cacert.pem
+      mountPath: /etc/ssl/certs/local-ca.pem
       subPath: cacert.pem
 
   # Extra volumes to manage our local custom CA and avoid to set ssl_verify: false

--- a/docs/installation/kubernetes.md
+++ b/docs/installation/kubernetes.md
@@ -106,6 +106,16 @@ $ kubectl config set-context --current --namespace=drive
 
 Please remember that `*.127.0.0.1.nip.io` will always resolve to `127.0.0.1`, except in the k8s cluster where we configure CoreDNS to answer with the ingress-nginx service IP.
 
+## Populate the CA certificate bundle
+
+Before deploying Drive, you need to build and load the mkcert root CA into a Kubernetes ConfigMap. This is required so that the backend can trust the local certificates.
+
+```
+$ cat /etc/ssl/cert.pem "$(mkcert -CAROOT)/rootCA.pem" > /tmp/cacert.pem
+$ kubectl delete configmap certifi
+$ kubectl create configmap certifi --from-file=cacert.pem=/tmp/cacert.pem
+```
+
 ## Preparation
 
 ### What do you use to authenticate your users?


### PR DESCRIPTION
## Summary

- Fix all helm chart `--repo` URLs pointing to GitHub Pages (`suitenumerique.github.io`) with direct GitHub repo URLs (`github.com/suitenumerique`) for `helm-dev-backend` and the `drive` chart
- Add a \"Populate the CA certificate bundle\" section explaining how to load the mkcert root CA into a Kubernetes ConfigMap before deploying
- Update `drive.values.yaml`: add `REQUESTS_CA_BUNDLE` and `SSL_CERT_FILE` env vars, and fix the CA cert volume mount path to use a generic system path (`/etc/ssl/certs/local-ca.pem`) instead of a Python-version-specific certifi path

## Test plan

- [ ] Follow the updated guide on a fresh Kind cluster using `bin/start-kind.sh`
- [ ] Verify helm installs succeed with the corrected repo URLs
- [ ] Verify the backend trusts local certificates after populating the CA ConfigMap

🤖 Generated with [Claude Code](https://claude.com/claude-code)