### PR TITLE
🐛(front) show actual selection count in hard delete modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to
 ### Fixed
 
 - 🐛(frontend) add actions menu on mobile My Files page
+- 🐛(frontend) show actual selection count in hard delete modal
 
 ## [v0.16.0] - 2026-04-09
 

--- a/src/frontend/apps/drive/src/features/explorer/components/modals/HardDeleteConfirmationModal.tsx
+++ b/src/frontend/apps/drive/src/features/explorer/components/modals/HardDeleteConfirmationModal.tsx
@@ -9,10 +9,10 @@ import { useTranslation } from "react-i18next";
 
 export const HardDeleteConfirmationModal = ({
   onDecide,
-  multiple = false,
+  count = 1,
   ...props
 }: DecisionModalProps & {
-  multiple?: boolean;
+  count?: number;
 }) => {
   const { t } = useTranslation();
   return (
@@ -45,7 +45,7 @@ export const HardDeleteConfirmationModal = ({
     >
       <div className="c__modal__content__text">
         {t("explorer.trash.hard_delete.content", {
-          count: multiple ? 2 : 1,
+          count,
         })}
       </div>
     </Modal>

--- a/src/frontend/apps/drive/src/pages/explorer/trash/index.tsx
+++ b/src/frontend/apps/drive/src/pages/explorer/trash/index.tsx
@@ -136,7 +136,7 @@ export const TrashPageSelectionBarActions = () => {
         <HardDeleteConfirmationModal
           {...hardDeleteConfirmationModal}
           onDecide={handleHardDelete}
-          multiple={selectedItems.length > 1}
+          count={selectedItems.length}
         />
       )}
     </>


### PR DESCRIPTION
## Summary
- The trash hard delete confirmation modal always read "2 items"
  regardless of the selection size, because the modal received a
  boolean `multiple` prop and hardcoded `count: 2` for the i18n
  interpolation.
- Replace the `multiple` boolean with a `count` number prop and pass
  `selectedItems.length` from the trash page so the plural message
  reflects the real selection.

Closes #651

## Test plan
- [ ] Open the trash view, select 3+ items, click hard delete and
      confirm the modal reads "delete these 3 items forever?".
- [ ] Select a single item and confirm the modal reads
      "delete this item forever?".
- [ ] Run frontend type-check / lint.