### PR TITLE
🐛(front) set size and variant on trash navigate modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to
 - 🐛(frontend) add actions menu on mobile My Files page
 - 🐛(frontend) show actual selection count in hard delete modal
 - 🐛(frontend) Responsive broken with long filters in search #659
+- 🐛(front) set size and variant on trash navigate modal #666
 
 ## [v0.16.0] - 2026-04-09
 

--- a/src/frontend/apps/drive/src/features/explorer/components/trash/utils.tsx
+++ b/src/frontend/apps/drive/src/features/explorer/components/trash/utils.tsx
@@ -1,4 +1,8 @@
-import { useModals } from "@gouvfr-lasuite/cunningham-react";
+import {
+  ModalSize,
+  useModals,
+  VariantType,
+} from "@gouvfr-lasuite/cunningham-react";
 import i18n from "@/features/i18n/initI18n";
 
 export const messageModalTrashNavigate = (
@@ -7,6 +11,8 @@ export const messageModalTrashNavigate = (
 ) => {
   const key = isFile ? "modal_file" : "modal_folder";
   modals.messageModal({
+    messageType: VariantType.INFO,
+    size: ModalSize.MEDIUM,
     title: i18n.t(`explorer.trash.navigate.${key}.title`),
     children: (
       <div className="clr-greyscale-600">


### PR DESCRIPTION
## Summary
- Pass `messageType: VariantType.INFO` and `size: ModalSize.MEDIUM` to the
  trash navigate message modal so it renders with the expected styling.

## Test plan
- [ ] Navigate into a trashed file/folder and confirm the modal displays
      with the medium size and info variant.