### PR TITLE
🐛(backend) better transaction management on duplicate action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to
 ### Fixed
 
 - 🐛(backend) accept CDFV2 mimetype from newer libmagic
+- 🐛(backend) better transaction management on duplicate action
 
 ### Removed
 

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -1596,7 +1596,6 @@ class ItemViewSet(
         methods=["post"],
         url_path="duplicate",
     )
-    @transaction.atomic
     def duplicate(self, request, *args, **kwargs):
         """
         Duplicate an item of type File. The item is duplicated in the folder where the original
@@ -1613,28 +1612,28 @@ class ItemViewSet(
             # If the user as reader role on the parent folder, then the duplicated
             # item must be created at the user's root
             parent = None
-
-        duplicated_item = models.Item.objects.create_child(
-            creator=user,
-            link_reach=None if parent else LinkReachChoices.RESTRICTED,
-            parent=parent,
-            title=capfirst(
-                _("copy of {title}").format(title=item_to_duplicate.title)
-            ),  # Title uniqueness is managed in the create_child method
-            type=models.ItemTypeChoices.FILE,
-            size=item_to_duplicate.size,
-            upload_state=models.ItemUploadStateChoices.DUPLICATING,
-            mimetype=item_to_duplicate.mimetype,
-            filename=item_to_duplicate.filename,
-            description=item_to_duplicate.description,
-        )
-
-        if duplicated_item.is_root:
-            models.ItemAccess.objects.create(
-                item=duplicated_item,
-                user=user,
-                role=models.RoleChoices.OWNER,
+        with transaction.atomic():
+            duplicated_item = models.Item.objects.create_child(
+                creator=user,
+                link_reach=None if parent else LinkReachChoices.RESTRICTED,
+                parent=parent,
+                title=capfirst(
+                    _("copy of {title}").format(title=item_to_duplicate.title)
+                ),  # Title uniqueness is managed in the create_child method
+                type=models.ItemTypeChoices.FILE,
+                size=item_to_duplicate.size,
+                upload_state=models.ItemUploadStateChoices.DUPLICATING,
+                mimetype=item_to_duplicate.mimetype,
+                filename=item_to_duplicate.filename,
+                description=item_to_duplicate.description,
             )
+
+            if duplicated_item.is_root:
+                models.ItemAccess.objects.create(
+                    item=duplicated_item,
+                    user=user,
+                    role=models.RoleChoices.OWNER,
+                )
 
         # Then duplicate the file in async way
         duplicate_file.delay(


### PR DESCRIPTION
## Purpose

On the duplicate action we are using the decorator @transaction.atomic to be sure that the duplicated item and its accesses are correctly created. The problem with that is that the celery task doing the file duplication on the object storage can be executed before the transaction is commited leading to an error saying that the duplicated_item does not exists.

## Proposal

Description...

- [x] 🐛(backend) better transaction management on duplicate action
