### PR TITLE
🐛(frontend) Cancel active uploads when parent folder is deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to
 - 🐛(frontend) show actual selection count in hard delete modal
 - 🐛(frontend) Responsive broken with long filters in search #659
 - 🐛(front) set size and variant on trash navigate modal #666
+- 🐛(frontend) fix uploads continuing after parent folder deletion
 
 ## [v0.16.0] - 2026-04-09
 

--- a/src/frontend/apps/drive/src/features/explorer/components/GlobalExplorerContext.tsx
+++ b/src/frontend/apps/drive/src/features/explorer/components/GlobalExplorerContext.tsx
@@ -58,6 +58,7 @@ export interface GlobalExplorerContextType {
   setPreviewItem: (item: Item | undefined) => void;
   setPreviewItems: (items: Item[]) => void;
   isMinimalLayout?: boolean;
+  cancelUploadsForDeletedItems: (deletedIds: string[]) => void;
   refreshMobileNodes: () => void;
   mobileNodesRefreshTrigger: number;
 }
@@ -191,7 +192,7 @@ export const GlobalExplorerProvider = ({
     }
   }, [rightPanelOpen]);
 
-  const { dropZone } = useUploadZone({ item: item! });
+  const { dropZone, cancelUploadsForDeletedItems } = useUploadZone({ item: item! });
 
   /**
    * Preview states.
@@ -216,6 +217,7 @@ export const GlobalExplorerProvider = ({
         item,
         onNavigate,
         dropZone,
+        cancelUploadsForDeletedItems,
         rightPanelForcedItem,
         setRightPanelForcedItem,
         rightPanelOpen,

--- a/src/frontend/apps/drive/src/features/explorer/components/app-view/ExplorerSelectionBar.tsx
+++ b/src/frontend/apps/drive/src/features/explorer/components/app-view/ExplorerSelectionBar.tsx
@@ -50,7 +50,7 @@ export const ExplorerSelectionBar = () => {
 
 export const ExplorerSelectionBarActions = () => {
   const { t } = useTranslation();
-  const { selectedItems, setSelectedItems, item } = useGlobalExplorer();
+  const { selectedItems, setSelectedItems, item, cancelUploadsForDeletedItems } = useGlobalExplorer();
   const moveModal = useModal();
 
   const deleteItems = useMutationDeleteItems();
@@ -73,8 +73,10 @@ export const ExplorerSelectionBarActions = () => {
           </span>
         </ToasterItem>
       );
+      const deletedIds = selectedItems.map((item) => item.id);
       setSelectedItems([]);
-      await deleteItems.mutateAsync(selectedItems.map((item) => item.id));
+      await deleteItems.mutateAsync(deletedIds);
+      cancelUploadsForDeletedItems(deletedIds);
     } else {
       addToast(
         <ToasterItem type="error">

--- a/src/frontend/apps/drive/src/features/explorer/hooks/useDeleteItem.tsx
+++ b/src/frontend/apps/drive/src/features/explorer/hooks/useDeleteItem.tsx
@@ -5,15 +5,18 @@ import {
 import { useMutationDeleteItems } from "./useMutations";
 import { useTranslation } from "react-i18next";
 import { useTreeUtils } from "./useTreeUtils";
+import { useGlobalExplorer } from "../components/GlobalExplorerContext";
 
 export const useDeleteItem = () => {
   const { t } = useTranslation();
   const treeUtils = useTreeUtils();
   const deleteItemsMutation = useMutationDeleteItems();
+  const { cancelUploadsForDeletedItems } = useGlobalExplorer();
 
   const deleteItems = async (itemIds: string[]) => {
     try {
       await deleteItemsMutation.mutateAsync(itemIds);
+      cancelUploadsForDeletedItems(itemIds);
       for (const itemId of itemIds) {
         treeUtils.deleteAllByOriginalId(itemId);
       }

--- a/src/frontend/apps/drive/src/features/explorer/hooks/useUpload.tsx
+++ b/src/frontend/apps/drive/src/features/explorer/hooks/useUpload.tsx
@@ -18,6 +18,16 @@ import { useConfig } from "@/features/config/ConfigProvider";
 import { getDriver } from "@/features/config/Config";
 import { APIError } from "@/features/api/APIError";
 import { useRefreshQueryCacheAfterMutation } from "./useRefreshItems";
+import { isIdInItemTree } from "../utils/utils";
+
+type ActiveUpload = {
+  file: FileUpload;
+  // Materialized path of the drop target folder (e.g. "root.A.B").
+  // Used by cancelUploadsForDeletedItems to detect ancestor deletions.
+  parentPath: string;
+  // Populated once the upload actually starts. Undefined while still queued.
+  abort?: () => Promise<void>;
+};
 import { formatSize } from "@/features/explorer/utils/utils";
 import {
   customGetFilesFromEvent,
@@ -239,24 +249,24 @@ export const useUploadZone = ({ item }: { item: Item }) => {
     filesMeta: {},
   });
 
-  // Abort functions keyed by file path
-  const abortFunctionsRef = useRef<Map<string, () => Promise<void>>>(new Map());
-  // Set of cancelled file paths to skip in the sequential loop
-  const cancelledRef = useRef<Set<string>>(new Set());
-  // Queue for files to upload (supports merging batches from concurrent drops)
-  const uploadQueueRef = useRef<FileUpload[]>([]);
+  // Single source of truth for queued + in-flight uploads. Map preserves
+  // insertion order, giving us FIFO for free. An entry whose `abort` is
+  // undefined is still queued; once upload starts we populate `abort`.
+  // Removing an entry (delete/clear) is the cancellation signal.
+  const activeUploadsRef = useRef<Map<string, ActiveUpload>>(new Map());
   // Whether the upload processing loop is currently running
   const isProcessingRef = useRef(false);
 
   const { filesToUpload, handleHierarchy } = useUpload({ item: item! });
 
   const onCancelFile = useCallback(async (fileName: string) => {
-    const abortFn = abortFunctionsRef.current.get(fileName);
-    if (abortFn) {
-      await abortFn();
-      abortFunctionsRef.current.delete(fileName);
+    const upload = activeUploadsRef.current.get(fileName);
+    // Remove from the map first: this is the signal the processing loop
+    // uses in its catch block to distinguish user cancel from real errors.
+    activeUploadsRef.current.delete(fileName);
+    if (upload?.abort) {
+      await upload.abort();
     }
-    cancelledRef.current.add(fileName);
     setUploadingState((prev) => {
       const meta = prev.filesMeta[fileName];
       if (!meta || meta.status === FileUploadStatus.DONE) return prev;
@@ -275,17 +285,19 @@ export const useUploadZone = ({ item }: { item: Item }) => {
   }, []);
 
   const onCancelAll = useCallback(async () => {
-    // Abort the currently uploading file
-    for (const [, abortFn] of abortFunctionsRef.current.entries()) {
-      await abortFn();
+    // Snapshot entries before clearing so we can abort in-flight uploads.
+    const entries = Array.from(activeUploadsRef.current.entries());
+    activeUploadsRef.current.clear();
+    for (const [, upload] of entries) {
+      if (upload.abort) {
+        await upload.abort();
+      }
     }
-    abortFunctionsRef.current.clear();
-    // Mark ALL uploading files as cancelled (including queued ones not yet in abortFunctionsRef)
     setUploadingState((prev) => {
       const newMeta = { ...prev.filesMeta };
-      for (const [name, meta] of Object.entries(newMeta)) {
-        if (meta.status === FileUploadStatus.UPLOADING) {
-          cancelledRef.current.add(name);
+      for (const [name] of entries) {
+        const meta = newMeta[name];
+        if (meta && meta.status === FileUploadStatus.UPLOADING) {
           newMeta[name] = { ...meta, status: FileUploadStatus.CANCELLED };
         }
       }
@@ -496,25 +508,31 @@ export const useUploadZone = ({ item }: { item: Item }) => {
         };
       }
 
-      // If no upload is in progress, reset state for a fresh batch
+      // Update UI state
       if (!isProcessingRef.current) {
-        cancelledRef.current.clear();
         setUploadingState({
           step: UploadingStep.UPLOAD_FILES,
           filesMeta: newFilesMeta,
         });
       } else {
-        // Merge into existing batch
         setUploadingState((prev) => ({
           step: UploadingStep.UPLOAD_FILES,
           filesMeta: { ...prev.filesMeta, ...newFilesMeta },
         }));
       }
 
-      // Add valid files to the upload queue
-      uploadQueueRef.current.push(...validFiles);
+      // Enqueue valid files in the single source of truth. The materialized
+      // path of the drop target is stored once per file so we can later
+      // resolve "was an ancestor of this upload deleted?" via isIdInItemTree.
+      const parentPath = item?.path ?? "";
+      for (const file of validFiles) {
+        activeUploadsRef.current.set(pathNicefy(file.path!), {
+          file,
+          parentPath,
+        });
+      }
 
-      // If the processing loop is already running, it will pick up the new files from the queue
+      // If the processing loop is already running, it will pick up the new files
       if (isProcessingRef.current) {
         return;
       }
@@ -522,15 +540,22 @@ export const useUploadZone = ({ item }: { item: Item }) => {
       // Start the processing loop
       isProcessingRef.current = true;
 
-      // Process files from the queue until it's empty
-      while (uploadQueueRef.current.length > 0) {
-        const file = uploadQueueRef.current.shift()!;
-        const filePath = pathNicefy(file.path!);
-
-        // Skip if cancelled before we even started this file
-        if (cancelledRef.current.has(filePath)) {
-          continue;
+      // Pick the next queued entry: the first one without an abort handle
+      // (abort === undefined means it hasn't started uploading yet).
+      // Map iteration follows insertion order → FIFO is preserved.
+      // The loop exits when no more queued entries remain.
+      while (true) {
+        let nextEntry: [string, ActiveUpload] | undefined;
+        for (const entry of activeUploadsRef.current) {
+          if (!entry[1].abort) {
+            nextEntry = entry;
+            break;
+          }
         }
+        if (!nextEntry) break;
+
+        const [filePath, upload] = nextEntry;
+        const file = upload.file;
 
         const { promise, abort } = driver.createFile({
           filename: file.name,
@@ -554,11 +579,17 @@ export const useUploadZone = ({ item }: { item: Item }) => {
           },
         });
 
-        abortFunctionsRef.current.set(filePath, abort);
+        // Mark this entry as "in flight" so the loop won't pick it again.
+        upload.abort = abort;
 
         try {
           await promise;
-          abortFunctionsRef.current.delete(filePath);
+          // If the upload was cancelled mid-flight, the entry was removed
+          // from the map: skip the success state update.
+          if (!activeUploadsRef.current.has(filePath)) {
+            continue;
+          }
+          activeUploadsRef.current.delete(filePath);
           refresh(file.parentId);
           setUploadingState((prev) => ({
             ...prev,
@@ -572,9 +603,12 @@ export const useUploadZone = ({ item }: { item: Item }) => {
             },
           }));
         } catch (err) {
-          abortFunctionsRef.current.delete(filePath);
+          // If the entry was already removed from the map, onCancelFile (or
+          // onCancelAll) ran while the upload was in flight → user cancel.
+          const wasCancelled = !activeUploadsRef.current.has(filePath);
+          activeUploadsRef.current.delete(filePath);
           if (
-            cancelledRef.current.has(filePath) ||
+            wasCancelled ||
             (err instanceof DOMException && err.name === "AbortError")
           ) {
             // Already handled by onCancelFile/onCancelAll
@@ -653,7 +687,33 @@ export const useUploadZone = ({ item }: { item: Item }) => {
     return () => window.removeEventListener("beforeunload", unloadCallback);
   }, [uploadingState.step]);
 
+  /**
+   * Cancel every active upload whose drop-target folder is — or is a
+   * descendant of — any of the deleted items. We use isIdInItemTree to
+   * check whether a deletedId appears anywhere in the materialized path,
+   * which covers both direct parent and ancestor deletions.
+   */
+  const cancelUploadsForDeletedItems = useCallback(
+    (deletedIds: string[]) => {
+      if (activeUploadsRef.current.size === 0 || deletedIds.length === 0) {
+        return;
+      }
+      // Collect matches first: onCancelFile mutates the map we're iterating.
+      const toCancel: string[] = [];
+      for (const [filePath, upload] of activeUploadsRef.current) {
+        if (
+          deletedIds.some((id) => isIdInItemTree(upload.parentPath, id))
+        ) {
+          toCancel.push(filePath);
+        }
+      }
+      toCancel.forEach((filePath) => void onCancelFile(filePath));
+    },
+    [onCancelFile],
+  );
+
   return {
     dropZone,
+    cancelUploadsForDeletedItems,
   };
 };

--- a/src/frontend/apps/e2e/__tests__/app-drive/upload.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-drive/upload.spec.ts
@@ -16,6 +16,9 @@ import {
   mockSlowUpload,
   mockSlowUploadEnded,
 } from "./utils/upload-utils";
+import { createFolderInCurrentFolder, deleteCurrentFolder } from "./utils-item";
+import { navigateToFolder, clickToMyFiles } from "./utils-navigate";
+import { clickOnRowItemActions } from "./utils-embedded-grid";
 
 const PDF_FILE_PATH = path.join(__dirname, "/assets/pv_cm.pdf");
 const DOCX_FILE_PATH = path.join(__dirname, "/assets/empty_doc.docx");
@@ -425,5 +428,107 @@ test.describe("File upload toast", () => {
       page.getByRole("cell", { name: "empty_doc", exact: true }),
     ).toBeVisible({ timeout: 15000 });
     await expect(getFileRowCheckIcon(page, "empty_doc.docx")).toBeVisible();
+  });
+
+  test("Delete parent folder — cancels active uploads", async ({ page }) => {
+    const { resolve } = await mockSlowUpload(page);
+    await setupUploadTest(page);
+
+    // Create a folder and navigate into it
+    await createFolderInCurrentFolder(page, "TestFolder");
+    await navigateToFolder(page, "TestFolder", ["My files", "TestFolder"]);
+
+    // Start uploading a file (parentId = TestFolder.id)
+    await uploadFile(page, PDF_FILE_PATH);
+
+    // Toast should be visible with the file uploading
+    await expect(getUploadToast(page)).toBeVisible();
+    await expect(getFileRow(page, "pv_cm.pdf")).toBeVisible();
+
+    // Delete the current folder via breadcrumb — triggers cancelUploadsForDeletedItems
+    await deleteCurrentFolder(page);
+
+    // Upload should be cancelled — file row should disappear from toast
+    await expect(getFileRow(page, "pv_cm.pdf")).not.toBeVisible();
+
+    // Unblock the S3 mock
+    resolve();
+
+    // File should NOT appear in the grid (we're now back in My Files)
+    await expect(
+      page.getByRole("cell", { name: "pv_cm", exact: true }),
+    ).not.toBeVisible();
+  });
+
+  test("Delete folder only cancels uploads for that folder", async ({
+    page,
+  }) => {
+    const { resolve } = await mockSlowUpload(page);
+    await setupUploadTest(page);
+
+    // Create two folders
+    await createFolderInCurrentFolder(page, "FolderA");
+    await createFolderInCurrentFolder(page, "FolderB");
+
+    // Navigate into FolderA and start uploading (blocked by mock)
+    await navigateToFolder(page, "FolderA", ["My files", "FolderA"]);
+    await uploadFile(page, PDF_FILE_PATH);
+    await expect(getUploadToast(page)).toBeVisible();
+    await expect(getFileRow(page, "pv_cm.pdf")).toBeVisible();
+
+    // Navigate back to My Files, then into FolderB
+    await clickToMyFiles(page);
+    await navigateToFolder(page, "FolderB", ["My files", "FolderB"]);
+
+    // Start another upload (merged into queue)
+    await uploadFile(page, DOCX_FILE_PATH);
+    await expect(getFileRow(page, "empty_doc.docx")).toBeVisible();
+
+    // Navigate back to My Files
+    await clickToMyFiles(page);
+
+    // Delete FolderA via row action menu — should only cancel FolderA's upload
+    await clickOnRowItemActions(page, "FolderA", "Delete");
+
+    // pv_cm.pdf (FolderA) should be cancelled
+    await expect(getFileRow(page, "pv_cm.pdf")).not.toBeVisible();
+
+    // empty_doc.docx (FolderB) should still be in the toast
+    await expect(getFileRow(page, "empty_doc.docx")).toBeVisible();
+
+    // Unblock uploads — FolderB's file should complete
+    resolve();
+    await expect(getFileRowCheckIcon(page, "empty_doc.docx")).toBeVisible({
+      timeout: 15000,
+    });
+  });
+
+  test("Delete ancestor folder — cancels uploads in a nested drop target", async ({
+    page,
+  }) => {
+    const { resolve } = await mockSlowUpload(page);
+    await setupUploadTest(page);
+
+    // Create FolderA, go in, create FolderB inside, go in, start upload
+    await createFolderInCurrentFolder(page, "FolderA");
+    await navigateToFolder(page, "FolderA", ["My files", "FolderA"]);
+    await createFolderInCurrentFolder(page, "FolderB");
+    await navigateToFolder(page, "FolderB", ["My files", "FolderA", "FolderB"]);
+
+    await uploadFile(page, PDF_FILE_PATH);
+    await expect(getUploadToast(page)).toBeVisible();
+    await expect(getFileRow(page, "pv_cm.pdf")).toBeVisible();
+
+    // Go back up to My Files and delete FolderA (ancestor of the drop target)
+    await clickToMyFiles(page);
+    await clickOnRowItemActions(page, "FolderA", "Delete");
+
+    // Upload should be cancelled via ancestor resolution
+    await expect(getFileRow(page, "pv_cm.pdf")).not.toBeVisible();
+
+    resolve();
+    await expect(
+      page.getByRole("cell", { name: "pv_cm", exact: true }),
+    ).not.toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary

- Track each uploading file's drop target folder
  via a Map (`fileDropTargetRef`)
- When a folder is deleted, selectively cancel only
  the uploads that were dropped into that folder,
  leaving other concurrent uploads unaffected
- Hook into both `useDeleteItem` and
  `ExplorerSelectionBar` deletion paths