### PR TITLE
✨ Track column type change and item duplicate posthog events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to
 - ✨(backend) add entitlements context and can_upload reason
 - ✨(frontend) add entitlement disclaimer modal
 - ✨(frontend) render PDF previews at per-page dimensions
+- ✨(tracking) add posthog events on custom columns and item duplication
 
 ### Fixed
 

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -1641,6 +1641,8 @@ class ItemViewSet(
             duplicated_item_id=duplicated_item.id,
         )
 
+        posthog_capture("item_duplicate", user, {}, item=duplicated_item)
+
         serializer = self.get_serializer(duplicated_item)
         return drf.response.Response(serializer.data, status=drf.status.HTTP_201_CREATED)
 

--- a/src/backend/core/tests/items/test_api_items_duplicate.py
+++ b/src/backend/core/tests/items/test_api_items_duplicate.py
@@ -407,3 +407,33 @@ def test_api_items_duplicate_deleted_item():
     response = client.post(f"/api/v1.0/items/{item.id!s}/duplicate/")
 
     assert response.status_code == 403
+
+
+# Posthog events
+
+
+def test_api_items_duplicate_posthog_event(settings):
+    """Duplicating an item should send an 'item_duplicate' event."""
+    settings.POSTHOG_KEY = "fake-key"
+    user = factories.UserFactory()
+    client = APIClient()
+    client.force_login(user)
+
+    item = factories.ItemFactory(
+        type=models.ItemTypeChoices.FILE,
+        update_upload_state=models.ItemUploadStateChoices.READY,
+        mimetype="text/plain",
+        filename="myfile.txt",
+        users=[(user, "owner")],
+    )
+
+    with (
+        mock.patch("core.tasks.item.duplicate_file.delay"),
+        mock.patch("core.api.viewsets.posthog_capture") as mock_capture,
+    ):
+        response = client.post(f"/api/v1.0/items/{item.id!s}/duplicate/")
+
+    assert response.status_code == 201
+
+    duplicated_item = models.Item.objects.get(id=response.json()["id"])
+    mock_capture.assert_called_once_with("item_duplicate", user, {}, item=duplicated_item)

--- a/src/frontend/apps/drive/src/features/explorer/components/embedded-explorer/EmbeddedExplorerGrid.tsx
+++ b/src/frontend/apps/drive/src/features/explorer/components/embedded-explorer/EmbeddedExplorerGrid.tsx
@@ -9,11 +9,7 @@ import {
 } from "react";
 import { useSelectionStore } from "@/features/explorer/stores/selectionStore";
 import { useTranslation } from "react-i18next";
-import {
-  CellContext,
-  createColumnHelper,
-  Row,
-} from "@tanstack/react-table";
+import { CellContext, createColumnHelper, Row } from "@tanstack/react-table";
 import { useReactTable } from "@tanstack/react-table";
 import { getCoreRowModel } from "@tanstack/react-table";
 import { AppExplorerProps } from "@/features/explorer/components/app-view/AppExplorer";
@@ -47,6 +43,9 @@ import { ColumnHeader } from "./headers/ColumnHeader";
 import { CustomizableColumnHeader } from "./headers/CustomizableColumnHeader";
 import { useDuplicatingItemsPoller } from "../../hooks/useDuplicatingItemsPoller";
 import { EmbeddedExplorerGridRow } from "./EmbeddedExplorerGridRow";
+import posthog from "posthog-js";
+
+const POSTHOG_EVENT_COLUMN_TYPE_CHANGED = "column_type_changed";
 
 export type EmbeddedExplorerGridProps = {
   isCompact?: boolean;
@@ -200,13 +199,27 @@ export const EmbeddedExplorerGrid = (props: EmbeddedExplorerGridProps) => {
   );
 
   const handleChangeCol1 = useCallback(
-    (type: ColumnType) => props.onChangeColumn?.("column1", type),
-    [props.onChangeColumn],
+    (type: ColumnType) => {
+      posthog.capture(POSTHOG_EVENT_COLUMN_TYPE_CHANGED, {
+        slot: "column1",
+        new_type: type,
+        previous_type: props.prefs?.column1,
+      });
+      props.onChangeColumn?.("column1", type);
+    },
+    [props.onChangeColumn, props.prefs?.column1],
   );
 
   const handleChangeCol2 = useCallback(
-    (type: ColumnType) => props.onChangeColumn?.("column2", type),
-    [props.onChangeColumn],
+    (type: ColumnType) => {
+      posthog.capture(POSTHOG_EVENT_COLUMN_TYPE_CHANGED, {
+        slot: "column2",
+        new_type: type,
+        previous_type: props.prefs?.column2,
+      });
+      props.onChangeColumn?.("column2", type);
+    },
+    [props.onChangeColumn, props.prefs?.column2],
   );
 
   const contextValue = useMemo<EmbeddedExplorerGridContextType>(
@@ -353,12 +366,7 @@ export const EmbeddedExplorerGrid = (props: EmbeddedExplorerGridProps) => {
         items: getItemActionMenuItems(row.original),
       });
     },
-    [
-      props.displayMode,
-      selectionStore,
-      contextMenu,
-      getItemActionMenuItems,
-    ],
+    [props.displayMode, selectionStore, contextMenu, getItemActionMenuItems],
   );
 
   const handleRowOver = useCallback(

--- a/src/frontend/apps/e2e/__tests__/app-drive/custom-columns.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-drive/custom-columns.spec.ts
@@ -16,6 +16,7 @@ import {
   getCellText,
   getColumnHeader,
 } from "./utils/custom-columns-utils";
+import { setupPosthogEventCapture } from "./utils/posthog-utils";
 
 const PDF_FILE_PATH = path.join(__dirname, "/assets/pv_cm.pdf");
 const DOCX_FILE_PATH = path.join(__dirname, "/assets/empty_doc.docx");
@@ -336,5 +337,28 @@ test.describe("Custom columns", () => {
     await expect(
       page.getByRole("menuitem", { name: "Created by (default)" }),
     ).toBeVisible();
+  });
+});
+
+test.describe("Custom columns analytics", () => {
+  test("Changing column type sends posthog event with slot", async ({
+    page,
+  }) => {
+    await clearDb();
+    const { expectEventSentWithProps } = await setupPosthogEventCapture(page);
+    await login(page, "drive@example.com");
+    await page.goto("/");
+    await clickToMyFiles(page);
+    await createFolderInCurrentFolder(page, "MyFolder");
+
+    await changeColumnType(page, 1, "File size");
+    await expectEventSentWithProps("column_type_changed", {
+      slot: "column1",
+    });
+
+    await changeColumnType(page, 2, "File type");
+    await expectEventSentWithProps("column_type_changed", {
+      slot: "column2",
+    });
   });
 });

--- a/src/frontend/apps/e2e/__tests__/app-drive/utils/posthog-utils.ts
+++ b/src/frontend/apps/e2e/__tests__/app-drive/utils/posthog-utils.ts
@@ -2,6 +2,11 @@ import { expect, Page } from "@playwright/test";
 
 const FAKE_POSTHOG_HOST = "http://fake-ph.test";
 
+type CapturedEvent = {
+  event: string;
+  properties: Record<string, unknown>;
+};
+
 /**
  * Intercepts the config API to enable PostHog with a fake key and
  * captures all PostHog events sent by the page.
@@ -9,12 +14,14 @@ const FAKE_POSTHOG_HOST = "http://fake-ph.test";
  * Must be called **before** any page navigation (e.g. before `page.goto`).
  *
  * @returns An object with:
- *  - `events`: the live array of captured event names
- *  - `expectEventSent(name, timeout?)`: assertion helper that polls
- *     until the given event appears
+ *  - `events`: the live array of captured events with their properties
+ *  - `expectEventSent(name, timeout?)`: polls until the given event name appears
+ *  - `expectEventSentWithProps(name, props, timeout?)`: polls until at least
+ *     one captured event matches the name AND has every entry in `props`
+ *     as a strict equality match
  */
 export const setupPosthogEventCapture = async (page: Page) => {
-  const events: string[] = [];
+  const events: CapturedEvent[] = [];
 
   await page.route("**/api/v1.0/config/**", async (route) => {
     const response = await route.fetch();
@@ -28,7 +35,10 @@ export const setupPosthogEventCapture = async (page: Page) => {
     try {
       const postData = JSON.parse(route.request().postData() ?? "{}");
       if (postData.event) {
-        events.push(postData.event);
+        events.push({
+          event: postData.event,
+          properties: postData.properties ?? {},
+        });
       }
     } catch {
       // ignore non-JSON requests (e.g. /decide)
@@ -42,9 +52,29 @@ export const setupPosthogEventCapture = async (page: Page) => {
 
   const expectEventSent = async (eventName: string, timeout = 5000) => {
     await expect
-      .poll(() => events.includes(eventName), { timeout })
+      .poll(() => events.some((e) => e.event === eventName), { timeout })
       .toBe(true);
   };
 
-  return { events, expectEventSent };
+  const expectEventSentWithProps = async (
+    eventName: string,
+    expectedProps: Record<string, unknown>,
+    timeout = 5000,
+  ) => {
+    await expect
+      .poll(
+        () =>
+          events.some(
+            (e) =>
+              e.event === eventName &&
+              Object.entries(expectedProps).every(
+                ([k, v]) => e.properties[k] === v,
+              ),
+          ),
+        { timeout },
+      )
+      .toBe(true);
+  };
+
+  return { events, expectEventSent, expectEventSentWithProps };
 };


### PR DESCRIPTION
Adds two new product analytics events and the e2e plumbing to verify them:

- `column_type_changed` (frontend) — fired when a user switches one of the customizable explorer columns.
- `item_duplicate` (backend) — fired on item duplication request.
