### PR TITLE
🐛(frontend) fix SDK picker link reach promotion

### DIFF
--- a/.github/workflows/drive-frontend.yml
+++ b/.github/workflows/drive-frontend.yml
@@ -161,6 +161,17 @@ jobs:
           cd src/frontend/apps/e2e
           npx playwright install-deps ${{ matrix.browser }}
 
+      - name: Build the drive SDK
+        run: |
+          cd src/frontend/packages/sdk
+          yarn build
+
+      - name: Start sdk-consumer dev server
+        run: |
+          cd src/frontend/apps/sdk-consumer
+          nohup yarn dev > /tmp/sdk-consumer.log 2>&1 &
+          echo "sdk-consumer PID $!"
+
       - name: Download frontend bundle
         uses: actions/download-artifact@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to
 - 🐛(frontend) Responsive broken with long filters in search #659
 - 🐛(front) set size and variant on trash navigate modal #666
 - 🐛(frontend) fix uploads continuing after parent folder deletion
+- 🐛(frontend) fix SDK picker link reach promotion
 
 ### Fixed
 

--- a/src/frontend/apps/drive/src/features/i18n/translations.json
+++ b/src/frontend/apps/drive/src/features/i18n/translations.json
@@ -544,6 +544,7 @@
       },
       "sdk": {
         "explorer": {
+          "cancel": "Cancel",
           "choose": "Choose",
           "picker_label_zero": "No files selected",
           "picker_label_one": "{{count}} file selected",
@@ -1755,6 +1756,7 @@
       "sdk": {
         "explorer": {
           "choose": "Kiezen",
+          "cancel": "Annuleren",
           "picker_label_zero": "Geen bestanden geselecteerd",
           "picker_label_one": "{{count}} bestand geselecteerd",
           "picker_label_other": "{{count}} bestanden geselecteerd",

--- a/src/frontend/apps/drive/src/features/sdk/SdkPickerFooter.tsx
+++ b/src/frontend/apps/drive/src/features/sdk/SdkPickerFooter.tsx
@@ -1,10 +1,10 @@
 import { useTranslation } from "react-i18next";
-import { getDriver } from "../config/Config";
 import { useEffect, useRef, useState } from "react";
-import { Item, LinkReach, LinkRole } from "../drivers/types";
+import { Item, LinkReach } from "../drivers/types";
 import { Button } from "@gouvfr-lasuite/cunningham-react";
 import { Spinner } from "@gouvfr-lasuite/ui-kit";
 import { ClientMessageType, SDKRelayManager } from "./SdkRelayManager";
+import { useMutationUpdateLinkConfiguration } from "../explorer/hooks/useMutations";
 
 export const PickerFooter = ({
   token,
@@ -15,20 +15,33 @@ export const PickerFooter = ({
 }) => {
   const { t } = useTranslation();
 
-  const driver = getDriver();
-
   const [waitForClosing, setWaitForClosing] = useState(false);
   const hasSentItemsSelected = useRef(false);
+
+  const updateLinkConfiguration = useMutationUpdateLinkConfiguration();
 
   const onChoose = async () => {
     const promises = selectedItems.map((item) => {
       if (item.link_reach === LinkReach.PUBLIC) {
         return Promise.resolve();
       }
-      return driver.updateItem({
-        id: item.id,
-        link_reach: LinkReach.PUBLIC,
-        link_role: LinkRole.READER,
+
+      return new Promise<void>((resolve, reject) => {
+        updateLinkConfiguration.mutate(
+          {
+            itemId: item.id,
+            link_reach: LinkReach.PUBLIC,
+            link_role: item.link_role,
+          },
+          {
+            onSuccess: () => {
+              resolve();
+            },
+            onError: (error) => {
+              reject(error);
+            },
+          },
+        );
       });
     });
 

--- a/src/frontend/apps/e2e/__tests__/sdk-consumer/picker.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/sdk-consumer/picker.spec.ts
@@ -1,0 +1,148 @@
+import test, { expect } from "@playwright/test";
+import path from "path";
+import { clearDb, login } from "../app-drive/utils-common";
+import { clickToMyFiles } from "../app-drive/utils-navigate";
+import { uploadFile } from "../app-drive/utils/upload-utils";
+
+const PDF_FILE_PATH = path.join(__dirname, "../app-drive/assets/pv_cm.pdf");
+
+const SDK_CONSUMER_URL = "http://localhost:5173/";
+
+test.describe("SDK file picker", () => {
+  test.beforeEach(async () => {
+    await clearDb();
+  });
+
+  test("cancel the picker, consumer shows cancelled and file stays private", async ({
+    page,
+  }) => {
+    // 1. Log in and upload a file in the drive app.
+    await login(page, "drive@example.com");
+    await page.goto("/");
+    await clickToMyFiles(page);
+    await expect(page.getByText("This tab is empty")).toBeVisible();
+
+    await uploadFile(page, PDF_FILE_PATH);
+    await expect(
+      page.getByRole("cell", { name: "pv_cm", exact: true }),
+    ).toBeVisible({ timeout: 15000 });
+
+    // 2. Go to the SDK consumer app and open the picker.
+    await page.goto(SDK_CONSUMER_URL);
+    const popupPromise = page.waitForEvent("popup");
+    await page.getByRole("button", { name: "Open picker" }).click();
+    const picker = await popupPromise;
+    await picker.waitForLoadState("domcontentloaded");
+
+    // 3. Select the file, then cancel instead of confirming — this proves
+    // cancel aborts even an in-progress selection.
+    const fileRow = picker.locator("tr", { hasText: "pv_cm" });
+    await expect(fileRow).toBeVisible({ timeout: 15000 });
+    await fileRow.click();
+
+    const cancelButton = picker.getByRole("button", {
+      name: "Cancel",
+      exact: true,
+    });
+    await expect(cancelButton).toBeEnabled();
+    await cancelButton.click();
+
+    await picker.waitForEvent("close");
+
+    // 4. Consumer shows the cancelled state, not the selection list.
+    await expect(
+      page.getByRole("heading", { name: "Cancelled :(" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Selected items:" }),
+    ).not.toBeVisible();
+
+    // 5. The item's link_reach must NOT have been promoted to public by
+    // a cancel — fetch it via the authenticated search endpoint (the
+    // root items list only returns top-level workspaces).
+    const searchRes = await page.request.get(
+      "http://localhost:8071/api/v1.0/items/search/?q=pv_cm",
+    );
+    expect(searchRes.ok()).toBeTruthy();
+    const body = await searchRes.json();
+    const items = Array.isArray(body) ? body : body.results;
+    const uploaded = items.find(
+      (it: { title: string }) => it.title === "pv_cm.pdf",
+    );
+    expect(uploaded, "uploaded file not returned by search").toBeTruthy();
+    expect(uploaded.link_reach).not.toBe("public");
+  });
+
+  test("pick a file, see it selected, and its URL is publicly reachable", async ({
+    page,
+    browser,
+  }) => {
+    // 1. Log in and upload a file in the drive app.
+    await login(page, "drive@example.com");
+    await page.goto("/");
+    await clickToMyFiles(page);
+    await expect(page.getByText("This tab is empty")).toBeVisible();
+
+    await uploadFile(page, PDF_FILE_PATH);
+    await expect(
+      page.getByRole("cell", { name: "pv_cm", exact: true }),
+    ).toBeVisible({ timeout: 15000 });
+
+    // 2. Go to the SDK consumer app.
+    await page.goto(SDK_CONSUMER_URL);
+    await expect(
+      page.getByRole("button", { name: "Open picker" }),
+    ).toBeVisible();
+
+    // 3. Click "Open picker" and capture the popup.
+    const popupPromise = page.waitForEvent("popup");
+    await page.getByRole("button", { name: "Open picker" }).click();
+    const picker = await popupPromise;
+    await picker.waitForLoadState("domcontentloaded");
+
+    // 4. Select the file in the picker and confirm.
+    const fileRow = picker.locator("tr", { hasText: "pv_cm" });
+    await expect(fileRow).toBeVisible({ timeout: 15000 });
+    await fileRow.click();
+
+    const chooseButton = picker.getByRole("button", {
+      name: "Choose",
+      exact: true,
+    });
+    await expect(chooseButton).toBeEnabled();
+    await chooseButton.click();
+
+    // Popup closes itself after the selection event is sent.
+    await picker.waitForEvent("close");
+
+    // 5. Consumer displays "Selected items:" with the picked file.
+    await expect(
+      page.getByRole("heading", { name: "Selected items:" }),
+    ).toBeVisible();
+
+    const selectedLink = page.locator("ul a", { hasText: /./ }).first();
+    await expect(selectedLink).toBeVisible();
+    const publicUrl = await selectedLink.getAttribute("href");
+    expect(publicUrl).toBeTruthy();
+
+    await expect(page.getByText("pv_cm.pdf")).toBeVisible();
+
+    // 6. The URL must be reachable in a fresh context (no auth cookies).
+    // We open it in a real page so the step is visible in headed mode.
+    // The backend serves it with Content-Disposition: attachment, so goto
+    // rejects with "Download is starting" — we instead wait for the
+    // download event, which only fires when the file actually streams.
+    const anonContext = await browser.newContext();
+    try {
+      const anonPage = await anonContext.newPage();
+      const downloadPromise = anonPage.waitForEvent("download");
+      await anonPage.goto(publicUrl!).catch(() => {
+        // Expected: navigation aborts because the response is a download.
+      });
+      const download = await downloadPromise;
+      expect(download.suggestedFilename()).toMatch(/pv_cm/);
+    } finally {
+      await anonContext.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Swap the direct `driver.updateItem` call in the SDK picker footer for the shared `useMutationUpdateLinkConfiguration` hook so the query cache is invalidated after the update.
- Preserve the item's existing `link_role` when promoting `link_reach` to `PUBLIC`, instead of force-downgrading to `READER`.
- Add the missing `sdk.explorer.cancel` translations for `en` and `nl`, and add e2e coverage for the cancel + confirm flows (including a public-reachability check of the returned URL).