### PR TITLE
🐛(frontend) add actions menu on mobile My Files page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to
 - ✨(frontend) add ErrorIcon component and support numeric icon sizes
 - ✨(frontend) make file upload abortable in driver layer
 
+### Fixed
+
+- 🐛(frontend) add actions menu on mobile My Files page
+
 ## [v0.16.0] - 2026-04-09
 
 ### Added

--- a/src/frontend/apps/drive/src/features/explorer/components/app-view/AppExplorerBreadcrumbs.tsx
+++ b/src/frontend/apps/drive/src/features/explorer/components/app-view/AppExplorerBreadcrumbs.tsx
@@ -4,6 +4,7 @@ import {
   useGlobalExplorer,
 } from "@/features/explorer/components/GlobalExplorerContext";
 import {
+  DropdownMenu,
   HorizontalSeparator,
   IconSize,
   useDropdownMenu,
@@ -24,6 +25,7 @@ import {
   ORDERED_DEFAULT_ROUTES,
 } from "@/utils/defaultRoutes";
 import { ItemActionDropdown } from "../item-actions/ItemActionDropdown";
+import { useCreateMenuItems } from "../../hooks/useCreateMenuItems";
 
 export const AppExplorerBreadcrumbs = () => {
   const { item, onNavigate } = useGlobalExplorer();
@@ -99,6 +101,11 @@ export const ExplorerBreadcrumbsMobile = () => {
   const { item, onNavigate } = useGlobalExplorer();
   const { data: breadcrumb } = useBreadcrumbQuery(item?.id);
   const [isActionMenuOpen, setIsActionMenuOpen] = useState(false);
+  const [isCreateMenuOpen, setIsCreateMenuOpen] = useState(false);
+  const { menuItems, modals: createModals } = useCreateMenuItems({
+    includeImport: true,
+    includeCreate: false,
+  });
 
   const defaultRouteId = getDefaultRouteId(router.pathname);
   const defaultRouteData = ORDERED_DEFAULT_ROUTES.find(
@@ -121,13 +128,29 @@ export const ExplorerBreadcrumbsMobile = () => {
 
   if (!item && defaultRouteData) {
     return (
-      <div className="explorer__content__breadcrumbs--mobile">
-        <div className="explorer__content__breadcrumbs--mobile__default-route">
-          <defaultRouteData.icon size={IconSize.MEDIUM} />
+      <>
+        <div className="explorer__content__breadcrumbs--mobile">
+          <div className="explorer__content__breadcrumbs--mobile__default-route">
+            <defaultRouteData.icon size={IconSize.MEDIUM} />
 
-          {t(defaultRouteData.label)}
+            {t(defaultRouteData.label)}
+          </div>
+          {defaultRouteId === DefaultRoute.MY_FILES && (
+            <DropdownMenu
+              options={menuItems}
+              isOpen={isCreateMenuOpen}
+              onOpenChange={setIsCreateMenuOpen}
+            >
+              <Button
+                variant="tertiary"
+                icon={<span className="material-icons">more_vert</span>}
+                onClick={() => setIsCreateMenuOpen(true)}
+              />
+            </DropdownMenu>
+          )}
         </div>
-      </div>
+        {defaultRouteId === DefaultRoute.MY_FILES && createModals}
+      </>
     );
   }
 

--- a/src/frontend/apps/drive/src/features/explorer/hooks/useCreateMenuItems.tsx
+++ b/src/frontend/apps/drive/src/features/explorer/hooks/useCreateMenuItems.tsx
@@ -16,6 +16,7 @@ import { useState } from "react";
 
 type UseCreateMenuItemsProps = {
   includeImport?: boolean;
+  includeCreate?: boolean;
 };
 
 type UseCreateMenuItemsReturn = {
@@ -33,6 +34,7 @@ const renderFileIcon = (item: Partial<Item>) => {
 
 export const useCreateMenuItems = ({
   includeImport = false,
+  includeCreate = true,
 }: UseCreateMenuItemsProps = {}): UseCreateMenuItemsReturn => {
   const { t } = useTranslation();
   const { item, itemId } = useGlobalExplorer();
@@ -81,41 +83,43 @@ export const useCreateMenuItems = ({
     );
   }
 
-  items.push(
-    {
-      icon: renderFileIcon({
-        type: ItemType.FILE,
-        filename: "doc.odt",
-        mimetype:
-          "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-      }),
-      label: t("explorer.tree.create.file.doc"),
-      isHidden,
-      callback: () => openCreateFileModal(ExplorerCreateFileType.DOC),
-    },
-    {
-      icon: renderFileIcon({
-        type: ItemType.FILE,
-        filename: "powerpoint.odp",
-        mimetype:
-          "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-      }),
-      label: t("explorer.tree.create.file.powerpoint"),
-      isHidden,
-      callback: () => openCreateFileModal(ExplorerCreateFileType.POWERPOINT),
-    },
-    {
-      icon: renderFileIcon({
-        type: ItemType.FILE,
-        filename: "calc.ods",
-        mimetype:
-          "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-      }),
-      label: t("explorer.tree.create.file.calc"),
-      isHidden,
-      callback: () => openCreateFileModal(ExplorerCreateFileType.CALC),
-    },
-  );
+  if (includeCreate) {
+    items.push(
+      {
+        icon: renderFileIcon({
+          type: ItemType.FILE,
+          filename: "doc.odt",
+          mimetype:
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        }),
+        label: t("explorer.tree.create.file.doc"),
+        isHidden,
+        callback: () => openCreateFileModal(ExplorerCreateFileType.DOC),
+      },
+      {
+        icon: renderFileIcon({
+          type: ItemType.FILE,
+          filename: "powerpoint.odp",
+          mimetype:
+            "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        }),
+        label: t("explorer.tree.create.file.powerpoint"),
+        isHidden,
+        callback: () => openCreateFileModal(ExplorerCreateFileType.POWERPOINT),
+      },
+      {
+        icon: renderFileIcon({
+          type: ItemType.FILE,
+          filename: "calc.ods",
+          mimetype:
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        }),
+        label: t("explorer.tree.create.file.calc"),
+        isHidden,
+        callback: () => openCreateFileModal(ExplorerCreateFileType.CALC),
+      },
+    );
+  }
 
   const modals = (
     <>

--- a/src/frontend/apps/drive/src/features/explorer/hooks/useItemActionMenuItems.tsx
+++ b/src/frontend/apps/drive/src/features/explorer/hooks/useItemActionMenuItems.tsx
@@ -1,19 +1,27 @@
 import { Item, ItemType } from "@/features/drivers/types";
-import { useTreeContext, MenuItem } from "@gouvfr-lasuite/ui-kit";
+import {
+  useTreeContext,
+  MenuItem,
+  Shared,
+  Download,
+  Copy,
+  FolderPlus,
+  Upload,
+  Star,
+  Edit,
+  ArrowRight,
+  Info,
+  Trash,
+} from "@gouvfr-lasuite/ui-kit";
 import { useModal } from "@gouvfr-lasuite/cunningham-react";
 import { t } from "i18next";
 import {
   itemToTreeItem,
   useGlobalExplorer,
 } from "../components/GlobalExplorerContext";
-import settingsSvg from "@/assets/icons/settings.svg";
-import starredSvg from "@/assets/icons/starred.svg";
-import unstarredSvg from "@/assets/icons/starred-slash.svg";
-import uploadFileSvg from "@/assets/icons/upload_file.svg";
 import { useDownloadItem } from "@/features/items/hooks/useDownloadItem";
 import { ExplorerRenameItemModal } from "../components/modals/ExplorerRenameItemModal";
 import { ExplorerCreateFolderModal } from "../components/modals/ExplorerCreateFolderModal";
-import { NewFolderIcon } from "@/features/ui/components/icon/NewFolderIcon";
 import { ItemShareModal } from "../components/modals/share/ItemShareModal";
 import { useDeleteItem } from "./useDeleteItem";
 import { ExplorerMoveFolder } from "../components/modals/move/ExplorerMoveFolderModal";
@@ -121,7 +129,7 @@ export const useItemActionMenuItems = ({
       ...(showAddChildren
         ? [
             {
-              icon: <NewFolderIcon />,
+              icon: <FolderPlus />,
               label: t("explorer.actions.createFolder.modal.title"),
               callback: () => {
                 setCurrentItem(effectiveItem);
@@ -129,7 +137,7 @@ export const useItemActionMenuItems = ({
               },
             },
             {
-              icon: <img src={uploadFileSvg.src} alt="" />,
+              icon: <Upload />,
               label: t("explorer.tree.import.files"),
               callback: () => {
                 document.getElementById("import-files")?.click();
@@ -140,7 +148,7 @@ export const useItemActionMenuItems = ({
         : []),
 
       {
-        icon: <span className="material-icons">group</span>,
+        icon: <Shared />,
         label: t("explorer.item.actions.share"),
         isHidden: !item.abilities?.accesses_view,
         callback: () => {
@@ -149,7 +157,7 @@ export const useItemActionMenuItems = ({
         },
       },
       {
-        icon: <span className="material-icons">download</span>,
+        icon: <Download />,
         label: t("explorer.item.actions.download"),
         isHidden: item.type === ItemType.FOLDER || minimal,
         callback: () => {
@@ -157,7 +165,7 @@ export const useItemActionMenuItems = ({
         },
       },
       {
-        icon: <span className="material-icons">content_copy</span>,
+        icon: <Copy />,
         label: t("explorer.item.actions.duplicate"),
         isHidden: !item.abilities?.duplicate || item.type === ItemType.FOLDER,
         callback: async () => {
@@ -175,12 +183,7 @@ export const useItemActionMenuItems = ({
       },
 
       {
-        icon: (
-          <img
-            src={item.is_favorite ? unstarredSvg.src : starredSvg.src}
-            alt=""
-          />
-        ),
+        icon: <Star />,
         label: item.is_favorite
           ? t("explorer.item.actions.unfavorite")
           : t("explorer.item.actions.favorite"),
@@ -191,7 +194,7 @@ export const useItemActionMenuItems = ({
       },
       { type: "separator" },
       {
-        icon: <img src={settingsSvg.src} alt="" />,
+        icon: <Edit />,
         label: t("explorer.item.actions.rename"),
         isHidden: !item.abilities?.update,
         callback: () => {
@@ -200,7 +203,7 @@ export const useItemActionMenuItems = ({
         },
       },
       {
-        icon: <span className="material-icons">arrow_forward</span>,
+        icon: <ArrowRight />,
         label: t("explorer.item.actions.move"),
         isHidden: !item.abilities?.move || minimal,
         callback: () => {
@@ -211,7 +214,7 @@ export const useItemActionMenuItems = ({
       { type: "separator" },
 
       {
-        icon: <span className="material-icons">info</span>,
+        icon: <Info />,
         label: t("explorer.item.actions.view_info"),
         isHidden: minimal,
         callback: () => {
@@ -221,7 +224,7 @@ export const useItemActionMenuItems = ({
       },
       { type: "separator" },
       {
-        icon: <span className="material-icons">delete</span>,
+        icon: <Trash />,
         label: t("explorer.item.actions.delete"),
         variant: "danger" as const,
         isHidden: !item.abilities?.destroy || item.main_workspace || minimal,

--- a/src/frontend/apps/e2e/__tests__/app-drive/mobile-actions.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-drive/mobile-actions.spec.ts
@@ -1,0 +1,54 @@
+import test, { expect } from "@playwright/test";
+import { clearDb, login } from "./utils-common";
+import { clickToMyFiles } from "./utils-navigate";
+import { createFolderInCurrentFolder } from "./utils-item";
+import { getRowItem } from "./utils-embedded-grid";
+
+const MOBILE_VIEWPORT = { width: 375, height: 667 };
+
+test.describe("Mobile actions menu", () => {
+  test.beforeEach(async ({ page }) => {
+    await clearDb();
+    await login(page, "drive@example.com");
+  });
+
+  test("My Files shows more menu with create and import options", async ({
+    page,
+  }) => {
+    await page.setViewportSize(MOBILE_VIEWPORT);
+    await page.goto("/explorer/items/my-files");
+
+    const moreButton = page.getByRole("button", { name: "more_vert" });
+    await expect(moreButton).toBeVisible();
+    await moreButton.click();
+
+    await expect(
+      page.getByRole("menuitem", { name: "New folder" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("menuitem", { name: "Import files" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("menuitem", { name: "Import folders" }),
+    ).toBeVisible();
+  });
+
+  test("Folder shows more menu button", async ({ page }) => {
+    // Create folder at desktop viewport where sidebar and buttons are available
+    await page.goto("/");
+    await clickToMyFiles(page);
+    await createFolderInCurrentFolder(page, "TestFolder");
+
+    // Get the folder URL
+    const folderRow = await getRowItem(page, "TestFolder");
+    await folderRow.dblclick();
+    const folderUrl = page.url();
+
+    // Switch to mobile and navigate to folder
+    await page.setViewportSize(MOBILE_VIEWPORT);
+    await page.goto(folderUrl);
+
+    const moreButton = page.getByRole("button", { name: "more_vert" });
+    await expect(moreButton).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

- Add a "..." (more_vert) dropdown menu on the mobile
  My Files page with "New folder", "Import files" and
  "Import folders" options
- Add `includeCreate` option to `useCreateMenuItems`
  hook to allow excluding document creation items
- Replace SVG/material-icons with ui-kit icon components
  in action menu items
- Add e2e tests for mobile actions menu