### PR TITLE
Fix Collabora healthcheck, conversion filename and post-upload polling

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -245,7 +245,7 @@ services:
   collabora:
     image: collabora/code:latest
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9980/hosting/discovery"]
+      test: ["CMD-SHELL", "bash -c 'echo -e \"GET /hosting/discovery HTTP/1.0\\r\\nHost: localhost\\r\\n\\r\\n\" > /dev/tcp/localhost/9980'"]
       interval: 30s
       retries: 5
       start_period: 60s

--- a/src/backend/core/tests/items/test_api_items_convert.py
+++ b/src/backend/core/tests/items/test_api_items_convert.py
@@ -58,7 +58,7 @@ def test_convert_endpoint_creates_placeholder_and_queues_task():
     body = response.json()
     placeholder = models.Item.objects.get(id=body["id"])
     assert placeholder.upload_state == models.ItemUploadStateChoices.CONVERTING
-    assert placeholder.filename == "document.docx"
+    assert placeholder.filename == "document (converted).docx"
     assert placeholder.parent().id == item.parent().id
     delay_mock.assert_called_once_with(
         source_item_id=str(item.id),

--- a/src/backend/locale/de_DE/LC_MESSAGES/django.po
+++ b/src/backend/locale/de_DE/LC_MESSAGES/django.po
@@ -445,6 +445,10 @@ msgstr "Deutsch"
 #~ msgid "Templates"
 #~ msgstr "Vorlagen"
 
+#: wopi/conversion/services.py:86
+msgid "converted"
+msgstr "konvertiert"
+
 #~ msgid "Template/user relation"
 #~ msgstr "Vorlage/Benutzer-Beziehung"
 

--- a/src/backend/locale/en_US/LC_MESSAGES/django.po
+++ b/src/backend/locale/en_US/LC_MESSAGES/django.po
@@ -360,3 +360,7 @@ msgstr ""
 #: drive/settings.py:252
 msgid "German"
 msgstr ""
+
+#: wopi/conversion/services.py:86
+msgid "converted"
+msgstr ""

--- a/src/backend/locale/fr_FR/LC_MESSAGES/django.po
+++ b/src/backend/locale/fr_FR/LC_MESSAGES/django.po
@@ -370,6 +370,10 @@ msgstr ""
 msgid "German"
 msgstr ""
 
+#: wopi/conversion/services.py:86
+msgid "converted"
+msgstr "converti"
+
 #~ msgid "A new item was created on your behalf!"
 #~ msgstr "Un nouveau item a été créé pour vous !"
 

--- a/src/backend/locale/nl_NL/LC_MESSAGES/django.po
+++ b/src/backend/locale/nl_NL/LC_MESSAGES/django.po
@@ -367,3 +367,7 @@ msgstr "Duits"
 #: drive/settings.py:253
 msgid "Dutch"
 msgstr "Nederlands"
+
+#: wopi/conversion/services.py:86
+msgid "converted"
+msgstr "geconverteerd"

--- a/src/backend/wopi/conversion/services.py
+++ b/src/backend/wopi/conversion/services.py
@@ -5,6 +5,7 @@ from os.path import splitext
 from django.conf import settings
 from django.core.files.storage import default_storage
 from django.db import DatabaseError, transaction
+from django.utils.translation import gettext as _
 
 from core import models
 from core.api.utils import detect_mimetype
@@ -81,8 +82,8 @@ def _target_filename(item, target_extension, parent, user):
     else:
         siblings = Item.objects.filter(path__depth=1, accesses__user=user).distinct()
 
-    base, _ = splitext(item.filename)
-    target = f"{base}.{target_extension}"
+    base, _extension = splitext(item.filename)
+    target = f"{base} ({_('converted')}).{target_extension}"
 
     return manage_unique_title(siblings, target)
 

--- a/src/backend/wopi/tests/conversion/test_services.py
+++ b/src/backend/wopi/tests/conversion/test_services.py
@@ -76,7 +76,7 @@ def test_convert_item_creates_converted_file_copy(settings):
 
     converted = services.convert_item(item, user)
 
-    assert converted.filename == "document.docx"
+    assert converted.filename == "document (converted).docx"
     assert converted.parent().id == parent.id
     assert converted.upload_state == models.ItemUploadStateChoices.READY
 
@@ -125,16 +125,16 @@ def test_convert_item_keeps_title_and_filename_aligned_on_collision(settings):
     factories.ItemFactory(
         parent=parent,
         type=models.ItemTypeChoices.FILE,
-        title="document.docx",
-        filename="document.docx",
+        title="document (converted).docx",
+        filename="document (converted).docx",
         update_upload_state=models.ItemUploadStateChoices.READY,
     )
     item = _file(user, parent=parent)
 
     converted = services.convert_item(item, user)
 
-    assert converted.title == "document_01.docx"
-    assert converted.filename == "document_01.docx"
+    assert converted.title == "document (converted)_01.docx"
+    assert converted.filename == "document (converted)_01.docx"
 
 
 def test_convert_item_uses_source_parent_when_user_can_update_it_via_link(settings):
@@ -336,7 +336,7 @@ def test_prepare_conversion_returns_placeholder_in_converting_state(settings):
 
     placeholder = services.prepare_conversion(item, user)
 
-    assert placeholder.filename == "document.docx"
+    assert placeholder.filename == "document (converted).docx"
     assert placeholder.upload_state == models.ItemUploadStateChoices.CONVERTING
     assert placeholder.parent().id == parent.id
 

--- a/src/frontend/apps/drive/src/features/drivers/types.ts
+++ b/src/frontend/apps/drive/src/features/drivers/types.ts
@@ -28,6 +28,7 @@ export enum ItemUploadState {
 }
 
 export const TRANSIENT_UPLOAD_STATES: string[] = [
+  ItemUploadState.ANALYZING,
   ItemUploadState.DUPLICATING,
   ItemUploadState.CONVERTING,
 ];

--- a/src/frontend/apps/drive/src/features/explorer/hooks/useTransientItem.ts
+++ b/src/frontend/apps/drive/src/features/explorer/hooks/useTransientItem.ts
@@ -13,10 +13,11 @@ export type TransientItem = {
 export const useTransientItem = (item: Item): TransientItem => {
   const { t } = useTranslation();
   const isTransient = TRANSIENT_UPLOAD_STATES.includes(item.upload_state);
-  const label = !isTransient
-    ? null
-    : item.upload_state === ItemUploadState.CONVERTING
-      ? t("explorer.item.converting")
-      : t("explorer.item.duplicating");
+  const transientLabels: Record<string, string> = {
+    [ItemUploadState.ANALYZING]: t("explorer.item.analyzing"),
+    [ItemUploadState.CONVERTING]: t("explorer.item.converting"),
+    [ItemUploadState.DUPLICATING]: t("explorer.item.duplicating"),
+  };
+  const label = transientLabels[item.upload_state] ?? null;
   return { isTransient, label };
 };

--- a/src/frontend/apps/drive/src/features/i18n/translations.json
+++ b/src/frontend/apps/drive/src/features/i18n/translations.json
@@ -511,7 +511,8 @@
             "delete": "Delete"
           },
           "duplicating": "duplication in progress",
-          "converting": "conversion in progress"
+          "converting": "conversion in progress",
+          "analyzing": "analysis in progress"
         }
       },
       "anonymous_cta": {
@@ -1122,7 +1123,8 @@
             "delete": "Supprimer"
           },
           "duplicating": "duplication en cours",
-          "converting": "conversion en cours"
+          "converting": "conversion en cours",
+          "analyzing": "analyse en cours"
         }
       },
       "anonymous_cta": {
@@ -1727,7 +1729,8 @@
             "delete": "Verwijder"
           },
           "duplicating": "duplicatie bezig",
-          "converting": "conversie bezig"
+          "converting": "conversie bezig",
+          "analyzing": "analyse bezig"
         }
       },
       "anonymous_cta": {


### PR DESCRIPTION
## Purpose

Fix Collabora healthcheck, conversion filename and post-upload state polling.

## Proposal

- Use bash `/dev/tcp` for Collabora healthcheck since recent images no longer ship `curl` (CollaboraOnline/online#15919)
- Add "(converted)" suffix to converted filename to distinguish it from the original
- Poll items in "analyzing" state so abilities update after upload without page reload