### PR TITLE
🐛(backend) catch IntegrityError on concurrent LinkTrace creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 ### Fixed
 
 - 🐛(backend) fix hard delete of files created by other users
+- 🐛(backend) handle race condition on concurrent LinkTrace creation
 
 ## [v0.15.0] - 2026-03-16
 

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -13,8 +13,8 @@ from django.contrib.postgres.search import TrigramSimilarity
 from django.core.cache import cache
 from django.core.exceptions import ValidationError
 from django.core.files.storage import default_storage
+from django.db import IntegrityError, transaction
 from django.db import models as db
-from django.db import transaction
 from django.db.models.expressions import RawSQL
 from django.db.models.functions import Coalesce
 from django.urls import reverse
@@ -537,7 +537,10 @@ class ItemViewSet(
         # `exists` query. The user will visit the item many times after the first visit
         # so that's what we should optimize for.
         if user.is_authenticated and not instance.link_traces.filter(user=user).exists():
-            models.LinkTrace.objects.create(item=instance, user=request.user)
+            try:
+                models.LinkTrace.objects.create(item=instance, user=request.user)
+            except IntegrityError:
+                pass  # Race condition: trace already created by concurrent request
 
         return drf.response.Response(serializer.data)
 

--- a/src/backend/core/tests/items/test_api_items_retrieve.py
+++ b/src/backend/core/tests/items/test_api_items_retrieve.py
@@ -9,6 +9,7 @@ from unittest import mock
 
 from django.contrib.auth.models import AnonymousUser
 from django.core.cache import cache
+from django.db import IntegrityError
 from django.utils import timezone
 
 import pytest
@@ -884,6 +885,33 @@ def test_api_items_retrieve_numqueries_with_link_trace(django_assert_num_queries
     assert response.status_code == 200
 
     assert response.json()["id"] == str(item.id)
+
+
+def test_api_items_retrieve_concurrent_link_trace_creation():
+    """
+    A concurrent retrieve request should not fail when a LinkTrace for the same
+    user/item pair is created by another request in between the exists() check
+    and the create() call.
+    """
+    user = factories.UserFactory()
+    client = APIClient()
+    client.force_login(user)
+
+    item = factories.ItemFactory(
+        link_reach="public",
+        type=models.ItemTypeChoices.FILE,
+    )
+
+    with mock.patch.object(
+        models.LinkTrace.objects,
+        "create",
+        side_effect=IntegrityError(
+            'duplicate key value violates unique constraint "unique_link_trace_item_user"'
+        ),
+    ):
+        response = client.get(f"/api/v1.0/items/{item.id!s}/")
+
+    assert response.status_code == 200
 
 
 # Soft/permanent delete


### PR DESCRIPTION


## Purpose

Handle race condition where two concurrent retrieve requests pass the exists() check and both attempt to create a LinkTrace for the same user/item pair, violating the unique constraint.

Fixes #611
