### PR TITLE
🔊(backend) log wopi max expected file size in get_file_content action

### DIFF
--- a/docker/onlyoffice/local-development.json
+++ b/docker/onlyoffice/local-development.json
@@ -1,17 +1,22 @@
 {
-    "wopi": {
-        "enable": true,
-        "host": "http://localhost:9981",
-        "pdfView": [],
-		"pdfEdit": [],
-		"forms": [],
-		"wordView": [],
-		"wordEdit": ["docx", "dotx", "docm"],
-		"cellView": [],
-		"cellEdit": ["xlsx", "xlsb", "xltx", "xlsm", "csv"],
-		"slideView": [],
-		"slideEdit": ["pptx", "potx", "pptm"],
-		"diagramView": [],
-		"diagramEdit": []
+  "wopi": {
+    "enable": true,
+    "host": "http://localhost:9981",
+    "pdfView": [],
+    "pdfEdit": [],
+    "forms": [],
+    "wordView": [],
+    "wordEdit": ["docx", "dotx", "docm"],
+    "cellView": [],
+    "cellEdit": ["xlsx", "xlsb", "xltx", "xlsm", "csv"],
+    "slideView": [],
+    "slideEdit": ["pptx", "potx", "pptm"],
+    "diagramView": [],
+    "diagramEdit": []
+  },
+  "FileConverter": {
+    "converter": {
+      "maxDownloadBytes": 209715200
     }
+  }
 }

--- a/src/backend/wopi/viewsets.py
+++ b/src/backend/wopi/viewsets.py
@@ -126,6 +126,11 @@ class WopiViewSet(viewsets.ViewSet):
         head_object = get_item_file_head_object(item)
         if max_expected_size:
             if int(head_object["ContentLength"]) > int(max_expected_size):
+                logger.info(
+                    "get_file_content: file size %s exceeds X-WOPI-MaxExpectedSize header value %s",
+                    int(head_object["ContentLength"]),
+                    int(max_expected_size),
+                )
                 return Response(status=412)
 
         s3_client = default_storage.connection.meta.client


### PR DESCRIPTION
## Purpose

In the get_file_content action we want to log the received max expected file size when this one is lower than the file size the user wants to edit. This will help us to correctly configure the WOPI host.


## Proposal

- [x] 🔊(backend) log wopi max expected file size in get_file_content action
