### PR TITLE
Fix OnlyOffice conversion JWT signing

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -270,7 +270,8 @@ services:
     environment:
       TZ: "Europe/Berlin"
       USE_UNAUTHORIZED_STORAGE: "true"
-      JWT_ENABLED: "false"
+      JWT_ENABLED: "true"
+      JWT_SECRET: "ThisIsNotASecretKeyDev"
     ports:
       - "9981:80"
     volumes:

--- a/docs/env.md
+++ b/docs/env.md
@@ -127,6 +127,12 @@ This document lists all configurable environment variables for the Drive applica
 | `WOPI_SRC_BASE_URL` | The backend url | None |
 | `WOPI_ACCESS_TOKEN_TIMEOUT` | TTL in seconds for the access_token_ttl sent to the WOPI client | `36000` (10H) |
 | `WOPI_LOCK_TIMEOUT` | TTL for the lock acquired by a WOPI client | `1800` (30 min) |
+| `WOPI_CONVERSION_SOURCE_TOKEN_TIMEOUT` | TTL in seconds for the short-lived token OnlyOffice uses to fetch the source file | `120` |
+| `WOPI_ONLYOFFICE_CONVERT_JWT_SECRET` | Shared secret for signing OnlyOffice /converter requests. Required for conversion to work. | `None` |
+| `WOPI_ONLYOFFICE_CONVERT_HTTP_CONNECT_TIMEOUT` | Connect timeout in seconds for the /converter request | `5` |
+| `WOPI_ONLYOFFICE_CONVERT_HTTP_READ_TIMEOUT` | Read timeout in seconds for the /converter request | `60` |
+| `WOPI_ONLYOFFICE_CONVERT_DOWNLOAD_CONNECT_TIMEOUT` | Connect timeout in seconds for downloading the converted file | `5` |
+| `WOPI_ONLYOFFICE_CONVERT_DOWNLOAD_READ_TIMEOUT` | Read timeout in seconds for downloading the converted file | `30` |
 | `WOPI_DISABLE_CHAT` | Disable chat in the WOPI client interface | `0` |
 | `WOPI_CONFIGURATION_CRONTAB_MINUTE` | Used to configure the celery beat crontab, See https://docs.celeryq.dev/en/main/reference/celery.schedules.html#celery.schedules.crontab | `0` |
 | `WOPI_CONFIGURATION_CRONTAB_HOUR` | Used to configure the celery beat crontab, See https://docs.celeryq.dev/en/main/reference/celery.schedules.html#celery.schedules.crontab | `3` |

--- a/env.d/development/common
+++ b/env.d/development/common
@@ -87,6 +87,7 @@ WOPI_COLLABORA_OPTIONS={"SupportsRename": False}
 # Background conversion of legacy Office files (.doc, .xls, .ppt) is forced
 # server-side via the OnlyOffice /converter endpoint.
 WOPI_ONLYOFFICE_OPTIONS={"ForceConvertExtensions": ["doc", "xls", "ppt"], "ConvertServiceUrl": "http://onlyoffice/converter"}
+WOPI_ONLYOFFICE_CONVERT_JWT_SECRET=ThisIsNotASecretKeyDev
 
 # Indexer
 # SEARCH_INDEXER_CLASS="core.services.search_indexers.SearchIndexer"

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -1299,6 +1299,7 @@ class Item(TreeModel, BaseModel):
             and self.type == ItemTypeChoices.FILE
             and self.upload_state == ItemUploadStateChoices.READY
             and bool(target_extension_for(self.extension))
+            and bool(settings.WOPI_ONLYOFFICE_CONVERT_JWT_SECRET)
         )
 
         return {

--- a/src/backend/core/tests/items/test_api_items_convert.py
+++ b/src/backend/core/tests/items/test_api_items_convert.py
@@ -34,6 +34,7 @@ def _build_user_and_item():
 def _wopi_settings(settings):
     """Configure the OnlyOffice WOPI client for the conversion tests."""
     settings.WOPI_SRC_BASE_URL = "https://drive.example"
+    settings.WOPI_ONLYOFFICE_CONVERT_JWT_SECRET = "test-jwt-secret"
     settings.WOPI_CLIENTS_CONFIGURATION = {
         "onlyoffice": {
             "options": {

--- a/src/backend/core/tests/test_models_items.py
+++ b/src/backend/core/tests/test_models_items.py
@@ -224,8 +224,9 @@ def test_models_items_hard_delete():
         (None, False),
     ],
 )
-def test_models_items_get_abilities_convert(extension, expected):
+def test_models_items_get_abilities_convert(extension, expected, settings):
     """Flag convert only for legacy extensions on READY files with update access."""
+    settings.WOPI_ONLYOFFICE_CONVERT_JWT_SECRET = "test-jwt-secret"
     user = factories.UserFactory()
     filename = f"file.{extension}" if extension else None
     item = factories.ItemFactory(
@@ -235,6 +236,19 @@ def test_models_items_get_abilities_convert(extension, expected):
         update_upload_state=models.ItemUploadStateChoices.READY,
     )
     assert item.get_abilities(user)["convert"] is expected
+
+
+def test_models_items_get_abilities_convert_disabled_without_jwt_secret(settings):
+    """Disable convert ability when the JWT secret is not configured."""
+    settings.WOPI_ONLYOFFICE_CONVERT_JWT_SECRET = None
+    user = factories.UserFactory()
+    item = factories.ItemFactory(
+        users=[(user, "editor")],
+        type=models.ItemTypeChoices.FILE,
+        filename="file.doc",
+        update_upload_state=models.ItemUploadStateChoices.READY,
+    )
+    assert item.get_abilities(user)["convert"] is False
 
 
 @pytest.mark.parametrize(

--- a/src/backend/drive/settings.py
+++ b/src/backend/drive/settings.py
@@ -1420,6 +1420,9 @@ class Base(Configuration):
     WOPI_ONLYOFFICE_CONVERT_DOWNLOAD_READ_TIMEOUT = values.IntegerValue(
         30, environ_name="WOPI_ONLYOFFICE_CONVERT_DOWNLOAD_READ_TIMEOUT", environ_prefix=None
     )
+    WOPI_ONLYOFFICE_CONVERT_JWT_SECRET = SecretFileValue(
+        None, environ_name="WOPI_ONLYOFFICE_CONVERT_JWT_SECRET", environ_prefix=None
+    )
     WOPI_DISABLE_CHAT = values.IntegerValue(
         0, environ_name="WOPI_DISABLE_CHAT", environ_prefix=None
     )

--- a/src/backend/wopi/authentication.py
+++ b/src/backend/wopi/authentication.py
@@ -12,13 +12,13 @@ class WopiAccessTokenAuthentication(BaseAuthentication):
     """
 
     def _get_access_token(self, request):
-        """Look for the access_token in both headers and query params."""
-        access_token = request.headers.get(
-            "Authorization", request.query_params.get("access_token")
-        )
+        """Look for the access_token in query params first, then headers."""
+        access_token = request.query_params.get("access_token")
 
-        if access_token and access_token.startswith("Bearer "):
-            access_token = access_token[7:]
+        if not access_token:
+            access_token = request.headers.get("Authorization", "")
+            if access_token.startswith("Bearer "):
+                access_token = access_token[7:]
 
         return access_token
 

--- a/src/backend/wopi/conversion/backends/onlyoffice.py
+++ b/src/backend/wopi/conversion/backends/onlyoffice.py
@@ -45,13 +45,13 @@ class OnlyOfficeConversionBackend:
             )
         return response
 
-    def _post_convert(self, payload, headers):
+    def _post_convert(self, payload, headers, key):
         """Call /converter and return the parsed completion payload."""
         response = self._request(
             "post",
             self.convert_service_url,
             label="/converter",
-            params={"shardkey": payload["key"]},
+            params={"shardkey": key},
             json=payload,
             headers=headers,
             timeout=self.http_timeout,
@@ -91,9 +91,8 @@ class OnlyOfficeConversionBackend:
         }
         headers = {"Accept": "application/json"}
         if self.jwt_secret:
-            token = jwt.encode({"payload": payload}, self.jwt_secret, algorithm="HS256")
-            payload = {**payload, "token": token}
-            headers["Authorization"] = f"Bearer {token}"
+            token = jwt.encode(payload, self.jwt_secret, algorithm="HS256")
+            payload = {"token": token}
 
-        data = self._post_convert(payload, headers)
+        data = self._post_convert(payload, headers, key)
         return self._download(data["fileUrl"], target_extension)

--- a/src/backend/wopi/conversion/backends/onlyoffice.py
+++ b/src/backend/wopi/conversion/backends/onlyoffice.py
@@ -17,12 +17,11 @@ class OnlyOfficeConversionBackend:
     def __init__(
         self,
         convert_service_url,
-        jwt_secret=None,
         http_timeout=None,
         download_timeout=None,
     ):
         self.convert_service_url = convert_service_url
-        self.jwt_secret = jwt_secret
+        self.jwt_secret = settings.WOPI_ONLYOFFICE_CONVERT_JWT_SECRET
         self.http_timeout = http_timeout or (
             settings.WOPI_ONLYOFFICE_CONVERT_HTTP_CONNECT_TIMEOUT,
             settings.WOPI_ONLYOFFICE_CONVERT_HTTP_READ_TIMEOUT,

--- a/src/backend/wopi/conversion/backends/onlyoffice.py
+++ b/src/backend/wopi/conversion/backends/onlyoffice.py
@@ -8,28 +8,19 @@ from django.core.files.base import ContentFile
 import jwt
 import requests
 
-from wopi.conversion.exceptions import (
-    ConversionMisconfigured,
-    ConversionProviderError,
-)
+from wopi.conversion.exceptions import ConversionProviderError
 
 
 class OnlyOfficeConversionBackend:
     """Run a synchronous OnlyOffice conversion through the /converter endpoint."""
 
-    # pylint: disable-next=too-many-arguments,too-many-positional-arguments
     def __init__(
         self,
         convert_service_url,
         jwt_secret=None,
-        jwt_required=False,
         http_timeout=None,
         download_timeout=None,
     ):
-        if jwt_required and not jwt_secret:
-            raise ConversionMisconfigured(
-                "OnlyOffice JWT is required but no ConvertJwtSecret is configured."
-            )
         self.convert_service_url = convert_service_url
         self.jwt_secret = jwt_secret
         self.http_timeout = http_timeout or (

--- a/src/backend/wopi/conversion/services.py
+++ b/src/backend/wopi/conversion/services.py
@@ -41,6 +41,9 @@ def _validate_conversion(item, user):
     if onlyoffice_config is None:
         raise ConversionRejected("No OnlyOffice client configured.")
 
+    if not settings.WOPI_ONLYOFFICE_CONVERT_JWT_SECRET:
+        raise ConversionMisconfigured("Missing WOPI_ONLYOFFICE_CONVERT_JWT_SECRET")
+
     client_options = onlyoffice_config.get("options", {})
     if not is_forced_conversion(item, client_options):
         raise ConversionRejected("Conversion not forced by the active WOPI client.")
@@ -56,7 +59,6 @@ def resolve_backend(client_options):
 
     return OnlyOfficeConversionBackend(
         convert_service_url=convert_service_url,
-        jwt_secret=settings.WOPI_ONLYOFFICE_CONVERT_JWT_SECRET,
     )
 
 

--- a/src/backend/wopi/conversion/services.py
+++ b/src/backend/wopi/conversion/services.py
@@ -56,8 +56,6 @@ def resolve_backend(client_options):
 
     return OnlyOfficeConversionBackend(
         convert_service_url=convert_service_url,
-        jwt_secret=client_options.get("ConvertJwtSecret"),
-        jwt_required=bool(client_options.get("ConvertJwtRequired", False)),
     )
 
 

--- a/src/backend/wopi/conversion/services.py
+++ b/src/backend/wopi/conversion/services.py
@@ -56,6 +56,7 @@ def resolve_backend(client_options):
 
     return OnlyOfficeConversionBackend(
         convert_service_url=convert_service_url,
+        jwt_secret=settings.WOPI_ONLYOFFICE_CONVERT_JWT_SECRET,
     )
 
 

--- a/src/backend/wopi/tests/conversion/test_backends_onlyoffice.py
+++ b/src/backend/wopi/tests/conversion/test_backends_onlyoffice.py
@@ -59,20 +59,29 @@ def test_convert_sends_synchronous_payload_with_shardkey():
 
 @responses.activate
 def test_convert_signs_payload_when_jwt_secret_is_set():
-    """Wrap the payload in a JWT and send it in body and Authorization header."""
+    """Encode conversion parameters directly in a body JWT token."""
     responses.add(responses.POST, CONVERT_URL, body=_ok_body(), status=200)
     responses.add(responses.GET, FILE_URL, body=b"converted", status=200)
 
     backend = OnlyOfficeConversionBackend(convert_service_url=CONVERT_URL, jwt_secret=JWT_SECRET)
-    backend.convert(_item(), SOURCE_URL, "docx")
+    item = _item()
+    backend.convert(item, SOURCE_URL, "docx")
 
     request = responses.calls[0].request
-    payload = json.loads(request.body)
-    token = payload.pop("token")
+    body = json.loads(request.body)
+    assert list(body.keys()) == ["token"]
 
-    decoded = jwt.decode(token, JWT_SECRET, algorithms=["HS256"])
-    assert decoded["payload"] == payload
-    assert request.headers.get("Authorization") == f"Bearer {token}"
+    decoded = jwt.decode(body["token"], JWT_SECRET, algorithms=["HS256"])
+    key = decoded.pop("key")
+    assert decoded == {
+        "async": False,
+        "filetype": "doc",
+        "outputtype": "docx",
+        "title": item.filename,
+        "url": SOURCE_URL,
+    }
+    assert str(item.id) in key
+    assert "Authorization" not in request.headers
 
 
 @responses.activate

--- a/src/backend/wopi/tests/conversion/test_backends_onlyoffice.py
+++ b/src/backend/wopi/tests/conversion/test_backends_onlyoffice.py
@@ -89,12 +89,6 @@ def test_convert_does_not_sign_when_no_secret():
     assert "token" not in payload
 
 
-def test_constructor_raises_when_jwt_required_but_secret_missing():
-    """Fail fast at construction time when JWT is required but the secret is missing."""
-    with pytest.raises(exceptions.ConversionMisconfigured, match="OnlyOffice JWT is required"):
-        OnlyOfficeConversionBackend(convert_service_url=CONVERT_URL, jwt_required=True)
-
-
 @responses.activate
 def test_convert_returns_content_file_with_downloaded_bytes():
     """Wrap the downloaded bytes in a ContentFile named after the target."""

--- a/src/backend/wopi/tests/conversion/test_backends_onlyoffice.py
+++ b/src/backend/wopi/tests/conversion/test_backends_onlyoffice.py
@@ -3,8 +3,6 @@
 import json
 from unittest import mock
 
-from django.conf import settings
-
 import jwt
 import pytest
 import requests
@@ -31,8 +29,9 @@ def _ok_body():
 
 
 @responses.activate
-def test_convert_sends_synchronous_payload_with_shardkey():
+def test_convert_sends_synchronous_payload_with_shardkey(settings):
     """Send a synchronous /converter call with required fields and shardkey."""
+    settings.WOPI_ONLYOFFICE_CONVERT_JWT_SECRET = None
     responses.add(responses.POST, CONVERT_URL, body=_ok_body(), status=200)
     responses.add(responses.GET, FILE_URL, body=b"converted", status=200)
 
@@ -58,12 +57,13 @@ def test_convert_sends_synchronous_payload_with_shardkey():
 
 
 @responses.activate
-def test_convert_signs_payload_when_jwt_secret_is_set():
+def test_convert_signs_payload_when_jwt_secret_is_set(settings):
     """Encode conversion parameters directly in a body JWT token."""
+    settings.WOPI_ONLYOFFICE_CONVERT_JWT_SECRET = JWT_SECRET
     responses.add(responses.POST, CONVERT_URL, body=_ok_body(), status=200)
     responses.add(responses.GET, FILE_URL, body=b"converted", status=200)
 
-    backend = OnlyOfficeConversionBackend(convert_service_url=CONVERT_URL, jwt_secret=JWT_SECRET)
+    backend = OnlyOfficeConversionBackend(convert_service_url=CONVERT_URL)
     item = _item()
     backend.convert(item, SOURCE_URL, "docx")
 
@@ -85,8 +85,9 @@ def test_convert_signs_payload_when_jwt_secret_is_set():
 
 
 @responses.activate
-def test_convert_does_not_sign_when_no_secret():
+def test_convert_does_not_sign_when_no_secret(settings):
     """Skip the token field when the backend has no JWT secret."""
+    settings.WOPI_ONLYOFFICE_CONVERT_JWT_SECRET = None
     responses.add(responses.POST, CONVERT_URL, body=_ok_body(), status=200)
     responses.add(responses.GET, FILE_URL, body=b"converted", status=200)
 
@@ -111,7 +112,7 @@ def test_convert_returns_content_file_with_downloaded_bytes():
     assert result.name.endswith(".docx")
 
 
-def test_convert_uses_separate_connect_and_read_timeouts():
+def test_convert_uses_separate_connect_and_read_timeouts(settings):
     """Apply the configured connect/read timeouts to /converter and the download."""
     with mock.patch("wopi.conversion.backends.onlyoffice.requests") as requests_mock:
         post_response = mock.Mock(ok=True)

--- a/src/backend/wopi/tests/conversion/test_services.py
+++ b/src/backend/wopi/tests/conversion/test_services.py
@@ -36,6 +36,7 @@ def _fake_backend(request):
 def _configure_wopi(settings, client="onlyoffice", options=None):
     """Wire a WOPI client config covering .doc files."""
     settings.WOPI_SRC_BASE_URL = "https://drive.example"
+    settings.WOPI_ONLYOFFICE_CONVERT_JWT_SECRET = "test-jwt-secret"
     settings.WOPI_CLIENTS_CONFIGURATION = {
         client: {
             "options": options
@@ -307,6 +308,20 @@ def test_resolve_backend_raises_when_onlyoffice_url_is_missing():
         exceptions.ConversionMisconfigured, match="Missing OnlyOffice ConvertServiceUrl"
     ):
         services.resolve_backend({})
+
+
+def test_prepare_conversion_raises_when_jwt_secret_is_missing(settings):
+    """Reject conversion before creating the placeholder when the secret is missing."""
+    _configure_wopi(settings)
+    settings.WOPI_ONLYOFFICE_CONVERT_JWT_SECRET = None
+    user = factories.UserFactory()
+    item = _file(user)
+
+    with pytest.raises(
+        exceptions.ConversionMisconfigured,
+        match="Missing WOPI_ONLYOFFICE_CONVERT_JWT_SECRET",
+    ):
+        services.prepare_conversion(item, user)
 
 
 def test_prepare_conversion_returns_placeholder_in_converting_state(settings):

--- a/src/backend/wopi/tests/conversion/test_services.py
+++ b/src/backend/wopi/tests/conversion/test_services.py
@@ -289,18 +289,14 @@ def test_perform_conversion_removes_saved_file_when_database_save_fails(settings
     assert deleted_keys == saved_keys
 
 
-def test_resolve_backend_builds_onlyoffice_backend_from_options():
-    """Build the OnlyOffice backend from the WOPI client options."""
+def test_resolve_backend_builds_onlyoffice_backend():
+    """Build the OnlyOffice backend from WOPI client options."""
     backend = services.resolve_backend(
-        {
-            "ConvertServiceUrl": "https://office.example/converter",
-            "ConvertJwtSecret": "test-secret",
-        },
+        {"ConvertServiceUrl": "https://office.example/converter"},
     )
 
     assert isinstance(backend, OnlyOfficeConversionBackend)
     assert backend.convert_service_url == "https://office.example/converter"
-    assert backend.jwt_secret == "test-secret"
 
 
 def test_resolve_backend_raises_when_onlyoffice_url_is_missing():

--- a/src/backend/wopi/tests/conversion/test_services.py
+++ b/src/backend/wopi/tests/conversion/test_services.py
@@ -289,14 +289,16 @@ def test_perform_conversion_removes_saved_file_when_database_save_fails(settings
     assert deleted_keys == saved_keys
 
 
-def test_resolve_backend_builds_onlyoffice_backend():
-    """Build the OnlyOffice backend from WOPI client options."""
+def test_resolve_backend_builds_onlyoffice_backend(settings):
+    """Build the OnlyOffice backend from options and settings."""
+    settings.WOPI_ONLYOFFICE_CONVERT_JWT_SECRET = "test-secret"
     backend = services.resolve_backend(
         {"ConvertServiceUrl": "https://office.example/converter"},
     )
 
     assert isinstance(backend, OnlyOfficeConversionBackend)
     assert backend.convert_service_url == "https://office.example/converter"
+    assert backend.jwt_secret == "test-secret"
 
 
 def test_resolve_backend_raises_when_onlyoffice_url_is_missing():

--- a/src/backend/wopi/tests/viewset/test_get_file_content.py
+++ b/src/backend/wopi/tests/viewset/test_get_file_content.py
@@ -87,6 +87,33 @@ def test_get_file_content_connected_user_not_linked_to_item():
     assert response.status_code == 403
 
 
+def test_get_file_content_prefers_query_param_over_authorization_header():
+    """Use the access_token query param even when an Authorization header is present."""
+    folder = factories.ItemFactory(type=models.ItemTypeChoices.FOLDER)
+    item = factories.ItemFactory(
+        parent=folder,
+        type=models.ItemTypeChoices.FILE,
+        filename="wopi_test.txt",
+        update_upload_state=models.ItemUploadStateChoices.READY,
+        link_reach=models.LinkReachChoices.RESTRICTED,
+        link_role=models.LinkRoleChoices.EDITOR,
+    )
+    user = factories.UserFactory()
+    factories.UserItemAccessFactory(item=item, user=user, role=models.RoleChoices.EDITOR)
+
+    default_storage.save(item.file_key, BytesIO(b"my prose"))
+
+    service = AccessUserItemService()
+    access_token, _ = service.insert_new_access(item, user)
+
+    client = APIClient()
+    response = client.get(
+        f"/api/v1.0/wopi/files/{item.id}/contents/?access_token={access_token}",
+        HTTP_AUTHORIZATION="Bearer foreign-jwt-token",
+    )
+    assert response.status_code == 200
+
+
 def test_get_file_content_max_expected_size():
     """
     User trying to get the file content of an item with a max expected size should get a 412 if


### PR DESCRIPTION
## Purpose

OnlyOffice rejects unsigned `/converter` requests with error code -8
when JWT is enabled. The conversion feature (PR #719) supported JWT
signing but was never wired to a secret, and the token format did not
match the OnlyOffice API specification.

## Proposal

- Remove dead `ConvertJwtSecret` / `ConvertJwtRequired` options plumbing
- Add a dedicated `WOPI_ONLYOFFICE_CONVERT_JWT_SECRET` Django setting
- Fix JWT body token format: encode parameters directly instead of
  wrapping in `{"payload": …}`, send only `{"token": "…"}` in the body
- Prefer the WOPI `access_token` query param over the `Authorization`
  header so OnlyOffice's own JWT header does not shadow the WOPI token
- Reject conversion early (before creating the placeholder) when the
  secret is missing, and hide the `convert` ability from the API
- Enable JWT on the development OnlyOffice container
- Document the new conversion environment variables