### PR TITLE
✨(frontend) preserve empty folders on drag & drop upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to
 - ⚡(ci) shard e2e tests and cache playwright browsers
 - ⬆️(frontend) upgrade cunningham-react and ui-kit to 0.20.0
 - ✨(frontend) improve custom columns with sortable config and i18n
+- ✨(frontend) preserve empty folders when uploading via drag & drop
 
 ### Changed
 

--- a/src/frontend/apps/drive/src/features/explorer/hooks/useUpload.tsx
+++ b/src/frontend/apps/drive/src/features/explorer/hooks/useUpload.tsx
@@ -18,6 +18,11 @@ import { useConfig } from "@/features/config/ConfigProvider";
 import { getDriver } from "@/features/config/Config";
 import { APIError } from "@/features/api/APIError";
 import { useRefreshQueryCacheAfterMutation } from "./useRefreshItems";
+import { formatSize } from "@/features/explorer/utils/utils";
+import {
+  customGetFilesFromEvent,
+  isEmptyFolderMarker,
+} from "@/features/explorer/utils/dropTraversal";
 
 type FileUpload = FileWithPath & {
   parentId?: string;
@@ -111,6 +116,12 @@ const useUpload = ({ item }: { item: Item }) => {
 
     for (const file of files) {
       const folder = getFolderByPath(file.path!);
+      // Empty-folder markers exist solely to materialize the folder chain
+      // via getFolderByPath above. They must never end up in folder.files,
+      // otherwise the upload loop would try to send them to the backend.
+      if (isEmptyFolderMarker(file)) {
+        continue;
+      }
       folder.files.push(file);
     }
     return {
@@ -239,23 +250,6 @@ export const useUploadZone = ({ item }: { item: Item }) => {
 
   const { filesToUpload, handleHierarchy } = useUpload({ item: item! });
 
-  const showUploadToast = () => {
-    if (fileUploadsToastId.current) return;
-    fileUploadsToastId.current = addToast(
-      <FileUploadToast
-        uploadingState={uploadingState}
-        onCancelFile={onCancelFile}
-        onCancelAll={onCancelAll}
-      />,
-      {
-        autoClose: false,
-        onClose: () => {
-          fileUploadsToastId.current = null;
-        },
-      },
-    );
-  };
-
   const onCancelFile = useCallback(async (fileName: string) => {
     const abortFn = abortFunctionsRef.current.get(fileName);
     if (abortFn) {
@@ -322,6 +316,10 @@ export const useUploadZone = ({ item }: { item: Item }) => {
     noClick: true,
     useFsAccessApi: false,
     validator: validateDrop,
+    // Custom traversal that preserves empty folders on drag & drop.
+    // Input change events (folder/file buttons) are delegated to
+    // file-selector inside this helper.
+    getFilesFromEvent: customGetFilesFromEvent,
     // If we do not set this, the click on the "..." menu of each items does not work, also click + select on items
     // does not work too. It might seems related to onFocus and onBlur events.
     noKeyboard: true,
@@ -371,12 +369,38 @@ export const useUploadZone = ({ item }: { item: Item }) => {
         return;
       }
 
+      // When the drop contains only empty-folder markers, there are no
+      // real files to upload. In that case we skip the FileUploadToast
+      // entirely and show a success toast once the folders have been created.
+      const hasOnlyEmptyFolders =
+        acceptedFiles.length > 0 &&
+        acceptedFiles.every((file) => isEmptyFolderMarker(file));
+
+      const showFileUploadToast = () => {
+        if (hasOnlyEmptyFolders || fileUploadsToastId.current) {
+          return;
+        }
+        fileUploadsToastId.current = addToast(
+          <FileUploadToast
+            uploadingState={uploadingState}
+            onCancelFile={onCancelFile}
+            onCancelAll={onCancelAll}
+          />,
+          {
+            autoClose: false,
+            onClose: () => {
+              fileUploadsToastId.current = null;
+            },
+          },
+        );
+      };
+
       setUploadingState((prev) => ({
         ...prev,
         step: UploadingStep.PREPARING,
       }));
 
-      showUploadToast();
+      showFileUploadToast();
 
       const entitlements = await getEntitlements();
       if (!entitlements.can_upload.result) {
@@ -401,23 +425,60 @@ export const useUploadZone = ({ item }: { item: Item }) => {
         step: UploadingStep.CREATE_FOLDERS,
       }));
 
-      showUploadToast();
+      showFileUploadToast();
       dismissDragToast();
 
       const upload = filesToUpload(acceptedFiles);
       await handleHierarchy(upload);
 
+      if (hasOnlyEmptyFolders) {
+        setUploadingState((prev) => ({
+          ...prev,
+          step: UploadingStep.DONE,
+        }));
+        addToast(
+          <ToasterItem type="info">
+            <span>{t("explorer.actions.upload.folders_created")}</span>
+          </ToasterItem>,
+        );
+        return;
+      }
+
+      // Strip empty-folder markers before any size/upload processing:
+      // they are zero-byte sentinels whose only purpose was to make
+      // filesToUpload create the corresponding FolderUpload nodes.
+      const realFiles = upload.files.filter(
+        (file) => !isEmptyFolderMarker(file),
+      );
+
       // Filter out files that exceed the maximum upload size.
       const maxSize = config.DATA_UPLOAD_MAX_MEMORY_SIZE;
-      const isMaxSize = maxSize !== undefined && maxSize !== null;
-      const validFiles = isMaxSize
-        ? upload.files.filter((file) => file.size <= maxSize)
-        : upload.files;
-      const tooLargeFiles = isMaxSize
-        ? upload.files.filter((file) => file.size > maxSize)
-        : [];
+      const validFiles =
+        maxSize !== undefined && maxSize !== null
+          ? realFiles.filter((file) => file.size <= maxSize)
+          : realFiles;
+      const tooLargeFiles =
+        maxSize !== undefined && maxSize !== null
+          ? realFiles.filter((file) => file.size > maxSize)
+          : [];
+      if (maxSize !== undefined && maxSize !== null) {
+        for (const file of tooLargeFiles) {
+          addToast(
+            <ToasterItem type="error">
+              <span>
+                {t("explorer.actions.upload.file_too_large", {
+                  name: file.name,
+                  maxSize: formatSize(maxSize, t),
+                })}
+              </span>
+            </ToasterItem>,
+          );
+        }
+      }
 
-      // Merge new files into the uploading state (instead of overwriting)
+      // Do not run "setUploadingState({});" because if a uploading is still in progress, it will be overwritten.
+
+      // First, add all the files to the uploading state in order to display them in the toast.
       const newFilesMeta: Record<string, FileUploadMeta> = {};
       for (const file of validFiles) {
         newFilesMeta[pathNicefy(file.path!)] = {

--- a/src/frontend/apps/drive/src/features/explorer/utils/__tests__/dropTraversal.test.ts
+++ b/src/frontend/apps/drive/src/features/explorer/utils/__tests__/dropTraversal.test.ts
@@ -1,0 +1,302 @@
+import {
+  createEmptyFolderMarker,
+  EMPTY_FOLDER_MARKER_NAME,
+  getFileFromEntry,
+  isEmptyFolderMarker,
+  readAllEntries,
+  traverseEntry,
+} from "../dropTraversal";
+
+// ---------------------------------------------------------------------------
+// Fake FileSystemEntry helpers (no DataTransfer / no DragEvent involved)
+// ---------------------------------------------------------------------------
+
+const makeFileEntry = (
+  fullPath: string,
+  content = "",
+): FileSystemFileEntry => {
+  const name = fullPath.split("/").pop() ?? "";
+  const file = new File([content], name, { type: "text/plain" });
+  return {
+    isFile: true,
+    isDirectory: false,
+    name,
+    fullPath,
+    file: (success: FileCallback) => success(file),
+  } as unknown as FileSystemFileEntry;
+};
+
+const makeFailingFileEntry = (
+  fullPath: string,
+  error: unknown,
+): FileSystemFileEntry => {
+  const name = fullPath.split("/").pop() ?? "";
+  return {
+    isFile: true,
+    isDirectory: false,
+    name,
+    fullPath,
+    file: (_success: FileCallback, errorCb?: ErrorCallback) => {
+      errorCb?.(error as DOMException);
+    },
+  } as unknown as FileSystemFileEntry;
+};
+
+/** Single-batch directory: readEntries returns children, then []. */
+const makeDirEntry = (
+  fullPath: string,
+  children: FileSystemEntry[],
+): FileSystemDirectoryEntry => {
+  const name = fullPath.split("/").pop() ?? "";
+  return {
+    isFile: false,
+    isDirectory: true,
+    name,
+    fullPath,
+    createReader: () => makeReader([children, []]),
+  } as unknown as FileSystemDirectoryEntry;
+};
+
+/** Build a reader that yields one batch per call until exhausted. */
+const makeReader = (
+  batches: FileSystemEntry[][],
+): FileSystemDirectoryReader => {
+  const queue = [...batches];
+  return {
+    readEntries: (success: FileSystemEntriesCallback) => {
+      success(queue.shift() ?? []);
+    },
+  } as FileSystemDirectoryReader;
+};
+
+const makeFailingReader = (error: unknown): FileSystemDirectoryReader => {
+  return {
+    readEntries: (
+      _success: FileSystemEntriesCallback,
+      errorCb?: ErrorCallback,
+    ) => {
+      errorCb?.(error as DOMException);
+    },
+  } as FileSystemDirectoryReader;
+};
+
+// ===========================================================================
+// createEmptyFolderMarker
+// ===========================================================================
+
+describe("createEmptyFolderMarker", () => {
+  it("creates a zero-byte File", () => {
+    const marker = createEmptyFolderMarker("/foo");
+    expect(marker).toBeInstanceOf(File);
+    expect(marker.size).toBe(0);
+  });
+
+  it("uses the standard marker name", () => {
+    const marker = createEmptyFolderMarker("/foo");
+    expect(marker.name).toBe(EMPTY_FOLDER_MARKER_NAME);
+  });
+
+  it("attaches a path of the form `<dirPath>/.empty-folder`", () => {
+    const marker = createEmptyFolderMarker("/foo/bar");
+    expect((marker as unknown as { path: string }).path).toBe(
+      `/foo/bar/${EMPTY_FOLDER_MARKER_NAME}`,
+    );
+  });
+
+  it("flags the marker with `isEmptyFolder: true`", () => {
+    const marker = createEmptyFolderMarker("/foo");
+    expect(
+      (marker as unknown as { isEmptyFolder: boolean }).isEmptyFolder,
+    ).toBe(true);
+  });
+});
+
+// ===========================================================================
+// isEmptyFolderMarker
+// ===========================================================================
+
+describe("isEmptyFolderMarker", () => {
+  it("returns true for a marker created by createEmptyFolderMarker", () => {
+    const marker = createEmptyFolderMarker("/foo");
+    expect(isEmptyFolderMarker(marker)).toBe(true);
+  });
+
+  it("returns false for a regular File", () => {
+    expect(isEmptyFolderMarker(new File(["hello"], "foo.txt"))).toBe(false);
+  });
+
+  it("returns false for a File whose name happens to be `.empty-folder`", () => {
+    // The check must rely on the flag, NOT on the file name.
+    expect(isEmptyFolderMarker(new File([], EMPTY_FOLDER_MARKER_NAME))).toBe(
+      false,
+    );
+  });
+});
+
+// ===========================================================================
+// getFileFromEntry
+// ===========================================================================
+
+describe("getFileFromEntry", () => {
+  it("resolves with the underlying File", async () => {
+    const entry = makeFileEntry("/foo.txt", "hello");
+    const file = await getFileFromEntry(entry);
+    expect(file).toBeInstanceOf(File);
+    expect(file.name).toBe("foo.txt");
+    expect(file.size).toBe(5);
+  });
+
+  it("attaches the entry's fullPath as `path`", async () => {
+    const entry = makeFileEntry("/dir/sub/foo.txt");
+    const file = await getFileFromEntry(entry);
+    expect((file as unknown as { path: string }).path).toBe("/dir/sub/foo.txt");
+  });
+
+  it("rejects when the underlying file() call fails", async () => {
+    const err = new DOMException("nope", "NotReadableError");
+    const entry = makeFailingFileEntry("/bad.txt", err);
+    await expect(getFileFromEntry(entry)).rejects.toBe(err);
+  });
+});
+
+// ===========================================================================
+// readAllEntries
+// ===========================================================================
+
+describe("readAllEntries", () => {
+  it("returns an empty array when the reader yields no batches", async () => {
+    const reader = makeReader([[]]);
+    expect(await readAllEntries(reader)).toEqual([]);
+  });
+
+  it("returns all entries from a single batch", async () => {
+    const a = makeFileEntry("/a.txt");
+    const b = makeFileEntry("/b.txt");
+    const reader = makeReader([[a, b], []]);
+    const entries = await readAllEntries(reader);
+    expect(entries).toEqual([a, b]);
+  });
+
+  it("concatenates entries across multiple batches (Safari-style)", async () => {
+    const a = makeFileEntry("/a.txt");
+    const b = makeFileEntry("/b.txt");
+    const c = makeFileEntry("/c.txt");
+    const d = makeFileEntry("/d.txt");
+    // The native API forces a loop until an empty batch is returned.
+    const reader = makeReader([[a, b], [c], [d], []]);
+    const entries = await readAllEntries(reader);
+    expect(entries).toEqual([a, b, c, d]);
+  });
+
+  it("calls readEntries until it yields an empty batch (loop terminates)", async () => {
+    const spy = jest.fn();
+    const queue: FileSystemEntry[][] = [
+      [makeFileEntry("/a.txt")],
+      [makeFileEntry("/b.txt")],
+      [],
+    ];
+    const reader = {
+      readEntries: (success: FileSystemEntriesCallback) => {
+        spy();
+        success(queue.shift() ?? []);
+      },
+    } as FileSystemDirectoryReader;
+
+    await readAllEntries(reader);
+    expect(spy).toHaveBeenCalledTimes(3);
+  });
+
+  it("rejects when readEntries calls the error callback", async () => {
+    const err = new DOMException("boom", "NotReadableError");
+    await expect(readAllEntries(makeFailingReader(err))).rejects.toBe(err);
+  });
+});
+
+// ===========================================================================
+// traverseEntry
+// ===========================================================================
+
+describe("traverseEntry", () => {
+  it("returns a single FileWithPath for a file entry", async () => {
+    const entry = makeFileEntry("/foo.txt", "x");
+    const result = await traverseEntry(entry);
+    expect(result).toHaveLength(1);
+    expect((result[0] as unknown as { path: string }).path).toBe("/foo.txt");
+    expect(isEmptyFolderMarker(result[0] as File)).toBe(false);
+  });
+
+  it("returns a single empty-folder marker for an empty directory", async () => {
+    const dir = makeDirEntry("/empty", []);
+    const result = await traverseEntry(dir);
+    expect(result).toHaveLength(1);
+    expect(isEmptyFolderMarker(result[0] as File)).toBe(true);
+    expect((result[0] as unknown as { path: string }).path).toBe(
+      `/empty/${EMPTY_FOLDER_MARKER_NAME}`,
+    );
+  });
+
+  it("flattens a non-empty directory and emits no marker", async () => {
+    const dir = makeDirEntry("/dir", [
+      makeFileEntry("/dir/a.txt"),
+      makeFileEntry("/dir/b.txt"),
+    ]);
+    const result = await traverseEntry(dir);
+    const paths = (result as Array<File & { path: string }>)
+      .map((f) => f.path)
+      .sort();
+    expect(paths).toEqual(["/dir/a.txt", "/dir/b.txt"]);
+    expect(result.some((f) => isEmptyFolderMarker(f as File))).toBe(false);
+  });
+
+  it("recurses into nested directories and emits one marker per empty leaf", async () => {
+    // /root
+    //   /a    (empty)
+    //   /b
+    //     /c  (empty)
+    //     b.txt
+    const a = makeDirEntry("/root/a", []);
+    const c = makeDirEntry("/root/b/c", []);
+    const b = makeDirEntry("/root/b", [c, makeFileEntry("/root/b/b.txt")]);
+    const root = makeDirEntry("/root", [a, b]);
+
+    const result = await traverseEntry(root);
+
+    const realPaths = (result as Array<File & { path: string }>)
+      .filter((f) => !isEmptyFolderMarker(f))
+      .map((f) => f.path)
+      .sort();
+    const markerPaths = (result as Array<File & { path: string }>)
+      .filter((f) => isEmptyFolderMarker(f))
+      .map((f) => f.path)
+      .sort();
+
+    expect(realPaths).toEqual(["/root/b/b.txt"]);
+    expect(markerPaths).toEqual([
+      `/root/a/${EMPTY_FOLDER_MARKER_NAME}`,
+      `/root/b/c/${EMPTY_FOLDER_MARKER_NAME}`,
+    ]);
+  });
+
+  it("returns an empty array for an entry that is neither file nor directory", async () => {
+    const weird = {
+      isFile: false,
+      isDirectory: false,
+      name: "weird",
+      fullPath: "/weird",
+    } as unknown as FileSystemEntry;
+    expect(await traverseEntry(weird)).toEqual([]);
+  });
+
+  it("propagates errors from readAllEntries", async () => {
+    const err = new DOMException("boom", "NotReadableError");
+    const dir = {
+      isFile: false,
+      isDirectory: true,
+      name: "boom",
+      fullPath: "/boom",
+      createReader: () => makeFailingReader(err),
+    } as unknown as FileSystemDirectoryEntry;
+
+    await expect(traverseEntry(dir)).rejects.toBe(err);
+  });
+});

--- a/src/frontend/apps/drive/src/features/explorer/utils/__tests__/dropTraversal.test.ts
+++ b/src/frontend/apps/drive/src/features/explorer/utils/__tests__/dropTraversal.test.ts
@@ -243,7 +243,7 @@ describe("traverseEntry", () => {
     const result = await traverseEntry(dir);
     const paths = (result as Array<File & { path: string }>)
       .map((f) => f.path)
-      .sort();
+      .sort((a, b) => a.localeCompare(b));
     expect(paths).toEqual(["/dir/a.txt", "/dir/b.txt"]);
     expect(result.some((f) => isEmptyFolderMarker(f as File))).toBe(false);
   });
@@ -264,11 +264,11 @@ describe("traverseEntry", () => {
     const realPaths = (result as Array<File & { path: string }>)
       .filter((f) => !isEmptyFolderMarker(f))
       .map((f) => f.path)
-      .sort();
+      .sort((a, b) => a.localeCompare(b));
     const markerPaths = (result as Array<File & { path: string }>)
       .filter((f) => isEmptyFolderMarker(f))
       .map((f) => f.path)
-      .sort();
+      .sort((a, b) => a.localeCompare(b));
 
     expect(realPaths).toEqual(["/root/b/b.txt"]);
     expect(markerPaths).toEqual([

--- a/src/frontend/apps/drive/src/features/explorer/utils/dropTraversal.ts
+++ b/src/frontend/apps/drive/src/features/explorer/utils/dropTraversal.ts
@@ -161,7 +161,7 @@ const isDragEventWithItems = (
  *   to file-selector's `fromEvent`.
  */
 export const customGetFilesFromEvent = async (
-  evt: Event | unknown,
+  evt: unknown,
 ): Promise<(FileWithPath | EmptyFolderMarker | DataTransferItem)[]> => {
   if (!isDragEventWithItems(evt)) {
     return fromEvent(evt as Event);

--- a/src/frontend/apps/drive/src/features/explorer/utils/dropTraversal.ts
+++ b/src/frontend/apps/drive/src/features/explorer/utils/dropTraversal.ts
@@ -1,0 +1,210 @@
+import { fromEvent, FileWithPath } from "file-selector";
+
+/**
+ * Custom drop traversal that preserves empty folders.
+ *
+ * react-dropzone's default getFilesFromEvent (from `file-selector`) walks
+ * dropped directories via webkitGetAsEntry() but silently drops empty
+ * folders: when readEntries() returns an empty batch, no entry is produced
+ * and the folder is lost.
+ *
+ * This module re-implements the drag traversal so that every empty
+ * directory yields a marker File. The marker is a real (zero-byte) File
+ * object — so it travels through the react-dropzone pipeline like any
+ * other file — but it carries an `isEmptyFolder` flag and a path that
+ * useUpload uses to materialize the folder hierarchy without ever
+ * uploading the marker to the backend.
+ *
+ * Input change events (the "Import folder/files" buttons) are delegated
+ * to file-selector's default behavior. The browser does not expose empty
+ * folders through <input webkitdirectory>, so this is an accepted
+ * limitation matching Google Drive / Proton Drive.
+ */
+
+export const EMPTY_FOLDER_MARKER_NAME = ".empty-folder";
+
+const EMPTY_FOLDER_MARKER_TYPE = "application/x-empty-folder-marker";
+
+export type EmptyFolderMarker = FileWithPath & { isEmptyFolder: true };
+
+/**
+ * Creates a zero-byte File object that marks the existence of an empty
+ * directory at `dirPath`. The marker's path is `<dirPath>/.empty-folder`
+ * so that useUpload's getFolderByPath splits it into the directory chain
+ * and ignores the trailing marker name.
+ *
+ * @internal exported for unit tests
+ */
+export const createEmptyFolderMarker = (
+  dirPath: string,
+): EmptyFolderMarker => {
+  const marker = new File([], EMPTY_FOLDER_MARKER_NAME, {
+    type: EMPTY_FOLDER_MARKER_TYPE,
+  }) as EmptyFolderMarker;
+  Object.defineProperty(marker, "path", {
+    value: `${dirPath}/${EMPTY_FOLDER_MARKER_NAME}`,
+    writable: false,
+    enumerable: true,
+    configurable: true,
+  });
+  Object.defineProperty(marker, "isEmptyFolder", {
+    value: true,
+    writable: false,
+    enumerable: true,
+    configurable: true,
+  });
+  return marker;
+};
+
+/** Tells whether a File is an empty folder marker created by this module. */
+export const isEmptyFolderMarker = (file: File): boolean => {
+  return (file as EmptyFolderMarker).isEmptyFolder === true;
+};
+
+/**
+ * Reads ALL entries from a FileSystemDirectoryReader. The native
+ * readEntries() returns batches (~100 entries) and must be called in a
+ * loop until it yields an empty batch. Older Safari versions had a bug
+ * where they only returned the first batch — looping is required for
+ * correctness.
+ *
+ * @internal exported for unit tests
+ */
+export const readAllEntries = (
+  reader: FileSystemDirectoryReader,
+): Promise<FileSystemEntry[]> => {
+  return new Promise((resolve, reject) => {
+    const all: FileSystemEntry[] = [];
+    const readBatch = () => {
+      reader.readEntries(
+        (batch) => {
+          if (batch.length === 0) {
+            resolve(all);
+            return;
+          }
+          all.push(...batch);
+          readBatch();
+        },
+        (err) => reject(err),
+      );
+    };
+    readBatch();
+  });
+};
+
+/** @internal exported for unit tests */
+export const getFileFromEntry = (
+  entry: FileSystemFileEntry,
+): Promise<FileWithPath> => {
+  return new Promise((resolve, reject) => {
+    entry.file(
+      (file) => {
+        const fwp = file as FileWithPath;
+        Object.defineProperty(fwp, "path", {
+          value: entry.fullPath,
+          writable: false,
+          enumerable: true,
+          configurable: true,
+        });
+        resolve(fwp);
+      },
+      (err) => reject(err),
+    );
+  });
+};
+
+/**
+ * Recursively walks a FileSystemEntry. Files are returned as FileWithPath,
+ * non-empty directories yield their flattened contents, and empty
+ * directories yield a single empty-folder marker.
+ *
+ * @internal exported for unit tests
+ */
+export const traverseEntry = async (
+  entry: FileSystemEntry,
+): Promise<(FileWithPath | EmptyFolderMarker)[]> => {
+  if (entry.isFile) {
+    const file = await getFileFromEntry(entry as FileSystemFileEntry);
+    return [file];
+  }
+
+  if (entry.isDirectory) {
+    const dirEntry = entry as FileSystemDirectoryEntry;
+    const children = await readAllEntries(dirEntry.createReader());
+
+    if (children.length === 0) {
+      return [createEmptyFolderMarker(dirEntry.fullPath)];
+    }
+
+    const nested = await Promise.all(children.map(traverseEntry));
+    return nested.flat();
+  }
+
+  return [];
+};
+
+const isDragEventWithItems = (
+  evt: unknown,
+): evt is { dataTransfer: DataTransfer } => {
+  if (typeof evt !== "object" || evt === null) return false;
+  const dt = (evt as { dataTransfer?: DataTransfer }).dataTransfer;
+  return !!dt && !!dt.items;
+};
+
+/**
+ * Drop-in replacement for react-dropzone's `getFilesFromEvent`.
+ *
+ * - DragEvent with dataTransfer.items: walks the entry tree ourselves
+ *   so empty folders surface as markers. Falls back to file-selector's
+ *   default if webkitGetAsEntry is unavailable on the items.
+ * - Anything else (input change, FileSystemHandle array, etc.): delegated
+ *   to file-selector's `fromEvent`.
+ */
+export const customGetFilesFromEvent = async (
+  evt: Event | unknown,
+): Promise<(FileWithPath | EmptyFolderMarker | DataTransferItem)[]> => {
+  if (!isDragEventWithItems(evt)) {
+    return fromEvent(evt as Event);
+  }
+
+  const dt = evt.dataTransfer;
+  const items = Array.from(dt.items).filter((item) => item.kind === "file");
+
+  // Mirror file-selector: on non-drop events (dragenter/dragover) the
+  // browser restricts access to item contents, so there is no point in
+  // walking the entry tree. Return the raw DataTransferItem[]
+  // synchronously — this is exactly what react-dropzone expects on those
+  // events, and any deviation breaks its event hand-shake (including the
+  // onDragEnter toast). The async webkitGetAsEntry() walk only runs on
+  // the real 'drop' event.
+  const evtType = (evt as unknown as { type?: string }).type;
+  if (evtType !== "drop") {
+    return items;
+  }
+
+  // If webkitGetAsEntry isn't available on the items, fall back to the
+  // default behavior so we don't break drag & drop in unsupported
+  // contexts.
+  const supportsEntries = items.every(
+    (item) => typeof item.webkitGetAsEntry === "function",
+  );
+  if (!supportsEntries) {
+    return fromEvent(evt as unknown as Event);
+  }
+
+  // Snapshot every entry SYNCHRONOUSLY before any await. On a real
+  // 'drop' event the DataTransferItem objects become inert after the
+  // first microtask tick, so calling webkitGetAsEntry() on later items
+  // after an await returns null — which silently drops every item past
+  // the first. We therefore pull all entries up front, then walk them
+  // asynchronously with Promise.all (mirroring what file-selector does
+  // via `items.map(toFilePromises)`).
+  const entries: FileSystemEntry[] = [];
+  for (const item of items) {
+    const entry = item.webkitGetAsEntry();
+    if (entry) entries.push(entry);
+  }
+
+  const walked = await Promise.all(entries.map(traverseEntry));
+  return walked.flat();
+};

--- a/src/frontend/apps/drive/src/features/i18n/translations.json
+++ b/src/frontend/apps/drive/src/features/i18n/translations.json
@@ -438,6 +438,7 @@
             "toast": "Drop your files here to transfer them in {{title}}",
             "toast_no_rights": "You don't have the necessary rights to transfer files in {{title}}",
             "file_too_large": "The file \"{{name}}\" is too large. Maximum allowed size is {{maxSize}}.",
+            "folders_created": "All folders have been created successfully.",
             "steps": {
               "preparing": "Preparing the transfer...",
               "create_folders": "Creation of folders in progress..."
@@ -1032,6 +1033,7 @@
             "toast": "Déposez vos fichiers ici pour les transférer dans {{title}}",
             "toast_no_rights": "Vous n'avez pas les droits nécessaires pour transférer des fichiers dans {{title}}",
             "file_too_large": "Le fichier \"{{name}}\" est trop volumineux. La taille maximale autorisée est {{maxSize}}.",
+            "folders_created": "Tous les dossiers ont été créés avec succès.",
             "steps": {
               "preparing": "Préparation du transfert...",
               "create_folders": "Création des dossiers en cours..."
@@ -1628,6 +1630,7 @@
             "toast": "Zet uw bestanden hier neer om ze over te zetten in {{title}}",
             "toast_no_rights": "U beschikt niet over de benodigde rechten om bestanden over te dragen in {{title}}",
             "file_too_large": "Het bestand \"{{name}}\" is te groot. De maximale toegestane grootte is {{maxSize}}.",
+            "folders_created": "Alle mappen zijn succesvol aangemaakt.",
             "steps": {
               "preparing": "Voorbereiding van de overdracht...",
               "create_folders": "Creatie van mappen in progress..."


### PR DESCRIPTION
## Summary

- Add a custom `getFilesFromEvent` for react-dropzone that walks the
  drop tree ourselves and emits a zero-byte marker file for every
  empty folder, so empty directories dropped into the explorer are
  now created instead of being silently dropped.
- Update `useUpload` to materialize the folder chain from markers via
  `getFolderByPath`, then filter them out before any size validation
  or backend upload. When a drop contains only markers, the file
  upload toast is suppressed and a dedicated success toast is shown
  once the folders have been created.
- Add unit tests covering marker creation, the batched
  `readEntries()` loop, recursive entry walking, and the
  `customGetFilesFromEvent` entry point.

Input change events (folder/file buttons) remain delegated to
`file-selector`: the browser does not expose empty folders through
`<input webkitdirectory>`, matching the Google Drive / Proton Drive
limitation.

## Test plan

- [ ] Drop an empty folder into the explorer and confirm it is
      created with the success toast.
- [ ] Drop a folder tree mixing empty and non-empty subfolders and
      confirm both the files and the empty folders land correctly.
- [ ] Drop a single file and confirm the regular upload toast still
      shows progress.
- [ ] Use the "Import folder" button with a non-empty folder and
      confirm the existing behavior is unchanged.
- [ ] Run the new unit tests in
      `dropTraversal.test.ts`.