### PR TITLE
🐛(backend) sanitize slash in template-created filenames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to
 ### Changed
 
 - 🐛(backend) replace VersionId by Etag for WOPI
+- 🐛(backend) sanitize slash in template-created filenames
 
 ### Removed
 

--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -659,7 +659,9 @@ class CreateItemSerializer(ItemSerializer):
                     raise serializers.ValidationError(
                         {"title": _("This field is required.")},
                     )
-                attrs["filename"] = f"{attrs['title']}.{extension}"
+                attrs["filename"] = utils.format_template_filename(
+                    attrs["title"], extension
+                )
             else:
                 # Regular file upload
                 if attrs.get("filename") is None:

--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -659,7 +659,7 @@ class CreateItemSerializer(ItemSerializer):
                     raise serializers.ValidationError(
                         {"title": _("This field is required.")},
                     )
-                attrs["filename"] = f"{attrs['title']}.{extension}"
+                attrs["filename"] = utils.format_template_filename(attrs["title"], extension)
             else:
                 # Regular file upload
                 if attrs.get("filename") is None:

--- a/src/backend/core/api/utils.py
+++ b/src/backend/core/api/utils.py
@@ -225,6 +225,11 @@ def detect_mimetype(file_buffer: bytes, filename: str | None = None) -> str:
     return mimetype_from_content or "application/octet-stream"
 
 
+def format_template_filename(title, extension):
+    """Build a filename from a template title and extension, replacing '/' with '-'."""
+    return f"{title}.{extension}".replace("/", "-")
+
+
 def sanitize_filename(filename):
     """
     Sanitize a filename to be compliant to use on filesystem.

--- a/src/backend/core/tests/items/test_api_items_children_from_template.py
+++ b/src/backend/core/tests/items/test_api_items_children_from_template.py
@@ -352,3 +352,32 @@ def test_api_items_children_from_template_correct_mimetype(extension, expected_m
 
     child = Item.objects.get(id=response.json()["id"])
     assert child.mimetype == expected_mimetype
+
+
+def test_api_items_children_from_template_title_with_slash_is_sanitized():
+    """
+    Creating a file from template with a slash in the title should
+    produce a sanitized filename (no slash in the stored filename).
+    """
+    user = factories.UserFactory()
+
+    client = APIClient()
+    client.force_login(user)
+
+    access = factories.UserItemAccessFactory(
+        user=user, role="owner", item__type=ItemTypeChoices.FOLDER
+    )
+
+    response = client.post(
+        f"/api/v1.0/items/{access.item.id!s}/children/",
+        {
+            "title": "30/03/30 - liste à faire",
+            "extension": "odt",
+            "type": "file",
+        },
+    )
+
+    assert response.status_code == 201
+
+    child = Item.objects.get(id=response.json()["id"])
+    assert child.filename == "30-03-30 - liste à faire.odt"

--- a/src/backend/core/tests/test_api_utils_format_template_filename.py
+++ b/src/backend/core/tests/test_api_utils_format_template_filename.py
@@ -1,0 +1,20 @@
+"""Test for the format_template_filename function in the api utils module."""
+
+import pytest
+
+from core.api.utils import format_template_filename
+
+
+@pytest.mark.parametrize(
+    "title,extension,expected",
+    [
+        ("my document", "odt", "my document.odt"),
+        ("30/03/30 - liste à faire", "odt", "30-03-30 - liste à faire.odt"),
+        ("budget/2026", "ods", "budget-2026.ods"),
+        ("a/b/c/d", "odp", "a-b-c-d.odp"),
+        ("/leading slash", "odt", "-leading slash.odt"),
+        ("trailing slash/", "odt", "trailing slash-.odt"),
+    ],
+)
+def test_api_utils_format_template_filename(title, extension, expected):
+    assert format_template_filename(title, extension) == expected

--- a/src/backend/core/tests/test_api_utils_format_template_filename.py
+++ b/src/backend/core/tests/test_api_utils_format_template_filename.py
@@ -1,0 +1,23 @@
+"""Test for the format_template_filename function in the api utils module."""
+
+import pytest
+
+from core.api.utils import format_template_filename
+
+
+@pytest.mark.parametrize(
+    "title,extension,expected",
+    [
+        ("my document", "odt", "my document.odt"),
+        ("30/03/30 - liste à faire", "odt", "30-03-30 - liste à faire.odt"),
+        ("budget/2026", "ods", "budget-2026.ods"),
+        ("a/b/c/d", "odp", "a-b-c-d.odp"),
+        ("/leading slash", "odt", "-leading slash.odt"),
+        ("trailing slash/", "odt", "trailing slash-.odt"),
+        ("../../etc/passwd", "odt", "..-..-etc-passwd.odt"),
+        ("notes..brouillon", "odt", "notes..brouillon.odt"),
+    ],
+)
+def test_api_utils_format_template_filename(title, extension, expected):
+    """Slashes in the title are replaced with dashes in the resulting filename."""
+    assert format_template_filename(title, extension) == expected


### PR DESCRIPTION
## Purpose

Titles containing '/' (e.g. "30/03/30 - liste à faire") produced a file_key with spurious path separators, crashing WOPI on open.

  Closes #626

## Proposal

Extract `format_template_filename()` to replace '/' with '-' when building the filename from a template title.

##  Alternatives considered                                                                                                                                                              

   ### Applying sanitize_filename() to template filenames

This existing function converts to ASCII, replaces spaces with underscores, and strips special characters. It would fix the /  issue but also mangle titles like "café résumé" into "cafe_resume", which diverges from what the user typed. Since the frontend displays title (not filename), the name would look fine in Drive but appear mangled in Collabora's editor (BaseFileName).                                                                                                               
                                                                                         
###  Aligning all filename paths to only replace / 
I explored replacing sanitize_filename() with the minimal `/ -> -` replacement in the rename task and update validation as well (not just template creation). This would make filenames consistent across all paths (template, rename, WOPI) and preserve unicode/accents everywhere. I decided against it for now as it  changes behavior on existing rename and update paths, and S3 keys would start containing characters they didn't before. The current fix is scoped to the template creation path where the bug occurs.



