### PR TITLE
🐛(frontend) add missing export action translations

### DIFF
--- a/src/frontend/apps/drive/src/features/i18n/translations.json
+++ b/src/frontend/apps/drive/src/features/i18n/translations.json
@@ -508,7 +508,8 @@
             "unfavorite": "Unstar",
             "duplicate": "Duplicate",
             "duplicate_error": "An error occurred while duplicating the item.",
-            "delete": "Delete"
+            "delete": "Delete",
+            "export": "Export as ZIP"
           },
           "duplicating": "duplication in progress",
           "converting": "conversion in progress"
@@ -1108,7 +1109,8 @@
             "unfavorite": "Retirer des favoris",
             "duplicate": "Dupliquer",
             "duplicate_error": "Une erreur est survenue lors de la duplication.",
-            "delete": "Supprimer"
+            "delete": "Supprimer",
+            "export": "Exporter en ZIP"
           },
           "duplicating": "duplication en cours",
           "converting": "conversion en cours"
@@ -1702,7 +1704,8 @@
             "unfavorite": "Verwijder uit favorieten",
             "duplicate": "Dupliceer",
             "duplicate_error": "Er is een fout opgetreden bij het dupliceren.",
-            "delete": "Verwijder"
+            "delete": "Verwijder",
+            "export": "Exporteren als ZIP"
           },
           "duplicating": "duplicatie bezig",
           "converting": "conversie bezig"


### PR DESCRIPTION
## Purpose

The folder export button (cd7bebfc) used the translation key
`explorer.item.actions.export` without adding the corresponding
entries in translations.json, so the button label was displayed
as a raw key.

## Proposal

Add the missing translation for all three locales:

- [x] EN: "Export as ZIP"
- [x] FR: "Exporter en ZIP"
- [x] NL: "Exporteren als ZIP"