### PR TITLE
🚨(backend) fix is_active in SearchIndexer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to
 
 - 🔥(backend) remove mirroring feature
 
+### Fixed
+
+- 🐛(backend) fix indexing payload is_active and reach
+
 ## [v0.17.0] - 2026-04-23
 
 ### Added
@@ -36,7 +40,6 @@ and this project adheres to
 - 🐛(frontend) range selection freezes when there are many items in the list
 - 🐛(backend) fix openapi schema for item access endpoints
 - 🐛(backend) load jwks url when OIDC_RS_PRIVATE_KEY_STR is set
-
 
 ## [v0.16.0] - 2026-04-09
 

--- a/src/backend/core/services/search_indexers.py
+++ b/src/backend/core/services/search_indexers.py
@@ -305,14 +305,14 @@ class SearchIndexer(BaseItemIndexer):
 
         # The deleted items are still accessible in Drive (not in Docs !)
         # See in V2 for handling hard deleted ones
-        is_active = True
+        is_active = item.deleted_at is None and item.ancestors_deleted_at is None
 
         # There is no endpoint in Find API for inactive items so we index it
         # again with an empty content.
         if is_active and self.can_serialize_content(item):
             content = self.to_text(item)
 
-        return {
+        payload = {
             "id": str(item.id),
             "title": item.title or "",
             "mimetype": item.mimetype or "",
@@ -325,10 +325,14 @@ class SearchIndexer(BaseItemIndexer):
             "updated_at": item.updated_at.isoformat(),
             "users": list(accesses.get(doc_path, {}).get("users", set())),
             "groups": list(accesses.get(doc_path, {}).get("teams", set())),
-            "reach": str(item.link_reach),
             "size": item.size or 0,
             "is_active": is_active,
         }
+
+        if item.link_reach:
+            payload["reach"] = str(item.link_reach)
+
+        return payload
 
     # pylint: disable-next=too-many-arguments,too-many-positional-arguments
     def search(self, text, token, visited=(), nb_results=None):

--- a/src/backend/core/tests/test_services_search_indexers.py
+++ b/src/backend/core/tests/test_services_search_indexers.py
@@ -454,7 +454,7 @@ def test_services_search_indexers_serialize_document_soft_deleted():
     result = indexer.serialize_item(item, {})
 
     # Still accessible through the thrashbin
-    assert result["is_active"] is True
+    assert result["is_active"] is False
     assert result["content"] == "This is a text file content"
 
 


### PR DESCRIPTION
i explored this bug

"""
Problematic behavior
When adding new files or deleting files, search indexer API is called with lists of files.
Some files are missing in that lists. Some files appear twice in that lists.

Expected behavior/code
All files added or deleted should appear in the lists sent to the API, so all files added are indexed, and all files deleted are removed from the index.

Steps to Reproduce
0. Prerequisite : replace Search Indexer URL with an API that catchs all calls and logs the payloads

Create a folder in drive
Access this folder
Drag & drop 6 files in that folder
Bug appears : only 5 files are in the lists sent to the SEARCH INDEXER API
Delete 4 files in the folder
Bug appears : only 3 files are in the lists sent to the SEARCH INDEXER API
Environment

Drive version: dev (built from source)
Commit: <hash>
Deployment: Docker Compose (dev stack)
"""

i don't reproduce the bug. i never observe a missing file. but i observe several indexing calls are sent when uploading 6 files. each call contain a a sub-set of all files. some of them are indexed several times because an item objects is saved several times when uploading a file and indexing is triggered with a post save signal.

this is solving 2 related bugs
- is_active is already True. it does not take deleted_at into account. -> fix logic
- item.reach can be None but Find accepts no reach but not a reach of None. -> remove the reach if None.

