### PR TITLE
Fix/600 improve process item deletion error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to
 
 - 🐛(backend) accept CDFV2 mimetype from newer libmagic
 - 🐛(backend) better transaction management on duplicate action
+- 🐛(backend) clean storage files in clean_pending_items
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@ and this project adheres to
 
 - 🐛(backend) accept CDFV2 mimetype from newer libmagic
 - 🐛(backend) better transaction management on duplicate action
+- 🐛(backend) clean storage files in clean_pending_items
 
 ### Removed
 

--- a/src/backend/core/management/commands/clean_pending_items.py
+++ b/src/backend/core/management/commands/clean_pending_items.py
@@ -6,6 +6,7 @@ from django.core.management.base import BaseCommand
 from django.utils import timezone
 
 from core.models import Item, ItemUploadStateChoices
+from core.tasks.item import process_item_purge
 
 
 class Command(BaseCommand):
@@ -33,7 +34,8 @@ class Command(BaseCommand):
         count = 0
         for item in items.iterator():
             item.soft_delete()
-            item.delete()
+            item.hard_delete()
+            process_item_purge.delay(item.id)
             count += 1
 
         self.stdout.write(f"Cleaned {count} stale pending item(s).")

--- a/src/backend/core/tests/commands/test_clean_pending_items.py
+++ b/src/backend/core/tests/commands/test_clean_pending_items.py
@@ -1,7 +1,9 @@
 """Tests for the clean_pending_items management command."""
 
 from datetime import timedelta
+from io import BytesIO
 
+from django.core.files.storage import default_storage
 from django.core.management import call_command
 from django.utils import timezone
 
@@ -80,3 +82,20 @@ def test_clean_pending_items_custom_hours():
     call_command("clean_pending_items", "--hours=8")
 
     assert not models.Item.objects.filter(pk=item.pk).exists()
+
+
+def test_clean_pending_items_removes_orphan_file_from_storage():
+    """Stale pending items must also have their storage file removed."""
+    old_date = timezone.now() - timedelta(hours=49)
+    item = factories.ItemFactory(
+        type=models.ItemTypeChoices.FILE,
+        filename="pending.txt",
+        update_upload_state=models.ItemUploadStateChoices.PENDING,
+    )
+    models.Item.objects.filter(pk=item.pk).update(created_at=old_date)
+    default_storage.save(item.file_key, BytesIO(b"orphan data"))
+
+    call_command("clean_pending_items")
+
+    assert not models.Item.objects.filter(pk=item.pk).exists()
+    assert not default_storage.exists(item.file_key)


### PR DESCRIPTION
## Purpose

  Stale pending items cleaned up by clean_pending_items were removed from the database but their files were left behind on the object storage, leading to orphan files accumulating    
  over time.                                                                                                                                                                           
                                                                                                                                                                                       
  Closes #600                                                                                                                                                                          
                                                                   
##  Proposal                                                                                                                                                                             

Soft-delete then hard-delete pending items, then schedule process_item_purge to clean both the storage file and the database record                                                
