### PR TITLE
✨(frontend) add v0.16.0 release note

### DIFF
--- a/src/frontend/apps/drive/src/features/i18n/translations.json
+++ b/src/frontend/apps/drive/src/features/i18n/translations.json
@@ -529,6 +529,27 @@
           "app_name": "Updates to Drive",
           "see_whats_new": "See what's new"
         },
+        "v0_16_0": {
+          "main_title": "What's new",
+          "steps": {
+            "0": {
+              "title": "Customizable columns",
+              "description": "Choose which information to display in your columns: last modified, creation date, author, file type, or size."
+            },
+            "1": {
+              "title": "Sort by column",
+              "description": "Sort your documents by creation date, size, type... Just click the sort button."
+            },
+            "2": {
+              "title": "Duplication",
+              "description": "Duplicate any document in one click."
+            },
+            "3": {
+              "title": "PDF viewer",
+              "description": "Open your PDFs right in Fichiers, with a new built-in viewer."
+            }
+          }
+        },
         "v0_13_0": {
           "main_title": "Advanced sharing",
           "steps": {
@@ -1089,6 +1110,27 @@
           "app_name": "Mise à jour de Fichiers",
           "see_whats_new": "Voir les nouveautés"
         },
+        "v0_16_0": {
+          "main_title": "Nouveautés",
+          "steps": {
+            "0": {
+              "title": "Colonnes personnalisables",
+              "description": "Choisissez les informations affichées dans vos colonnes : date de modification, date de création, auteur, type de fichier ou taille."
+            },
+            "1": {
+              "title": "Tri par colonne",
+              "description": "Triez vos documents par date de création, taille, type… Un clic sur le bouton de tri suffit."
+            },
+            "2": {
+              "title": "Duplication",
+              "description": "Dupliquez n'importe quel document en un clic."
+            },
+            "3": {
+              "title": "Lecteur PDF",
+              "description": "Ouvrez vos PDF directement dans Fichiers, grâce à un nouveau lecteur intégré."
+            }
+          }
+        },
         "v0_13_0": {
           "main_title": "Partages avancés",
           "steps": {
@@ -1638,6 +1680,27 @@
         "labels": {
           "app_name": "Wat is er nieuw",
           "see_whats_new": "Zie wat er nieuw is"
+        },
+        "v0_16_0": {
+          "main_title": "Wat is er nieuw",
+          "steps": {
+            "0": {
+              "title": "Aanpasbare kolommen",
+              "description": "Kies welke informatie in uw kolommen wordt weergegeven: laatst gewijzigd, aanmaakdatum, auteur, bestandstype of grootte."
+            },
+            "1": {
+              "title": "Sorteren op kolom",
+              "description": "Sorteer uw documenten op aanmaakdatum, grootte, type... Klik gewoon op de sorteerknop."
+            },
+            "2": {
+              "title": "Duplicatie",
+              "description": "Dupliceer elk document met één klik."
+            },
+            "3": {
+              "title": "PDF-lezer",
+              "description": "Open uw PDF's rechtstreeks in Fichiers, met een nieuwe ingebouwde lezer."
+            }
+          }
         },
         "v0_13_0": {
           "main_title": "Wat is er nieuw",

--- a/src/frontend/apps/drive/src/features/ui/components/release-note/releaseNotes.config.ts
+++ b/src/frontend/apps/drive/src/features/ui/components/release-note/releaseNotes.config.ts
@@ -3,8 +3,8 @@ import { ReleaseNoteStep } from "@gouvfr-lasuite/ui-kit";
 import { ALL_VERSIONS } from "./versions";
 
 export interface ReleaseNoteStepConfig {
-  icon: ReleaseNoteStep["icon"];
-  activeIcon: ReleaseNoteStep["activeIcon"];
+  icon?: ReleaseNoteStep["icon"];
+  activeIcon?: ReleaseNoteStep["activeIcon"];
   titleKey: string;
   descriptionKey: string;
 }

--- a/src/frontend/apps/drive/src/features/ui/components/release-note/versions/index.ts
+++ b/src/frontend/apps/drive/src/features/ui/components/release-note/versions/index.ts
@@ -1,9 +1,10 @@
 import { ReleaseNoteConfig } from "../releaseNotes.config";
 import { v0_13_0 } from "./v0.13.0";
+import { v0_16_0 } from "./v0.16.0";
 
 /**
  * All release notes configurations.
  * IMPORTANT: Keep entries ordered from most recent (first) to oldest (last).
  * The first entry is automatically used as the current version.
  */
-export const ALL_VERSIONS: ReleaseNoteConfig[] = [v0_13_0];
+export const ALL_VERSIONS: ReleaseNoteConfig[] = [v0_16_0, v0_13_0];

--- a/src/frontend/apps/drive/src/features/ui/components/release-note/versions/v0.16.0/index.tsx
+++ b/src/frontend/apps/drive/src/features/ui/components/release-note/versions/v0.16.0/index.tsx
@@ -1,0 +1,25 @@
+import { ReleaseNoteConfig } from "../../releaseNotes.config";
+
+export const v0_16_0: ReleaseNoteConfig = {
+  version: "0.16.0",
+  mainTitleKey: "release_notes.v0_16_0.main_title",
+  createdAt: "2026-04-09",
+  steps: [
+    {
+      titleKey: "release_notes.v0_16_0.steps.0.title",
+      descriptionKey: "release_notes.v0_16_0.steps.0.description",
+    },
+    {
+      titleKey: "release_notes.v0_16_0.steps.1.title",
+      descriptionKey: "release_notes.v0_16_0.steps.1.description",
+    },
+    {
+      titleKey: "release_notes.v0_16_0.steps.2.title",
+      descriptionKey: "release_notes.v0_16_0.steps.2.description",
+    },
+    {
+      titleKey: "release_notes.v0_16_0.steps.3.title",
+      descriptionKey: "release_notes.v0_16_0.steps.3.description",
+    },
+  ],
+};

--- a/src/frontend/apps/e2e/__tests__/app-drive/release-note.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-drive/release-note.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 import { login } from "./utils-common";
 
-const CURRENT_VERSION = "0.13.0";
+const CURRENT_VERSION = "0.16.0";
 
 test.describe("Release Note", () => {
   test.beforeEach(async ({ page }) => {


### PR DESCRIPTION
## Summary
- Add the v0.16.0 release note (customizable columns, column sorting, duplication, PDF viewer) with en/fr/nl translations.
- Make release note step icons optional so versions can opt out of providing icons.