### PR TITLE
🐛(front) fix "+ New" menu in read-only folders and virtual tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to
 - 🐛(front) set size and variant on trash navigate modal #666
 - 🐛(frontend) fix uploads continuing after parent folder deletion
 
+### Fixed
+
+- 🐛(frontend) fix "+ New" menu in read-only folders and virtual tabs
+
 ## [v0.16.0] - 2026-04-09
 
 ### Added

--- a/src/frontend/apps/drive/src/features/explorer/components/modals/ExplorerCreateFileModal.tsx
+++ b/src/frontend/apps/drive/src/features/explorer/components/modals/ExplorerCreateFileModal.tsx
@@ -8,6 +8,8 @@ import { useTranslation } from "react-i18next";
 import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
 import { RhfInput } from "@/features/forms/components/RhfInput";
 import { useMutationCreateFileFromTemplate } from "../../hooks/useMutations";
+import { useRouter } from "next/router";
+import { useGlobalExplorer } from "../GlobalExplorerContext";
 
 type Inputs = {
   filename: string;
@@ -33,12 +35,15 @@ const getExtension = (type: ExplorerCreateFileType) => {
 export const ExplorerCreateFileModal = (
   props: Pick<ModalProps, "isOpen" | "onClose"> & {
     parentId?: string;
+    redirectAfterCreate?: boolean;
     type: ExplorerCreateFileType;
   }
 ) => {
   const { t } = useTranslation();
   const form = useForm<Inputs>();
   const createFileFromTemplate = useMutationCreateFileFromTemplate();
+  const router = useRouter();
+  const { setSelectedItems } = useGlobalExplorer();
 
   const onSubmit: SubmitHandler<Inputs> = async (data) => {
     const extension = getExtension(props.type);
@@ -50,9 +55,13 @@ export const ExplorerCreateFileModal = (
         title: data.filename,
       },
       {
-        onSuccess: () => {
+        onSuccess: (createdItem) => {
           form.reset();
           props.onClose();
+          if (props.redirectAfterCreate && createdItem?.id) {
+            router.push(`/explorer/items/my-files`);
+            setSelectedItems([createdItem]);
+          }
         },
       }
     );

--- a/src/frontend/apps/drive/src/features/explorer/components/modals/ExplorerCreateFolderModal.tsx
+++ b/src/frontend/apps/drive/src/features/explorer/components/modals/ExplorerCreateFolderModal.tsx
@@ -9,6 +9,7 @@ import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
 import { RhfInput } from "@/features/forms/components/RhfInput";
 import { useMutationCreateFolder } from "../../hooks/useMutations";
 import { useRouter } from "next/router";
+import { useGlobalExplorer } from "../GlobalExplorerContext";
 
 type Inputs = {
   title: string;
@@ -16,6 +17,7 @@ type Inputs = {
 
 type ExplorerCreateFolderModalProps = Pick<ModalProps, "isOpen" | "onClose"> & {
   parentId?: string;
+  redirectAfterCreate?: boolean;
 };
 
 export const ExplorerCreateFolderModal = ({
@@ -25,6 +27,7 @@ export const ExplorerCreateFolderModal = ({
   const form = useForm<Inputs>();
   const createFolder = useMutationCreateFolder();
   const router = useRouter();
+  const { setSelectedItems } = useGlobalExplorer();
 
   const onSubmit: SubmitHandler<Inputs> = async (data) => {
     form.reset();
@@ -34,11 +37,12 @@ export const ExplorerCreateFolderModal = ({
         parentId: props.parentId,
       },
       {
-        onSuccess: () => {
+        onSuccess: (createdItem) => {
           form.reset();
           props.onClose();
-          if (!props.parentId) {
-            router.push(`/explorer/items/my-files`);
+          if (props.redirectAfterCreate && createdItem?.id) {
+            router.push(`/explorer/items/${createdItem.id}`);
+            setSelectedItems([createdItem]);
           }
         },
       },

--- a/src/frontend/apps/drive/src/features/explorer/hooks/useCreateMenuItems.tsx
+++ b/src/frontend/apps/drive/src/features/explorer/hooks/useCreateMenuItems.tsx
@@ -13,6 +13,8 @@ import {
 import { ExplorerCreateFolderModal } from "../components/modals/ExplorerCreateFolderModal";
 import { useModal } from "@gouvfr-lasuite/cunningham-react";
 import { useState } from "react";
+import { useRouter } from "next/router";
+import { isMyFilesRoute } from "@/utils/defaultRoutes";
 
 type UseCreateMenuItemsProps = {
   includeImport?: boolean;
@@ -38,8 +40,13 @@ export const useCreateMenuItems = ({
 }: UseCreateMenuItemsProps = {}): UseCreateMenuItemsReturn => {
   const { t } = useTranslation();
   const { item, itemId } = useGlobalExplorer();
-  const canCreateChildren = item ? item?.abilities?.children_create : true;
-  const isHidden = !canCreateChildren;
+  const router = useRouter();
+  const isOnMyFiles = isMyFilesRoute(router.pathname);
+  const canCreateHere = item?.abilities?.children_create ?? false;
+  const effectiveParentId = canCreateHere ? itemId : undefined;
+  // On "My files", the item is created without a parent, which already puts
+  // it in the current view — no redirect needed.
+  const shouldRedirectToCreated = !canCreateHere && !isOnMyFiles;
 
   const createFolderModal = useModal();
   const [createFileModalType, setCreateFileModalType] =
@@ -55,7 +62,6 @@ export const useCreateMenuItems = ({
     {
       icon: <img src={createFolderSvg.src} alt="" />,
       label: t("explorer.tree.create.folder"),
-      isHidden,
       callback: createFolderModal.open,
     },
     { type: "separator" },
@@ -66,7 +72,6 @@ export const useCreateMenuItems = ({
       {
         icon: <img src={uploadFileSvg.src} alt="" />,
         label: t("explorer.tree.import.files"),
-        isHidden,
         callback: () => {
           document.getElementById("import-files")?.click();
         },
@@ -74,7 +79,6 @@ export const useCreateMenuItems = ({
       {
         icon: <img src={uploadFolderSvg.src} alt="" />,
         label: t("explorer.tree.import.folders"),
-        isHidden,
         callback: () => {
           document.getElementById("import-folders")?.click();
         },
@@ -93,7 +97,6 @@ export const useCreateMenuItems = ({
             "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
         }),
         label: t("explorer.tree.create.file.doc"),
-        isHidden,
         callback: () => openCreateFileModal(ExplorerCreateFileType.DOC),
       },
       {
@@ -104,7 +107,6 @@ export const useCreateMenuItems = ({
             "application/vnd.openxmlformats-officedocument.presentationml.presentation",
         }),
         label: t("explorer.tree.create.file.powerpoint"),
-        isHidden,
         callback: () => openCreateFileModal(ExplorerCreateFileType.POWERPOINT),
       },
       {
@@ -115,7 +117,6 @@ export const useCreateMenuItems = ({
             "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
         }),
         label: t("explorer.tree.create.file.calc"),
-        isHidden,
         callback: () => openCreateFileModal(ExplorerCreateFileType.CALC),
       },
     );
@@ -123,10 +124,15 @@ export const useCreateMenuItems = ({
 
   const modals = (
     <>
-      <ExplorerCreateFolderModal {...createFolderModal} parentId={itemId} />
+      <ExplorerCreateFolderModal
+        {...createFolderModal}
+        parentId={effectiveParentId}
+        redirectAfterCreate={shouldRedirectToCreated}
+      />
       <ExplorerCreateFileModal
         {...createFileModal}
-        parentId={itemId}
+        parentId={effectiveParentId}
+        redirectAfterCreate={shouldRedirectToCreated}
         type={createFileModalType}
       />
     </>

--- a/src/frontend/apps/e2e/__tests__/app-drive/create-fallback-to-my-files.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-drive/create-fallback-to-my-files.spec.ts
@@ -1,0 +1,177 @@
+import test, {
+  test as base,
+  BrowserContext,
+  expect,
+  Page,
+} from "@playwright/test";
+import { clearDb, login } from "./utils-common";
+import {
+  clickToFavorites,
+  clickToMyFiles,
+  clickToRecent,
+  clickToSharedWithMe,
+  navigateToFolder,
+} from "./utils-navigate";
+import { createFolderInCurrentFolder } from "./utils-item";
+import { shareCurrentItemWithWebkitUser } from "./utils/share-utils";
+import { expectRowItem } from "./utils-embedded-grid";
+import { expectExplorerBreadcrumbs } from "./utils-explorer";
+
+type TwoUsers = {
+  userA: { context: BrowserContext; page: Page };
+  userB: { context: BrowserContext; page: Page };
+};
+
+const MultiUserTest = base.extend<TwoUsers>({
+  userA: async ({ browser }, use) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    await use({ context, page });
+    await context.close();
+  },
+
+  userB: async ({ browser }, use) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    await use({ context, page });
+    await context.close();
+  },
+});
+
+const READ_ONLY_FOLDER = "ReadOnly folder";
+
+const setupReadOnlyFolderSharedWithWebkitUser = async (
+  userA: Page,
+  userB: Page,
+) => {
+  await clearDb();
+  await login(userA, "drive@example.com");
+  await login(userB, "user@webkit.test");
+
+  await userA.goto("/");
+  await clickToMyFiles(userA);
+  await createFolderInCurrentFolder(userA, READ_ONLY_FOLDER);
+  await navigateToFolder(userA, READ_ONLY_FOLDER, [
+    "My files",
+    READ_ONLY_FOLDER,
+  ]);
+  await shareCurrentItemWithWebkitUser(userA, "Reader");
+};
+
+const navigateIntoReadOnlyFolder = async (page: Page) => {
+  await page.goto("/");
+  await clickToSharedWithMe(page);
+  await navigateToFolder(page, READ_ONLY_FOLDER, [
+    "Shared with me",
+    READ_ONLY_FOLDER,
+  ]);
+};
+
+const createViaNewMenu = async (
+  page: Page,
+  opts: { menuItem: string; inputLabel: string; name: string },
+) => {
+  await page.getByRole("button", { name: "New" }).click();
+  await page.getByRole("menuitem", { name: opts.menuItem }).click();
+  await page.getByRole("textbox", { name: opts.inputLabel }).fill(opts.name);
+  await page.getByRole("button", { name: "Create" }).click();
+};
+
+const createFolderViaNewMenu = (page: Page, folderName: string) =>
+  createViaNewMenu(page, {
+    menuItem: "New folder",
+    inputLabel: "Folder name",
+    name: folderName,
+  });
+
+const createDocumentViaNewMenu = (page: Page, fileName: string) =>
+  createViaNewMenu(page, {
+    menuItem: "New text document",
+    inputLabel: "File name",
+    name: fileName,
+  });
+
+MultiUserTest(
+  "+ New > Folder from a read-only folder falls back to My files",
+  async ({ userA, userB }) => {
+    await setupReadOnlyFolderSharedWithWebkitUser(userA.page, userB.page);
+
+    await navigateIntoReadOnlyFolder(userB.page);
+
+    // The + New menu must still be populated even though the folder is read-only
+    await createFolderViaNewMenu(userB.page, "Fallback folder");
+
+    // The folder is created in B's own My files, and we are redirected into it
+    await expectExplorerBreadcrumbs(userB.page, [
+      "My files",
+      "Fallback folder",
+    ]);
+    await expect(userB.page).toHaveURL(/\/explorer\/items\/[0-9a-f-]+$/);
+
+    // And it is visible in the My files listing
+    await clickToMyFiles(userB.page);
+    await expectRowItem(userB.page, "Fallback folder");
+  },
+);
+
+MultiUserTest(
+  "+ New > Document from a read-only folder falls back to the My files view",
+  async ({ userA, userB }) => {
+    await setupReadOnlyFolderSharedWithWebkitUser(userA.page, userB.page);
+
+    await navigateIntoReadOnlyFolder(userB.page);
+
+    await createDocumentViaNewMenu(userB.page, "Fallback doc");
+
+    // For a file we land on the My files view (the file itself is not navigable)
+    await expect(userB.page).toHaveURL(/\/explorer\/items\/my-files$/);
+    await expectExplorerBreadcrumbs(userB.page, ["My files"]);
+    await expectRowItem(userB.page, "Fallback doc");
+  },
+);
+
+const virtualTabs: Array<{
+  go: (page: Page) => Promise<void>;
+  label: string;
+}> = [
+  { go: clickToRecent, label: "Recent" },
+  { go: clickToSharedWithMe, label: "Shared" },
+  { go: clickToFavorites, label: "Starred" },
+];
+
+for (const { go, label } of virtualTabs) {
+  test(`+ New from ${label} tab creates in My files`, async ({ page }) => {
+    await clearDb();
+    await login(page, "drive@example.com");
+    await page.goto("/");
+    await go(page);
+
+    const folderName = `Tab folder ${label}`;
+    await createFolderViaNewMenu(page, folderName);
+
+    // Created in My files (no parent), and we are redirected into it
+    await expectExplorerBreadcrumbs(page, ["My files", folderName]);
+  });
+}
+
+test("+ New inside a writable folder still creates in place", async ({
+  page,
+}) => {
+  await clearDb();
+  await login(page, "drive@example.com");
+  await page.goto("/");
+  await clickToMyFiles(page);
+
+  await createFolderInCurrentFolder(page, "Writable parent");
+  await navigateToFolder(page, "Writable parent", [
+    "My files",
+    "Writable parent",
+  ]);
+
+  // Use the + New dropdown directly to make sure it also works in place
+  await createFolderViaNewMenu(page, "Child");
+
+  // Still inside the parent — no fallback redirect to My files
+  await expectExplorerBreadcrumbs(page, ["My files", "Writable parent"]);
+  await expectRowItem(page, "Child");
+});


### PR DESCRIPTION
## Summary

- Always populate the "+ New" dropdown, even when the current folder is
  read-only or we're on a virtual tab (Recent, My Files, Shared with me,
  Starred). Previously the popover was empty because every entry was
  hidden on `!children_create`.
- When the user cannot create in place, fall back to creating the item
  in **My Files** (no parent). After a fallback creation:
  - folder → redirect into the new folder
  - file → redirect to the My Files view (a file is not a navigable
    route), new file pre-selected in the listing
- Add Playwright e2e tests covering the four branches of the new
  behavior (folder + file fallback from a read-only shared folder,
  folder creation from virtual tabs, and a sanity check that writable
  folders still create in place).

Fixes #577.

## Test plan

- [ ] Open a folder shared with you as Reader, click **+ New → Folder**,
      check you land inside the new folder under My Files.
- [ ] Same folder, **+ New → Text document**, check you land on
      `/explorer/items/my-files` with the new doc listed.
- [ ] Repeat from the Recent / Shared with me / Starred tabs.
- [ ] In a folder you own, **+ New → Folder** still creates in place
      with no redirect.
- [ ] `cd src/frontend/apps/e2e && yarn test create-fallback-to-my-files.spec.ts`