### PR TITLE
🐛(backend) fix openapi schema for item access endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ and this project adheres to
 
 - 🐛(frontend) range selection freezes when there are many items in the list
 
+### Fixed
+
+- 🐛(backend) fix openapi schema for item access endpoints
+
 ## [v0.16.0] - 2026-04-09
 
 ### Added

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -29,6 +29,7 @@ from corsheaders.middleware import (
     ACCESS_CONTROL_ALLOW_METHODS,
     ACCESS_CONTROL_ALLOW_ORIGIN,
 )
+from drf_spectacular.utils import extend_schema, extend_schema_view
 from lasuite.drf.models.choices import (
     PRIVILEGED_ROLES,
     LinkReachChoices,
@@ -1638,6 +1639,17 @@ class ItemViewSet(
         return drf.response.Response(serializer.data, status=drf.status.HTTP_201_CREATED)
 
 
+# Declare the schema statically because `get_serializer_class` depends on
+# `self.item`, which reads `self.kwargs["resource_id"]` — unavailable during
+# drf-spectacular introspection. Without this, spectacular fails to resolve
+# the serializer and drops the requestBody for POST/PUT/PATCH operations.
+@extend_schema(
+    request=serializers.ItemAccessSerializer,
+    responses=serializers.ItemAccessSerializer,
+)
+@extend_schema_view(
+    list=extend_schema(responses=serializers.ItemAccessSerializer(many=True)),
+)
 class ItemAccessViewSet(
     drf.mixins.CreateModelMixin,
     drf.mixins.DestroyModelMixin,
@@ -1669,6 +1681,9 @@ class ItemAccessViewSet(
     """
 
     lookup_field = "pk"
+    # Forcing to None makes sure the OpenApi schema does not infer that the
+    # list endpoint supports pagination.
+    pagination_class = None
     permission_classes = [permissions.ItemAccessPermission]
     queryset = models.ItemAccess.objects.select_related("user", "item").all()
     resource_field_name = "item"


### PR DESCRIPTION
The openAPI schema is broken on accesses viewset, this cause issue for users using TS generated API types.

- `ItemAccessViewSet.get_serializer_class` relies on `self.item`, which reads `self.kwargs["resource_id"]`. That key is unavailable during drf-spectacular introspection, so spectacular could not resolve the serializer and dropped the `requestBody` from the generated schema for POST/PUT/PATCH operations on item access endpoints.
- Declare the schema statically with `@extend_schema` and `@extend_schema_view` so the generated OpenAPI exposes the correct request and response payloads.

This is was working before v0.13.0, broken since the refactor of accesses viewset. 