### PR TITLE
Security: E2E authentication endpoint allows unauthenticated account takeover when enabled

### DIFF
--- a/src/backend/e2e/viewsets.py
+++ b/src/backend/e2e/viewsets.py
@@ -1,10 +1,12 @@
 """Viewsets for the e2e app."""
 
+from django.conf import settings
 from django.contrib.auth import login
 
 import rest_framework as drf
 from rest_framework import response as drf_response
 from rest_framework import status
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.permissions import AllowAny
 
 from core import models
@@ -23,6 +25,9 @@ class UserAuthViewSet(drf.viewsets.ViewSet):
         POST /api/v1.0/e2e/user-auth/
         Create a user with the given email if it doesn't exist and log them in
         """
+        if not (settings.DEBUG or getattr(settings, "TESTING", False)):
+            raise PermissionDenied()
+
         serializer = E2EAuthSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 


### PR DESCRIPTION
## Summary

Security: E2E authentication endpoint allows unauthenticated account takeover when enabled

## Problem

**Severity**: `High` | **File**: `src/backend/e2e/viewsets.py:L16`

The E2E `UserAuthViewSet` is exposed with `AllowAny` and no authentication classes, and it logs in (or creates) any user based only on a submitted email address. If `LOAD_E2E_URLS` is enabled outside isolated test environments, an attacker can authenticate as arbitrary users by knowing their email.

## Solution

Restrict this endpoint to test-only environments (e.g., enforce `DEBUG`/`TESTING` checks), require a strong shared secret or mTLS/IP allowlist, and fail hard at startup if `LOAD_E2E_URLS` is enabled in production.

## Changes

- `src/backend/e2e/viewsets.py` (modified)