### PR TITLE
🌐(frontend) reuse download label for folder export action

### DIFF
--- a/src/frontend/apps/drive/src/features/explorer/hooks/useItemActionMenuItems.tsx
+++ b/src/frontend/apps/drive/src/features/explorer/hooks/useItemActionMenuItems.tsx
@@ -167,7 +167,7 @@ export const useItemActionMenuItems = ({
       },
       {
         icon: <Download />,
-        label: t("explorer.item.actions.export"),
+        label: t("explorer.item.actions.download"),
         isHidden: !item.abilities?.export || minimal,
         callback: () => {
           window.location.href = `${baseApiUrl()}items/${effectiveItemId}/export/`;

--- a/src/frontend/apps/drive/src/features/i18n/translations.json
+++ b/src/frontend/apps/drive/src/features/i18n/translations.json
@@ -508,8 +508,7 @@
             "unfavorite": "Unstar",
             "duplicate": "Duplicate",
             "duplicate_error": "An error occurred while duplicating the item.",
-            "delete": "Delete",
-            "export": "Export as ZIP"
+            "delete": "Delete"
           },
           "duplicating": "duplication in progress",
           "converting": "conversion in progress"
@@ -1120,8 +1119,7 @@
             "unfavorite": "Retirer des favoris",
             "duplicate": "Dupliquer",
             "duplicate_error": "Une erreur est survenue lors de la duplication.",
-            "delete": "Supprimer",
-            "export": "Exporter en ZIP"
+            "delete": "Supprimer"
           },
           "duplicating": "duplication en cours",
           "converting": "conversion en cours"
@@ -1726,8 +1724,7 @@
             "unfavorite": "Verwijder uit favorieten",
             "duplicate": "Dupliceer",
             "duplicate_error": "Er is een fout opgetreden bij het dupliceren.",
-            "delete": "Verwijder",
-            "export": "Exporteren als ZIP"
+            "delete": "Verwijder"
           },
           "duplicating": "duplicatie bezig",
           "converting": "conversie bezig"

--- a/src/frontend/apps/e2e/__tests__/app-drive/context-menu.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-drive/context-menu.spec.ts
@@ -80,14 +80,14 @@ test.describe("Context menu", () => {
     await expect(page.getByRole("menuitem", { name: "Share" })).toBeVisible();
     await expect(page.getByRole("menuitem", { name: "Move" })).toBeVisible();
     await expect(
-      page.getByRole("menuitem", { name: "Export" }),
+      page.getByRole("menuitem", { name: "Download" }),
     ).toBeVisible();
     await expect(page.getByRole("menuitem", { name: "Rename" })).toBeVisible();
     await expect(page.getByRole("menuitem", { name: "Star" })).toBeVisible();
     await expect(page.getByRole("menuitem", { name: "Delete" })).toBeVisible();
   });
 
-  test("Right-click on folder > Export calls the export endpoint", async ({
+  test("Right-click on folder > Download calls the export endpoint", async ({
     page,
   }) => {
     await createFolderInCurrentFolder(page, "TestFolder");
@@ -109,7 +109,7 @@ test.describe("Context menu", () => {
 
     const row = await getRowItem(page, "TestFolder");
     await row.click({ button: "right" });
-    await page.getByRole("menuitem", { name: "Export" }).click();
+    await page.getByRole("menuitem", { name: "Download" }).click();
 
     const exportRequest = await exportRequestPromise;
     expect(exportRequest.url()).toMatch(


### PR DESCRIPTION


## Purpose

As we want to use the same label for file download and folder export, the same key is used, and the unused one is removed.
