### PR TITLE
Mirror files when boto3.copy_object is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to
 - 📝(doc) add local network setup documentation
 - ✨(global) add custom columns feature with configurable grid columns
 - ✨(backend) mirror a file once renamed
+- ✨(backend) mirror a file when duplicated
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to
 - ✨(frontend) integrate PDF viewer into file preview modal
 - 📝(doc) add local network setup documentation
 - ✨(global) add custom columns feature with configurable grid columns
+- ✨(backend) mirror a file once renamed
 
 ### Changed
 

--- a/src/backend/core/tasks/item.py
+++ b/src/backend/core/tasks/item.py
@@ -13,6 +13,7 @@ import botocore
 
 from core.api.utils import sanitize_filename
 from core.models import Item, ItemTypeChoices, ItemUploadStateChoices
+from core.tasks.storage import rename_file_on_mirroring_bucket
 
 from drive.celery_app import app
 
@@ -104,6 +105,8 @@ def rename_file(item_id, new_title):
         Bucket=default_storage.bucket_name,
         Key=from_file_key,
     )
+
+    rename_file_on_mirroring_bucket.delay(item.id, from_file_key, to_file_key)
 
 
 @app.task

--- a/src/backend/core/tasks/item.py
+++ b/src/backend/core/tasks/item.py
@@ -13,7 +13,7 @@ import botocore
 
 from core.api.utils import sanitize_filename
 from core.models import Item, ItemTypeChoices, ItemUploadStateChoices
-from core.tasks.storage import rename_file_on_mirroring_bucket
+from core.tasks.storage import duplicate_file_on_mirroring_bucket, rename_file_on_mirroring_bucket
 
 from drive.celery_app import app
 
@@ -132,7 +132,7 @@ def update_suspicious_item_file_hash(item_id):
 
 @app.task(bind=True, max_retries=10)
 def duplicate_file(self, item_to_duplicate_id, duplicated_item_id):
-    """Copy a file on the storage."""
+    """Duplicate a file on the storage by creating a copy of the original file."""
     try:
         item_to_duplicate = Item.objects.get(id=item_to_duplicate_id)
     except Item.DoesNotExist:
@@ -197,3 +197,7 @@ def duplicate_file(self, item_to_duplicate_id, duplicated_item_id):
 
     duplicated_item.upload_state = ItemUploadStateChoices.READY
     duplicated_item.save(update_fields=["upload_state", "updated_at"])
+
+    duplicate_file_on_mirroring_bucket.delay(
+        duplicated_item.id, item_to_duplicate.file_key, duplicated_item.file_key
+    )

--- a/src/backend/core/tasks/storage.py
+++ b/src/backend/core/tasks/storage.py
@@ -144,3 +144,37 @@ def rename_file_on_mirroring_bucket(item_id, from_file_key, to_file_key):
         Bucket=mirror_bucket,
         Key=from_file_key,
     )
+
+
+@app.task
+def duplicate_file_on_mirroring_bucket(duplicated_item_id, from_file_key, to_file_key):
+    """Duplicate a file on the mirror bucket by creating a copy of the original file."""
+
+    mirror_s3_client = get_mirror_s3_client()
+    if not mirror_s3_client:
+        logger.info(
+            "Mirroring S3 bucket is not configured, skipping renaming file on the mirroring bucket"
+        )
+        return
+    mirror_bucket = settings.AWS_S3_MIRRORING_STORAGE_BUCKET_NAME
+
+    try:
+        mirror_s3_client.head_object(Bucket=mirror_bucket, Key=from_file_key)
+    except botocore.exceptions.ClientError:
+        item = Item.objects.get(pk=duplicated_item_id)
+        mirror_task = MirrorItemTask.objects.create(
+            item=item, status=MirrorItemTaskStatusChoices.PENDING
+        )
+
+        mirror_file.delay(mirror_task.id)
+        return
+
+    mirror_s3_client.copy_object(
+        Bucket=mirror_bucket,
+        CopySource={
+            "Bucket": mirror_bucket,
+            "Key": from_file_key,
+        },
+        Key=to_file_key,
+        MetadataDirective="COPY",
+    )

--- a/src/backend/core/tasks/storage.py
+++ b/src/backend/core/tasks/storage.py
@@ -10,7 +10,7 @@ import boto3
 import botocore
 
 from core.api.utils import get_item_file_head_object
-from core.models import MirrorItemTask, MirrorItemTaskStatusChoices
+from core.models import Item, MirrorItemTask, MirrorItemTaskStatusChoices
 
 from drive.celery_app import app
 
@@ -104,3 +104,43 @@ def mirror_file(self, mirror_task_id):
     logger.info("Successfully mirrored file %s to bucket %s", item_key, mirror_bucket)
     mirror_task.status = MirrorItemTaskStatusChoices.COMPLETED
     mirror_task.save(update_fields=["status", "updated_at"])
+
+
+@app.task
+def rename_file_on_mirroring_bucket(item_id, from_file_key, to_file_key):
+    """
+    Rename a file on the mirroring bucket. If the original file does not exist, mirror it.
+    Copy it otherwise
+    """
+    mirror_s3_client = get_mirror_s3_client()
+    if not mirror_s3_client:
+        logger.info(
+            "Mirroring S3 bucket is not configured, skipping renaming file on the mirroring bucket"
+        )
+        return
+    mirror_bucket = settings.AWS_S3_MIRRORING_STORAGE_BUCKET_NAME
+
+    try:
+        mirror_s3_client.head_object(Bucket=mirror_bucket, Key=from_file_key)
+    except botocore.exceptions.ClientError:
+        item = Item.objects.get(pk=item_id)
+        mirror_task = MirrorItemTask.objects.create(
+            item=item, status=MirrorItemTaskStatusChoices.PENDING
+        )
+
+        mirror_file.delay(mirror_task.id)
+        return
+
+    mirror_s3_client.copy_object(
+        Bucket=mirror_bucket,
+        CopySource={
+            "Bucket": mirror_bucket,
+            "Key": from_file_key,
+        },
+        Key=to_file_key,
+        MetadataDirective="COPY",
+    )
+    mirror_s3_client.delete_object(
+        Bucket=mirror_bucket,
+        Key=from_file_key,
+    )

--- a/src/backend/core/tests/tasks/items/test_duplicate_file.py
+++ b/src/backend/core/tests/tasks/items/test_duplicate_file.py
@@ -2,6 +2,7 @@
 
 import uuid
 from io import BytesIO
+from unittest import mock
 
 from django.core.files.storage import default_storage
 
@@ -9,7 +10,7 @@ import botocore
 import pytest
 
 from core import factories, models
-from core.tasks.item import duplicate_file
+from core.tasks.item import duplicate_file, duplicate_file_on_mirroring_bucket
 
 pytestmark = pytest.mark.django_db
 
@@ -20,7 +21,12 @@ pytestmark = pytest.mark.django_db
 def test_duplicate_file_item_to_duplicate_does_not_exist(caplog):
     """Test when the item_to_duplicate does not exists, should abort the task."""
 
-    with caplog.at_level("ERROR", logger="core.tasks.item"):
+    with (
+        caplog.at_level("ERROR", logger="core.tasks.item"),
+        mock.patch.object(
+            duplicate_file_on_mirroring_bucket, "delay"
+        ) as mock_duplicate_file_on_mirroring_bucket,
+    ):
         item_to_duplicate_id = uuid.uuid4()
         duplicate_file(item_to_duplicate_id=item_to_duplicate_id, duplicated_item_id=uuid.uuid4())
 
@@ -29,13 +35,20 @@ def test_duplicate_file_item_to_duplicate_does_not_exist(caplog):
         "aborting" in caplog.text
     )
 
+    mock_duplicate_file_on_mirroring_bucket.assert_not_called()
+
 
 def test_duplicate_file_duplicated_item_does_not_exist(caplog):
     """Test when the duplicated_item does not exists, should abort the task."""
 
     item_to_duplicate = factories.ItemFactory(type=models.ItemTypeChoices.FILE)
 
-    with caplog.at_level("ERROR", logger="core.tasks.item"):
+    with (
+        caplog.at_level("ERROR", logger="core.tasks.item"),
+        mock.patch.object(
+            duplicate_file_on_mirroring_bucket, "delay"
+        ) as mock_duplicate_file_on_mirroring_bucket,
+    ):
         duplicated_item_id = uuid.uuid4()
         duplicate_file(
             item_to_duplicate_id=item_to_duplicate.id,
@@ -46,6 +59,7 @@ def test_duplicate_file_duplicated_item_does_not_exist(caplog):
         f"duplicating file: duplicated_item with id {duplicated_item_id} does not exist, aborting"
         in caplog.text
     )
+    mock_duplicate_file_on_mirroring_bucket.assert_not_called()
 
 
 def test_duplicate_file_duplicated_file_not_in_duplicating_state(caplog):
@@ -60,7 +74,12 @@ def test_duplicate_file_duplicated_file_not_in_duplicating_state(caplog):
         update_upload_state=models.ItemUploadStateChoices.READY,
     )
 
-    with caplog.at_level("ERROR", logger="core.tasks.item"):
+    with (
+        caplog.at_level("ERROR", logger="core.tasks.item"),
+        mock.patch.object(
+            duplicate_file_on_mirroring_bucket, "delay"
+        ) as mock_duplicate_file_on_mirroring_bucket,
+    ):
         duplicate_file(
             item_to_duplicate_id=item_to_duplicate.id,
             duplicated_item_id=duplicated_item.id,
@@ -70,6 +89,7 @@ def test_duplicate_file_duplicated_file_not_in_duplicating_state(caplog):
         "duplicating file: the duplidated file upload_state is not duplicating but ready, "
         "aborting" in caplog.text
     )
+    mock_duplicate_file_on_mirroring_bucket.assert_not_called()
 
 
 def test_duplicate_file():
@@ -89,16 +109,21 @@ def test_duplicate_file():
     default_storage.save(item_to_duplicate.file_key, BytesIO(b"my prose"))
 
     assert not default_storage.exists(duplicated_item.file_key)
-
-    duplicate_file(
-        item_to_duplicate_id=item_to_duplicate.id,
-        duplicated_item_id=duplicated_item.id,
-    )
+    with mock.patch.object(
+        duplicate_file_on_mirroring_bucket, "delay"
+    ) as mock_duplicate_file_on_mirroring_bucket:
+        duplicate_file(
+            item_to_duplicate_id=item_to_duplicate.id,
+            duplicated_item_id=duplicated_item.id,
+        )
 
     duplicated_item.refresh_from_db()
 
     assert duplicated_item.upload_state == models.ItemUploadStateChoices.READY
     assert default_storage.exists(duplicated_item.file_key)
+    mock_duplicate_file_on_mirroring_bucket.assert_called_once_with(
+        duplicated_item.id, item_to_duplicate.file_key, duplicated_item.file_key
+    )
 
 
 def test_duplicate_file_retry(caplog):
@@ -119,6 +144,9 @@ def test_duplicate_file_retry(caplog):
     with (
         caplog.at_level("ERROR", logger="core.tasks.item"),
         pytest.raises(botocore.exceptions.ClientError),
+        mock.patch.object(
+            duplicate_file_on_mirroring_bucket, "delay"
+        ) as mock_duplicate_file_on_mirroring_bucket,
     ):
         duplicate_file(
             item_to_duplicate_id=item_to_duplicate.id,
@@ -130,6 +158,7 @@ def test_duplicate_file_retry(caplog):
         "(NoSuchKey) when calling the CopyObject operation: The specified key does not exist."
         in caplog.text
     )
+    mock_duplicate_file_on_mirroring_bucket.assert_not_called()
 
 
 def test_duplicate_file_max_retries_exceeded(caplog):
@@ -150,6 +179,9 @@ def test_duplicate_file_max_retries_exceeded(caplog):
     with (
         caplog.at_level("ERROR", logger="core.tasks.item"),
         pytest.raises(botocore.exceptions.ClientError),
+        mock.patch.object(
+            duplicate_file_on_mirroring_bucket, "delay"
+        ) as mock_duplicate_file_on_mirroring_bucket,
     ):
         duplicate_file.max_retries = 0
         duplicate_file(
@@ -163,3 +195,4 @@ def test_duplicate_file_max_retries_exceeded(caplog):
         f"duplicating file: 0 max retries exceeded, the duplicated item {duplicated_item.id} is"
         " deleted" in caplog.text
     )
+    mock_duplicate_file_on_mirroring_bucket.assert_not_called()

--- a/src/backend/core/tests/tasks/items/test_rename_file.py
+++ b/src/backend/core/tests/tasks/items/test_rename_file.py
@@ -1,13 +1,14 @@
 """Test the rename file task."""
 
 from io import BytesIO
+from unittest import mock
 
 from django.core.files.storage import default_storage
 
 import pytest
 
 from core import factories, models
-from core.tasks.item import rename_file
+from core.tasks.item import rename_file, rename_file_on_mirroring_bucket
 
 pytestmark = pytest.mark.django_db
 
@@ -26,11 +27,17 @@ def test_rename_file():
 
     default_storage.save(item.file_key, BytesIO(b"my prose"))
 
-    rename_file(item.id, "new_title")
+    with mock.patch.object(
+        rename_file_on_mirroring_bucket, "delay"
+    ) as mock_rename_file_on_mirroring_bucket:
+        rename_file(item.id, "new_title")
     item.refresh_from_db()
     assert item.filename == "new_title.txt"
     assert default_storage.exists(item.file_key)
     assert not default_storage.exists(f"{item.key_base}/old_title.txt")
+    mock_rename_file_on_mirroring_bucket.assert_called_once_with(
+        item.id, f"{item.key_base}/old_title.txt", item.file_key
+    )
 
 
 def test_rename_file_origin_extension_is_kept():
@@ -46,11 +53,17 @@ def test_rename_file_origin_extension_is_kept():
     )
     default_storage.save(item.file_key, BytesIO(b"my prose"))
 
-    rename_file(item.id, "new_title.pdf")
+    with mock.patch.object(
+        rename_file_on_mirroring_bucket, "delay"
+    ) as mock_rename_file_on_mirroring_bucket:
+        rename_file(item.id, "new_title.pdf")
     item.refresh_from_db()
     assert item.filename == "new_title.pdf.txt"
     assert default_storage.exists(item.file_key)
     assert not default_storage.exists(f"{item.key_base}/old_title.txt")
+    mock_rename_file_on_mirroring_bucket.assert_called_once_with(
+        item.id, f"{item.key_base}/old_title.txt", item.file_key
+    )
 
 
 def test_rename_filename_invalid_filename():
@@ -67,11 +80,17 @@ def test_rename_filename_invalid_filename():
 
     default_storage.save(item.file_key, BytesIO(b"my prose"))
 
-    rename_file(item.id, "><img src=x onerror=alert()>␊")
+    with mock.patch.object(
+        rename_file_on_mirroring_bucket, "delay"
+    ) as mock_rename_file_on_mirroring_bucket:
+        rename_file(item.id, "><img src=x onerror=alert()>␊")
     item.refresh_from_db()
     assert item.filename == "img_srcx_onerroralert.txt"
     assert default_storage.exists(item.file_key)
     assert not default_storage.exists(f"{item.key_base}/old_title.txt")
+    mock_rename_file_on_mirroring_bucket.assert_called_once_with(
+        item.id, f"{item.key_base}/old_title.txt", item.file_key
+    )
 
 
 def test_rename_file_filename_has_not_changed():
@@ -89,11 +108,15 @@ def test_rename_file_filename_has_not_changed():
     updated_at = item.updated_at
     file_key = item.file_key
 
-    rename_file(item.id, "new_title")
+    with mock.patch.object(
+        rename_file_on_mirroring_bucket, "delay"
+    ) as mock_rename_file_on_mirroring_bucket:
+        rename_file(item.id, "new_title")
     item.refresh_from_db()
     assert item.filename == "new_title.txt"
     assert item.updated_at == updated_at
     assert default_storage.exists(file_key)
+    mock_rename_file_on_mirroring_bucket.assert_not_called()
 
 
 def test_rename_file_item_not_ready(caplog):
@@ -107,11 +130,17 @@ def test_rename_file_item_not_ready(caplog):
         creator=user,
         users=[(user, models.RoleChoices.OWNER)],
     )
-    with caplog.at_level("ERROR", logger="core.tasks.item"):
+    with (
+        caplog.at_level("ERROR", logger="core.tasks.item"),
+        mock.patch.object(
+            rename_file_on_mirroring_bucket, "delay"
+        ) as mock_rename_file_on_mirroring_bucket,
+    ):
         rename_file(item.id, "new_title")
     item.refresh_from_db()
     assert item.filename == "old_title.txt"
     assert f"Item {item.id} is not ready for renaming" in caplog.text
+    mock_rename_file_on_mirroring_bucket.assert_not_called()
 
 
 def test_rename_file_new_title_is_empty(caplog):
@@ -126,11 +155,17 @@ def test_rename_file_new_title_is_empty(caplog):
         users=[(user, models.RoleChoices.OWNER)],
     )
 
-    with caplog.at_level("ERROR", logger="core.tasks.item"):
+    with (
+        caplog.at_level("ERROR", logger="core.tasks.item"),
+        mock.patch.object(
+            rename_file_on_mirroring_bucket, "delay"
+        ) as mock_rename_file_on_mirroring_bucket,
+    ):
         rename_file(item.id, "")
     item.refresh_from_db()
     assert item.filename == "old_title.txt"
     assert "New title is empty, skipping rename file" in caplog.text
+    mock_rename_file_on_mirroring_bucket.assert_not_called()
 
 
 def test_rename_file_new_title_is_none(caplog):
@@ -145,8 +180,14 @@ def test_rename_file_new_title_is_none(caplog):
         users=[(user, models.RoleChoices.OWNER)],
     )
 
-    with caplog.at_level("ERROR", logger="core.tasks.item"):
+    with (
+        caplog.at_level("ERROR", logger="core.tasks.item"),
+        mock.patch.object(
+            rename_file_on_mirroring_bucket, "delay"
+        ) as mock_rename_file_on_mirroring_bucket,
+    ):
         rename_file(item.id, None)
     item.refresh_from_db()
     assert item.filename == "old_title.txt"
     assert "New title is empty, skipping rename file" in caplog.text
+    mock_rename_file_on_mirroring_bucket.assert_not_called()

--- a/src/backend/core/tests/tasks/storage/conftest.py
+++ b/src/backend/core/tests/tasks/storage/conftest.py
@@ -1,0 +1,11 @@
+"""Fixtures for tests in the core.tests.tasks.storage module."""
+
+import pytest
+
+from core.tasks.storage import get_mirror_s3_client
+
+
+@pytest.fixture(autouse=True)
+def clear_get_mirror_s3_client_cache():
+    """Clear the cache for get_mirror_s3_client."""
+    get_mirror_s3_client.cache_clear()

--- a/src/backend/core/tests/tasks/storage/test_duplicate_file_on_mirroring_bucket.py
+++ b/src/backend/core/tests/tasks/storage/test_duplicate_file_on_mirroring_bucket.py
@@ -1,4 +1,4 @@
-"""Test the rename_file_on_mirroring_bucket task."""
+"""Test the duplicate_file_on_mirroring_bucket task."""
 
 from unittest import mock
 
@@ -7,19 +7,19 @@ import pytest
 
 from core.factories import ItemFactory
 from core.models import ItemTypeChoices, MirrorItemTask, MirrorItemTaskStatusChoices
-from core.tasks.storage import rename_file_on_mirroring_bucket
+from core.tasks.storage import duplicate_file_on_mirroring_bucket
 
 pytestmark = pytest.mark.django_db
 
 
-def test_rename_file_no_s3_config_should_abort(settings, caplog):
+def test_duplicate_file_no_s3_config_should_abort(settings, caplog):
     """Task should abort and log when mirroring S3 is not configured."""
     settings.AWS_S3_MIRRORING_ACCESS_KEY_ID = None
     settings.AWS_S3_MIRRORING_SECRET_ACCESS_KEY = None
     settings.AWS_S3_MIRRORING_ENDPOINT_URL = None
 
     with caplog.at_level("INFO", logger="core.tasks.storage"):
-        rename_file_on_mirroring_bucket("item-id", "old/key", "new/key")
+        duplicate_file_on_mirroring_bucket("item-id", "old/key", "new/key")
 
     assert (
         "Mirroring S3 bucket is not configured, skipping renaming file on the mirroring bucket"
@@ -27,7 +27,7 @@ def test_rename_file_no_s3_config_should_abort(settings, caplog):
     )
 
 
-def test_rename_file_source_not_found_on_mirror_should_trigger_mirror_file(settings):
+def test_duplicate_file_source_not_found_on_mirror_should_trigger_mirror_file(settings):
     """When the source file does not exist on the mirroring bucket, mirror it instead."""
     settings.AWS_S3_MIRRORING_STORAGE_BUCKET_NAME = "test_mirror"
 
@@ -45,7 +45,7 @@ def test_rename_file_source_not_found_on_mirror_should_trigger_mirror_file(setti
         mock_mirror_s3_client.head_object.side_effect = client_error
         mock_get_mirror_s3_client.return_value = mock_mirror_s3_client
 
-        rename_file_on_mirroring_bucket(item.pk, "old/key", "new/key")
+        duplicate_file_on_mirroring_bucket(item.pk, "old/key", "new/key")
 
         mock_mirror_s3_client.head_object.assert_called_once_with(
             Bucket="test_mirror", Key="old/key"
@@ -57,11 +57,12 @@ def test_rename_file_source_not_found_on_mirror_should_trigger_mirror_file(setti
         mock_mirror_file.delay.assert_called_once_with(mirror_task.id)
 
         mock_mirror_s3_client.copy_object.assert_not_called()
-        mock_mirror_s3_client.delete_object.assert_not_called()
 
 
-def test_rename_file_source_exists_should_copy_then_delete(settings):
-    """When the source file exists on the mirroring bucket, copy it then delete the original."""
+def test_duplicate_file_source_exists_should_copy_without_delete(settings):
+    """
+    When the source file exists on the mirroring bucket, copy it without deleting the original.
+    """
     settings.AWS_S3_MIRRORING_STORAGE_BUCKET_NAME = "test_mirror"
 
     item = ItemFactory(type=ItemTypeChoices.FILE, filename="file.txt")
@@ -73,7 +74,7 @@ def test_rename_file_source_exists_should_copy_then_delete(settings):
         mock_mirror_s3_client.head_object.return_value = {"ContentLength": 42}
         mock_get_mirror_s3_client.return_value = mock_mirror_s3_client
 
-        rename_file_on_mirroring_bucket(item.pk, "old/key", "new/key")
+        duplicate_file_on_mirroring_bucket(item.pk, "old/key", "new/key")
 
         mock_mirror_s3_client.head_object.assert_called_once_with(
             Bucket="test_mirror", Key="old/key"
@@ -84,12 +85,10 @@ def test_rename_file_source_exists_should_copy_then_delete(settings):
             Key="new/key",
             MetadataDirective="COPY",
         )
-        mock_mirror_s3_client.delete_object.assert_called_once_with(
-            Bucket="test_mirror", Key="old/key"
-        )
+        mock_mirror_s3_client.delete_object.assert_not_called()
 
 
-def test_rename_file_source_exists_does_not_create_mirror_task(settings):
+def test_duplicate_file_source_exists_does_not_create_mirror_task(settings):
     """When the source file exists on the mirroring bucket, no MirrorItemTask should be created."""
     settings.AWS_S3_MIRRORING_STORAGE_BUCKET_NAME = "test_mirror"
 
@@ -100,12 +99,12 @@ def test_rename_file_source_exists_does_not_create_mirror_task(settings):
         mock_mirror_s3_client.head_object.return_value = {"ContentLength": 42}
         mock_get_mirror_s3_client.return_value = mock_mirror_s3_client
 
-        rename_file_on_mirroring_bucket(item.pk, "old/key", "new/key")
+        duplicate_file_on_mirroring_bucket(item.pk, "old/key", "new/key")
 
     assert not MirrorItemTask.objects.filter(item=item).exists()
 
 
-def test_rename_file_source_not_found_creates_exactly_one_mirror_task(settings):
+def test_duplicate_file_source_not_found_creates_exactly_one_mirror_task(settings):
     """Only one MirrorItemTask should be created when the source file is missing."""
     settings.AWS_S3_MIRRORING_STORAGE_BUCKET_NAME = "test_mirror"
 
@@ -123,6 +122,6 @@ def test_rename_file_source_not_found_creates_exactly_one_mirror_task(settings):
         mock_mirror_s3_client.head_object.side_effect = client_error
         mock_get_mirror_s3_client.return_value = mock_mirror_s3_client
 
-        rename_file_on_mirroring_bucket(item.pk, "old/key", "new/key")
+        duplicate_file_on_mirroring_bucket(item.pk, "old/key", "new/key")
 
     assert MirrorItemTask.objects.filter(item=item).count() == 1

--- a/src/backend/core/tests/tasks/storage/test_mirror_file.py
+++ b/src/backend/core/tests/tasks/storage/test_mirror_file.py
@@ -22,12 +22,6 @@ pytestmark = pytest.mark.django_db
 # pylint: disable=no-value-for-parameter
 
 
-@pytest.fixture(autouse=True)
-def clear_get_mirror_s3_client_cache():
-    """Clear the cache for get_mirror_s3_client."""
-    get_mirror_s3_client.cache_clear()
-
-
 def test_get_mirror_s3_client_no_config_should_return_none(settings):
     """Test get_mirror_s3_client without config should return None."""
     settings.AWS_S3_MIRRORING_ACCESS_KEY_ID = None

--- a/src/backend/core/tests/tasks/storage/test_rename_file_on_mirroring_bucket.py
+++ b/src/backend/core/tests/tasks/storage/test_rename_file_on_mirroring_bucket.py
@@ -1,0 +1,138 @@
+"""Test the rename_file_on_mirroring_bucket task."""
+
+from unittest import mock
+
+import botocore
+import pytest
+
+from core.factories import ItemFactory
+from core.models import ItemTypeChoices, MirrorItemTask, MirrorItemTaskStatusChoices
+from core.tasks.storage import (
+    get_mirror_s3_client,
+    rename_file_on_mirroring_bucket,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture(autouse=True)
+def clear_get_mirror_s3_client_cache():
+    """Clear the cache for get_mirror_s3_client."""
+    get_mirror_s3_client.cache_clear()
+
+
+def test_rename_file_no_s3_config_should_abort(settings, caplog):
+    """Task should abort and log when mirroring S3 is not configured."""
+    settings.AWS_S3_MIRRORING_ACCESS_KEY_ID = None
+    settings.AWS_S3_MIRRORING_SECRET_ACCESS_KEY = None
+    settings.AWS_S3_MIRRORING_ENDPOINT_URL = None
+
+    with caplog.at_level("INFO", logger="core.tasks.storage"):
+        result = rename_file_on_mirroring_bucket("item-id", "old/key", "new/key")
+
+    assert result is None
+    assert (
+        "Mirroring S3 bucket is not configured, skipping renaming file on the mirroring bucket"
+        in caplog.text
+    )
+
+
+def test_rename_file_source_not_found_on_mirror_should_trigger_mirror_file(settings):
+    """When the source file does not exist on the mirroring bucket, mirror it instead."""
+    settings.AWS_S3_MIRRORING_STORAGE_BUCKET_NAME = "test_mirror"
+
+    item = ItemFactory(type=ItemTypeChoices.FILE, filename="file.txt")
+
+    client_error = botocore.exceptions.ClientError(
+        {"Error": {"Code": "404", "Message": "Not Found"}}, "HeadObject"
+    )
+
+    with (
+        mock.patch("core.tasks.storage.get_mirror_s3_client") as mock_get_mirror_s3_client,
+        mock.patch("core.tasks.storage.mirror_file") as mock_mirror_file,
+    ):
+        mock_mirror_s3_client = mock.MagicMock()
+        mock_mirror_s3_client.head_object.side_effect = client_error
+        mock_get_mirror_s3_client.return_value = mock_mirror_s3_client
+
+        rename_file_on_mirroring_bucket(item.pk, "old/key", "new/key")
+
+        mock_mirror_s3_client.head_object.assert_called_once_with(
+            Bucket="test_mirror", Key="old/key"
+        )
+
+        mirror_task = MirrorItemTask.objects.get(item=item)
+        assert mirror_task.status == MirrorItemTaskStatusChoices.PENDING
+
+        mock_mirror_file.delay.assert_called_once_with(mirror_task.id)
+
+        mock_mirror_s3_client.copy_object.assert_not_called()
+        mock_mirror_s3_client.delete_object.assert_not_called()
+
+
+def test_rename_file_source_exists_should_copy_then_delete(settings):
+    """When the source file exists on the mirroring bucket, copy it then delete the original."""
+    settings.AWS_S3_MIRRORING_STORAGE_BUCKET_NAME = "test_mirror"
+
+    item = ItemFactory(type=ItemTypeChoices.FILE, filename="file.txt")
+
+    with (
+        mock.patch("core.tasks.storage.get_mirror_s3_client") as mock_get_mirror_s3_client,
+    ):
+        mock_mirror_s3_client = mock.MagicMock()
+        mock_mirror_s3_client.head_object.return_value = {"ContentLength": 42}
+        mock_get_mirror_s3_client.return_value = mock_mirror_s3_client
+
+        rename_file_on_mirroring_bucket(item.pk, "old/key", "new/key")
+
+        mock_mirror_s3_client.head_object.assert_called_once_with(
+            Bucket="test_mirror", Key="old/key"
+        )
+        mock_mirror_s3_client.copy_object.assert_called_once_with(
+            Bucket="test_mirror",
+            CopySource={"Bucket": "test_mirror", "Key": "old/key"},
+            Key="new/key",
+            MetadataDirective="COPY",
+        )
+        mock_mirror_s3_client.delete_object.assert_called_once_with(
+            Bucket="test_mirror", Key="old/key"
+        )
+
+
+def test_rename_file_source_exists_does_not_create_mirror_task(settings):
+    """When the source file exists on the mirroring bucket, no MirrorItemTask should be created."""
+    settings.AWS_S3_MIRRORING_STORAGE_BUCKET_NAME = "test_mirror"
+
+    item = ItemFactory(type=ItemTypeChoices.FILE, filename="file.txt")
+
+    with mock.patch("core.tasks.storage.get_mirror_s3_client") as mock_get_mirror_s3_client:
+        mock_mirror_s3_client = mock.MagicMock()
+        mock_mirror_s3_client.head_object.return_value = {"ContentLength": 42}
+        mock_get_mirror_s3_client.return_value = mock_mirror_s3_client
+
+        rename_file_on_mirroring_bucket(item.pk, "old/key", "new/key")
+
+    assert not MirrorItemTask.objects.filter(item=item).exists()
+
+
+def test_rename_file_source_not_found_creates_exactly_one_mirror_task(settings):
+    """Only one MirrorItemTask should be created when the source file is missing."""
+    settings.AWS_S3_MIRRORING_STORAGE_BUCKET_NAME = "test_mirror"
+
+    item = ItemFactory(type=ItemTypeChoices.FILE, filename="file.txt")
+
+    client_error = botocore.exceptions.ClientError(
+        {"Error": {"Code": "404", "Message": "Not Found"}}, "HeadObject"
+    )
+
+    with (
+        mock.patch("core.tasks.storage.get_mirror_s3_client") as mock_get_mirror_s3_client,
+        mock.patch("core.tasks.storage.mirror_file"),
+    ):
+        mock_mirror_s3_client = mock.MagicMock()
+        mock_mirror_s3_client.head_object.side_effect = client_error
+        mock_get_mirror_s3_client.return_value = mock_mirror_s3_client
+
+        rename_file_on_mirroring_bucket(item.pk, "old/key", "new/key")
+
+    assert MirrorItemTask.objects.filter(item=item).count() == 1


### PR DESCRIPTION
## Purpose

When a file is renamed or duplicated. We don't use the storage backend to do that but directly the S3 client to use the [copy_object](https://docs.aws.amazon.com/boto3/latest/reference/services/s3/client/copy_object.html) to not transfer the file but to make the operation directly on the bucket.

Doing this, the copy on the bucket is not mirrored on the mirror bucket if this feature is enabled.

This PR add 2 commits, one for the rename function and another for the duplicate function


## Proposal

- [x] ✨(backend) mirror a file once renamed
- [x] ✨(backend) mirror a file when duplicated
