### PR TITLE
🐛(backend) prevent moving an item to itself or its descendant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to
 
 - 🐛(backend) replace VersionId by Etag for WOPI
 
+### Fixed
+
+- 🐛(backend) prevent moving an item to itself or one of its descendants
+
 ## [v0.18.0] - 2026-05-04
 
 ### Added

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -1094,6 +1094,19 @@ class Item(TreeModel, BaseModel):
                 }
             )
 
+        if target:
+            target_path = str(target.path)
+            self_path = str(self.path)
+            if target_path == self_path or target_path.startswith(f"{self_path}."):
+                raise ValidationError(
+                    {
+                        "target": ValidationError(
+                            _("Cannot move an item to itself or one of its descendants"),
+                            code="item_move_target_is_descendant",
+                        )
+                    }
+                )
+
         old_path = self.path
         if target:
             self.path = f"{target.path!s}.{self.id!s}"

--- a/src/backend/core/tests/items/test_api_items_move.py
+++ b/src/backend/core/tests/items/test_api_items_move.py
@@ -830,3 +830,100 @@ def test_api_items_move_missing_permission_posthog_event(settings):
         {},
         item=item,
     )
+
+
+def test_api_items_move_to_descendant_should_fail():
+    """
+    Moving an item to one of its own descendants should return a validation
+    error and leave the tree untouched.
+    """
+    user = factories.UserFactory()
+    client = APIClient()
+    client.force_login(user)
+
+    # Create a hierarchy: parent -> child -> grandchild
+    parent = factories.ItemFactory(
+        users=[(user, models.RoleChoices.OWNER)],
+        type=models.ItemTypeChoices.FOLDER,
+    )
+    child = factories.ItemFactory(
+        users=[(user, models.RoleChoices.OWNER)],
+        type=models.ItemTypeChoices.FOLDER,
+        parent=parent,
+    )
+    grandchild = factories.ItemFactory(
+        users=[(user, models.RoleChoices.OWNER)],
+        type=models.ItemTypeChoices.FOLDER,
+        parent=child,
+    )
+
+    expected_error = {
+        "errors": [
+            {
+                "attr": "target",
+                "code": "item_move_target_is_descendant",
+                "detail": "Cannot move an item to itself or one of its descendants",
+            },
+        ],
+        "type": "validation_error",
+    }
+
+    # Moving parent to its direct child
+    response = client.post(
+        f"/api/v1.0/items/{parent.id!s}/move/",
+        data={"target_item_id": str(child.id)},
+    )
+    assert response.status_code == 400
+    assert response.json() == expected_error
+
+    # Moving parent to its grandchild
+    response = client.post(
+        f"/api/v1.0/items/{parent.id!s}/move/",
+        data={"target_item_id": str(grandchild.id)},
+    )
+    assert response.status_code == 400
+    assert response.json() == expected_error
+
+    # Moving child to its own child
+    response = client.post(
+        f"/api/v1.0/items/{child.id!s}/move/",
+        data={"target_item_id": str(grandchild.id)},
+    )
+    assert response.status_code == 400
+    assert response.json() == expected_error
+
+    # The tree must be unchanged
+    parent.refresh_from_db()
+    child.refresh_from_db()
+    grandchild.refresh_from_db()
+    assert child.parent() == parent
+    assert grandchild.parent() == child
+
+
+def test_api_items_move_to_itself_should_fail():
+    """Moving an item to itself should return a validation error."""
+    user = factories.UserFactory()
+    client = APIClient()
+    client.force_login(user)
+
+    item = factories.ItemFactory(
+        users=[(user, models.RoleChoices.OWNER)],
+        type=models.ItemTypeChoices.FOLDER,
+    )
+
+    response = client.post(
+        f"/api/v1.0/items/{item.id!s}/move/",
+        data={"target_item_id": str(item.id)},
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "errors": [
+            {
+                "attr": "target",
+                "code": "item_move_target_is_descendant",
+                "detail": "Cannot move an item to itself or one of its descendants",
+            },
+        ],
+        "type": "validation_error",
+    }


### PR DESCRIPTION
## Problem

`Item.move()` had no guard against moving a folder into itself or one of its own descendants.

Drive uses `django_ltree`, which raises no error in this case, it silently runs the `RawSQL` path rewrite. Because the `path__descendants` ltree lookup (`<@`) is **inclusive**, the moved item matches its *own* descendant query, so both it and its children get rewritten and the subtree ends up orphaned.

### Walkthrough

https://github.com/user-attachments/assets/ddd86340-99e0-413d-8c41-dce80b48673d


Take a parent `P` with path `P` and a child `C` with path `P.C`. Moving `P` into `C`:

```python
old_path = self.path                      # "P"
self.path = f"{target.path}.{self.id}"     # "P.C.P"
self.save(update_fields=["path"])          # P is now "P.C.P"

# P is a FOLDER, so descendants get rewritten:
Item.objects.filter(path__descendants=old_path).update(   # descendants of "P"
    path=RawSQL("%s || subpath(path, nlevel(%s))", (self.path, old_path))
)
```

After `self.save()`, the rows matching "descendant of `P`" are:

- `C` with path `P.C` → `P.C <@ P` ✅
- `P` itself with its **new** path `P.C.P` → `P.C.P <@ P` ✅ — P matches its own descendant query

So the bulk `UPDATE` rewrites both, with `self.path = "P.C.P"` and `nlevel("P") = 1`:

| Item | New path |
|------|----------|
| `C` | `"P.C.P"` ‖ `subpath("P.C", 1)` = `P.C.P.C` |
| `P` | `"P.C.P"` ‖ `subpath("P.C.P", 1)` = `P.C.P.C.P` |

**Result:** no item has path `P` anymore, so neither `P` nor `C` is reachable from the real tree. `P` ends up with the self-referential path `P.C.P.C.P` — a cycle baked into the materialized paths, leaving the subtree orphaned and unrecoverable through the UI.

## Fix

Reject the move in `Item.move()` when the target is the item itself or one of its descendants, mirroring the style of the existing not-a-folder check:

```python
if target:
    target_path = str(target.path)
    self_path = str(self.path)
    if target_path == self_path or target_path.startswith(f"{self_path}."):
        raise ValidationError(...)  # code="item_move_target_is_descendant"
```