### PR TITLE
🐛(backend) accept CDFV2 mimetype from newer libmagic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to
 - ✨(frontend) add entitlement disclaimer modal
 - ✨(frontend) render PDF previews at per-page dimensions
 
+### Fixed
+
+- 🐛(backend) accept CDFV2 mimetype from newer libmagic
+
 ### Removed
 
 - 🔥(backend) remove mirroring feature
@@ -43,7 +47,6 @@ and this project adheres to
 - 🐛(frontend) range selection freezes when there are many items in the list
 - 🐛(backend) fix openapi schema for item access endpoints
 - 🐛(backend) load jwks url when OIDC_RS_PRIVATE_KEY_STR is set
-
 
 ## [v0.16.0] - 2026-04-09
 

--- a/src/backend/core/api/utils.py
+++ b/src/backend/core/api/utils.py
@@ -204,7 +204,8 @@ def detect_mimetype(file_buffer: bytes, filename: str | None = None) -> str:
     # Generic/unreliable MIME types that we should try to improve
     generic_types = {
         "application/octet-stream",
-        "application/x-ole-storage",  # used by .xls, .doc and .ppt
+        "application/x-ole-storage",  # used by .xls, .doc and .ppt (older libmagic)
+        "application/CDFV2",  # used by .xls, .doc and .ppt (newer libmagic)
         "application/zip",
         "text/plain",
     }

--- a/src/backend/core/tests/test_api_utils_detect_mimetype.py
+++ b/src/backend/core/tests/test_api_utils_detect_mimetype.py
@@ -1,5 +1,7 @@
 """Test utils.detect_mimetype"""
 
+import magic
+
 from core.api import utils
 
 
@@ -156,3 +158,17 @@ def test_detect_mimetype_ole_storage():
     mimetype = utils.detect_mimetype(xls_ole_content, filename="document.xls")
 
     assert mimetype == "application/vnd.ms-excel"
+
+
+def test_detect_mimetype_cdfv2(monkeypatch):
+    """
+    Newer libmagic versions (e.g. on Scalingo's Ubuntu runtime) return
+    application/CDFV2 instead of application/x-ole-storage for the OLE2
+    compound-document container used by legacy .doc/.xls/.ppt. The function
+    should treat it as generic and fall back to extension-based detection.
+    """
+    monkeypatch.setattr(magic.Magic, "from_buffer", lambda self, buf: "application/CDFV2")
+
+    mimetype = utils.detect_mimetype(b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1", filename="doclegacy.doc")
+
+    assert mimetype == "application/msword"


### PR DESCRIPTION
Scalingo's Ubuntu runtime ships a newer libmagic that returns application/CDFV2 for legacy .doc/.xls/.ppt files, where Alpine's older libmagic (used in our Docker image) returns the older label application/x-ole-storage. Both describe the same OLE2 / Composite Document File V2 container.

detect_mimetype() already treats application/x-ole-storage as a generic content-detection result and falls back to extension-based detection (yielding application/msword, application/vnd.ms-excel, etc.). Without the same handling for CDFV2, legacy .doc uploads on Scalingo are rejected by the mimetype allow-list with "mimetype not allowed application/CDFV2 for filename ...".
