### PR TITLE
🐛(backend) fix share invitation email links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to
 - ✨(frontend) add ErrorIcon component and support numeric icon sizes
 - ✨(frontend) make file upload abortable in driver layer
 - ✨(frontend) files preview v2
+- 🔧(project) add DJANGO_EMAIL_URL_APP environment variable
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to
 - 🐛(front) set size and variant on trash navigate modal #666
 - 🐛(frontend) fix uploads continuing after parent folder deletion
 - 🐛(frontend) fix SDK picker link reach promotion
+- 🐛(backend) route share invitation link to file view for files
 
 ### Fixed
 

--- a/docs/env.md
+++ b/docs/env.md
@@ -50,6 +50,7 @@ This document lists all configurable environment variables for the Drive applica
 | `EMAIL_HOST_USER` | SMTP username for email sending | `None` |
 | `EMAIL_LOGO_IMG` | Logo image URL for email templates | `None` |
 | `EMAIL_PORT` | SMTP port for email sending | `None` |
+| `EMAIL_URL_APP` | URL used in emails to link back to the app | `None` |
 | `EMAIL_USE_SSL` | Use SSL for SMTP connection | `False` |
 | `EMAIL_USE_TLS` | Use TLS for SMTP connection | `False` |
 | `FEATURES_ALPHA` | Enable alpha features | `False` |

--- a/docs/examples/helm/drive.values.yaml
+++ b/docs/examples/helm/drive.values.yaml
@@ -24,6 +24,7 @@ backend:
     DJANGO_EMAIL_HOST: "mailcatcher"
     DJANGO_EMAIL_LOGO_IMG: https://drive.127.0.0.1.nip.io/assets/logo-suite-numerique.png
     DJANGO_EMAIL_PORT: 1025
+    DJANGO_EMAIL_URL_APP: https://drive.127.0.0.1.nip.io
     DJANGO_EMAIL_USE_SSL: False
     LOGGING_LEVEL_LOGGERS_ROOT: INFO
     LOGGING_LEVEL_LOGGERS_APP: INFO

--- a/env.d/development/common
+++ b/env.d/development/common
@@ -20,6 +20,7 @@ DJANGO_EMAIL_BRAND_NAME="La Suite Numérique"
 DJANGO_EMAIL_HOST="mailcatcher"
 DJANGO_EMAIL_LOGO_IMG="http://localhost:3000/assets/logo-suite-numerique.png"
 DJANGO_EMAIL_PORT=1025
+DJANGO_EMAIL_URL_APP="http://localhost:3000"
 
 # Media
 STORAGES_STATICFILES_BACKEND=django.contrib.staticfiles.storage.StaticFilesStorage

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -915,17 +915,17 @@ class Item(TreeModel, BaseModel):
             return
 
         context = context or {}
-        domain = Site.objects.get_current().domain
+        base_url = settings.EMAIL_URL_APP or Site.objects.get_current().domain
         language = language or get_language()
         context.update(
             {
                 "brandname": settings.EMAIL_BRAND_NAME,
                 "item": self,
-                "domain": domain,
+                "domain": base_url,
                 "link": (
-                    f"{domain}/explorer/items/files/{self.id}/"
+                    f"{base_url}/explorer/items/files/{self.id}/"
                     if self.type == ItemTypeChoices.FILE
-                    else f"{domain}/explorer/items/{self.id}/"
+                    else f"{base_url}/explorer/items/{self.id}/"
                 ),
                 "logo_img": settings.EMAIL_LOGO_IMG,
             }

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -922,7 +922,11 @@ class Item(TreeModel, BaseModel):
                 "brandname": settings.EMAIL_BRAND_NAME,
                 "item": self,
                 "domain": domain,
-                "link": f"{domain}/explorer/items/{self.id}/",
+                "link": (
+                    f"{domain}/explorer/items/files/{self.id}/"
+                    if self.type == ItemTypeChoices.FILE
+                    else f"{domain}/explorer/items/{self.id}/"
+                ),
                 "logo_img": settings.EMAIL_LOGO_IMG,
             }
         )

--- a/src/backend/core/tests/test_models_items.py
+++ b/src/backend/core/tests/test_models_items.py
@@ -759,7 +759,7 @@ def test_models_items__email_invitation__success():
     """
     The email invitation is sent successfully.
     """
-    item = factories.ItemFactory()
+    item = factories.ItemFactory(type=models.ItemTypeChoices.FOLDER)
 
     # pylint: disable-next=no-member
     assert len(mail.outbox) == 0
@@ -787,7 +787,7 @@ def test_models_items__email_invitation__success_fr():
     """
     The email invitation is sent successfully in french.
     """
-    item = factories.ItemFactory()
+    item = factories.ItemFactory(type=models.ItemTypeChoices.FOLDER)
 
     # pylint: disable-next=no-member
     assert len(mail.outbox) == 0
@@ -814,6 +814,37 @@ def test_models_items__email_invitation__success_fr():
         f"sur le item suivant: {item.title}" in email_content
     )
     assert f"items/{item.id}/" in email_content
+
+
+def test_models_items__email_invitation__link_for_folder():
+    """
+    The invitation email link for a folder item points to the folder explorer route.
+    """
+    item = factories.ItemFactory(type=models.ItemTypeChoices.FOLDER)
+    sender = factories.UserFactory()
+
+    item.send_invitation_email("guest-folder@example.com", models.RoleChoices.EDITOR, sender, "en")
+
+    # pylint: disable-next=no-member
+    email = mail.outbox[-1]
+    assert f"/explorer/items/{item.id}/" in email.body
+    assert f"/explorer/items/files/{item.id}/" not in email.body
+
+
+def test_models_items__email_invitation__link_for_file():
+    """
+    The invitation email link for a file item points to the dedicated file route,
+    so the recipient opens the file preview rather than an empty folder view.
+    """
+    item = factories.ItemFactory(type=models.ItemTypeChoices.FILE, filename="doc.pdf")
+    sender = factories.UserFactory()
+
+    item.send_invitation_email("guest-file@example.com", models.RoleChoices.EDITOR, sender, "en")
+
+    # pylint: disable-next=no-member
+    email = mail.outbox[-1]
+    assert f"/explorer/items/files/{item.id}/" in email.body
+    assert f"/explorer/items/{item.id}/" not in email.body
 
 
 @mock.patch(

--- a/src/backend/core/tests/test_models_items.py
+++ b/src/backend/core/tests/test_models_items.py
@@ -847,6 +847,35 @@ def test_models_items__email_invitation__link_for_file():
     assert f"/explorer/items/{item.id}/" not in email.body
 
 
+@pytest.mark.parametrize(
+    "email_url_app",
+    [
+        "https://test-example.com",  # Test with EMAIL_URL_APP set
+        None,  # Test fallback to Site domain
+    ],
+)
+def test_models_items__email_invitation__url_app_param(email_url_app, settings):
+    """
+    Email invitation uses EMAIL_URL_APP when set, or falls back to the Site domain.
+    """
+    settings.EMAIL_URL_APP = email_url_app
+
+    item = factories.ItemFactory(type=models.ItemTypeChoices.FOLDER)
+    sender = factories.UserFactory()
+
+    item.send_invitation_email("guest@example.com", models.RoleChoices.EDITOR, sender, "en")
+
+    # pylint: disable-next=no-member
+    email = mail.outbox[-1]
+    email_content = " ".join(email.body.split())
+
+    if email_url_app:
+        assert f"https://test-example.com/explorer/items/{item.id}/" in email_content
+    else:
+        # Default Site domain is example.com
+        assert f"example.com/explorer/items/{item.id}/" in email_content
+
+
 @mock.patch(
     "core.models.send_mail",
     side_effect=smtplib.SMTPException("Error SMTPException"),

--- a/src/backend/drive/settings.py
+++ b/src/backend/drive/settings.py
@@ -1000,6 +1000,7 @@ class Base(Configuration):
     EMAIL_HOST_PASSWORD = SecretFileValue(None)
     EMAIL_LOGO_IMG = values.Value(None)
     EMAIL_PORT = values.PositiveIntegerValue(None)
+    EMAIL_URL_APP = values.Value(None)
     EMAIL_USE_TLS = values.BooleanValue(False)
     EMAIL_USE_SSL = values.BooleanValue(False)
     EMAIL_FROM = values.Value("from@example.com")

--- a/src/helm/env.d/dev/values.drive.yaml.gotmpl
+++ b/src/helm/env.d/dev/values.drive.yaml.gotmpl
@@ -24,6 +24,7 @@ backend:
     DJANGO_EMAIL_HOST: "mailcatcher"
     DJANGO_EMAIL_LOGO_IMG: https://drive.127.0.0.1.nip.io/assets/logo-suite-numerique.png
     DJANGO_EMAIL_PORT: 1025
+    DJANGO_EMAIL_URL_APP: https://drive.127.0.0.1.nip.io
     DJANGO_EMAIL_USE_SSL: False
     LOGGING_LEVEL_LOGGERS_ROOT: INFO
     LOGGING_LEVEL_LOGGERS_APP: INFO


### PR DESCRIPTION
## Summary

Two bugs in the share-invitation email flow (`Item.send_email`):

1. **File invitations opened an empty folder view.** The link was
   always built as `/explorer/items/<id>/`, routing to the folder
   explorer which rendered an empty children list for file items.
   Fixed by branching on `item.type` and using
   `/explorer/items/files/<id>/` for files — the same route used
   by the in-app share-link button.

2. **Invitation links had no absolute URL.** The link used
   `Site.objects.get_current().domain` directly, which Django
   seeds as `example.com` and which carries no scheme. The
   resulting `href` was interpreted as relative by mail clients
   and 404'd. Fixed by introducing a dedicated
   `DJANGO_EMAIL_URL_APP` environment variable (same pattern as
   suitenumerique/docs#1825), holding the absolute app URL, with
   fallback on the current Site domain when unset.

## ⚠️ New env

```
DJANGO_EMAIL_URL_APP="http://localhost:3000"
```

Wired in `env.d/development/common`, helm dev values and the helm
example. Staging/prod must set `DJANGO_EMAIL_URL_APP` to their
public app URL.

## Test plan

- [ ] Invite a user to a **file**; email link points to
  `http://localhost:3000/explorer/items/files/<id>/` and opens
  the file preview
- [ ] Invite a user to a **folder**; link points to
  `http://localhost:3000/explorer/items/<id>/` and opens the
  folder
- [ ] `pytest core/tests/test_models_items.py -k email_invitation`
  passes (includes the new `__url_app_param` parametrized test
  covering both the env-var and Site-fallback branches)
