### PR TITLE
✨(backend) make invitation validity duration configurable via env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Added
 
+- ✨(backend) make invitation validity duration configurable via env var
 - ✨(frontend) enhance upload toast with progress, errors and cancel support
 - ✨(frontend) add ErrorIcon component and support numeric icon sizes
 - ✨(frontend) make file upload abortable in driver layer

--- a/docs/env.md
+++ b/docs/env.md
@@ -67,6 +67,7 @@ This document lists all configurable environment variables for the Drive applica
 | `FRONTEND_FEEDBACK_MESSAGES_WIDGET_PATH` | Path for feedback messages widget | `None` |
 | `FRONTEND_RELEASE_NOTE_ENABLED` | Enable release notes modal on connexion | `True` |
 | `ITEM_FILE_MAX_SIZE` | Maximum file size for uploads in bytes | `5368709120` (5GB) |
+| `INVITATION_VALIDITY_DURATION` | Duration during which an invitation remains valid, in seconds | `604800` (7 days) |
 | `LANGUAGE_CODE` | Default language code | `en-us` |
 | `LOGIN_REDIRECT_URL` | URL to redirect after successful login | `None` |
 | `LOGIN_REDIRECT_URL_FAILURE` | URL to redirect after failed login | `None` |

--- a/src/backend/core/tests/test_models_invitations.py
+++ b/src/backend/core/tests/test_models_invitations.py
@@ -78,6 +78,25 @@ def test_models_invitations_is_expired():
         assert expired_invitation.is_expired is True
 
 
+def test_models_invitations_is_expired_custom_duration(settings):
+    """
+    The 'is_expired' property should honor the INVITATION_VALIDITY_DURATION setting,
+    which is configurable via env var.
+    """
+    settings.INVITATION_VALIDITY_DURATION = 60  # 1 minute
+
+    invitation = factories.InvitationFactory()
+    assert invitation.is_expired is False
+
+    not_late = timezone.now() + timedelta(seconds=59)
+    with mock.patch("django.utils.timezone.now", return_value=not_late):
+        assert invitation.is_expired is False
+
+    too_late = timezone.now() + timedelta(seconds=60)
+    with mock.patch("django.utils.timezone.now", return_value=too_late):
+        assert invitation.is_expired is True
+
+
 def test_models_invitationd_new_userd_convert_invitations_to_accesses():
     """
     Upon creating a new user, invitations linked to the email

--- a/src/backend/drive/settings.py
+++ b/src/backend/drive/settings.py
@@ -1005,7 +1005,9 @@ class Base(Configuration):
     EMAIL_FROM = values.Value("from@example.com")
 
     AUTH_USER_MODEL = "core.User"
-    INVITATION_VALIDITY_DURATION = 604800  # 7 days, in seconds
+    INVITATION_VALIDITY_DURATION = values.PositiveIntegerValue(
+        604800, environ_name="INVITATION_VALIDITY_DURATION", environ_prefix=None
+    )  # 7 days, in seconds
 
     # CORS
     CORS_ALLOW_CREDENTIALS = True


### PR DESCRIPTION
People using Drive, from Mon Espace Collectivite were facing invitation expiration too early for their process. By making this setting configurable, we let consumers decide their expiration period.

- Expose `INVITATION_VALIDITY_DURATION` as an environment variable instead of a hardcoded 7-day constant, so operators can tune invitation lifetime per deployment.
- Add a test asserting `Invitation.is_expired` honors the configured duration.

Default behavior is unchanged (604800 seconds / 7 days).