### PR TITLE
✨(frontend) open WOPI editor after file creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to
 - ✨(backend) manage reconciliation requests for user accounts
 - ✨(backend) add recursive folder export as ZIP archive
 - ✨(frontend) add folder export action
+- ✨(frontend) open WOPI editor after file creation
 
 ### Changed
 

--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -601,6 +601,7 @@ class CreateItemSerializer(ItemSerializer):
             "description",
             "hard_delete_at",
             "extension",
+            "is_wopi_supported",
         ]
         read_only_fields = [
             "abilities",
@@ -625,6 +626,7 @@ class CreateItemSerializer(ItemSerializer):
             "main_workspace",
             "size",
             "hard_delete_at",
+            "is_wopi_supported",
         ]
 
     def get_fields(self):

--- a/src/frontend/apps/drive/src/features/explorer/components/modals/ExplorerCreateFileModal.tsx
+++ b/src/frontend/apps/drive/src/features/explorer/components/modals/ExplorerCreateFileModal.tsx
@@ -8,6 +8,8 @@ import { useTranslation } from "react-i18next";
 import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
 import { RhfInput } from "@/features/forms/components/RhfInput";
 import { useMutationCreateFileFromTemplate } from "../../hooks/useMutations";
+import { openWopiInNewTab } from "@/features/wopi/openWopi";
+import { itemToPreviewFile } from "../../utils/utils";
 import { useRouter } from "next/router";
 import { useSetSelectedItems } from "../../stores/selectionStore";
 
@@ -58,9 +60,12 @@ export const ExplorerCreateFileModal = (
         onSuccess: (createdItem) => {
           form.reset();
           props.onClose();
-          if (props.redirectAfterCreate && createdItem?.id) {
+          if (props.redirectAfterCreate) {
             router.push(`/explorer/items/my-files`);
-            setSelectedItems([createdItem]);
+          }
+          setSelectedItems([createdItem]);
+          if (createdItem.is_wopi_supported) {
+            openWopiInNewTab(itemToPreviewFile(createdItem));
           }
         },
       }

--- a/src/frontend/apps/drive/src/features/explorer/components/modals/ExplorerCreateFolderModal.tsx
+++ b/src/frontend/apps/drive/src/features/explorer/components/modals/ExplorerCreateFolderModal.tsx
@@ -40,10 +40,10 @@ export const ExplorerCreateFolderModal = ({
         onSuccess: (createdItem) => {
           form.reset();
           props.onClose();
-          if (props.redirectAfterCreate && createdItem?.id) {
+          if (props.redirectAfterCreate) {
             router.push(`/explorer/items/${createdItem.id}`);
-            setSelectedItems([createdItem]);
           }
+          setSelectedItems([createdItem]);
         },
       },
     );


### PR DESCRIPTION
## Purpose

Resolves https://github.com/suitenumerique/drive/issues/717

When a file is created using the creation menu and WOPI is enabled, automatically open it in a new tab. Also select the file in the listing independent of WOPI being enabled or not.

preserves the existing redirect behavior for changes in the shared/stars folders.

https://github.com/suitenumerique/drive/pull/700 dropped the in-page preview for WOPI files, so we just follow drive's current behavior and open in a new tab.


## Proposal
| Location | Type | WOPI | Behavior |
|---|---|---|---|
| My Files | Folder | — | Select |
| My Files | Document | Yes | Select + open WOPI tab |
| My Files | Document | No | Select |
| Shared With Me/Stars | Folder | — | Redirect into new folder + select |
| Shared With Me/Stars | Document | Yes | Redirect to My Files + select + open WOPI tab |
| Shared With Me/Stars | Document | No | Redirect to My Files + select |


Disclaimer: AI-assisted, tested manually by a human, PR by a human.