### PR TITLE
🔖(minor) bump release version 0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [v0.19.0] - 2026-06-09
+
 ### Added
 
 - ✨(backend) manage reconciliation requests for user accounts
@@ -15,6 +17,7 @@ and this project adheres to
 - ✨(frontend) add folder export action
 - ✨(backend) background conversion of legacy Office files
 - ✨(backend) allow grist file upload
+- ✨(frontend) add CTA on public link for anonymous and authenticated users
 
 ### Changed
 
@@ -24,10 +27,6 @@ and this project adheres to
 ### Removed
 
 - 🔥(backend) drop deprecated numchild columns from item
-
-### Added
-
-- ✨(frontend) add CTA on public link for anonymous and authenticated users
 
 ## [v0.18.0] - 2026-05-04
 
@@ -453,7 +452,8 @@ and this project adheres to
 - 🌐(front) add english translation for rename modal
 - 🐛(global) fix wrong Content-Type on specific s3 implementations
 
-[unreleased]: https://github.com/suitenumerique/drive/compare/v0.18.0...main
+[unreleased]: https://github.com/suitenumerique/drive/compare/v0.19.0...main
+[v0.19.0]: https://github.com/suitenumerique/drive/releases/v0.19.0
 [v0.18.0]: https://github.com/suitenumerique/drive/releases/v0.18.0
 [v0.17.0]: https://github.com/suitenumerique/drive/releases/v0.17.0
 [v0.16.0]: https://github.com/suitenumerique/drive/releases/v0.16.0

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "uv_build"
 
 [project]
 name = "drive"
-version = "0.18.0"
+version = "0.19.0"
 authors = [{ "name" = "DINUM", "email" = "dev@mail.numerique.gouv.fr" }]
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/src/backend/uv.lock
+++ b/src/backend/uv.lock
@@ -658,7 +658,7 @@ wheels = [
 
 [[package]]
 name = "drive"
-version = "0.18.0"
+version = "0.19.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/frontend/apps/drive/package.json
+++ b/src/frontend/apps/drive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drive",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "main",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "private": true,
   "workspaces": [
     "apps/*",

--- a/src/helm/drive/Chart.yaml
+++ b/src/helm/drive/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 type: application
 name: drive
-version: 0.18.0
+version: 0.19.0
 appVersion: latest

--- a/src/helm/helmfile.yaml.gotmpl
+++ b/src/helm/helmfile.yaml.gotmpl
@@ -1,7 +1,7 @@
 environments:
   dev:
     values:
-      - version: 0.18.0
+      - version: 0.19.0
 ---
 repositories:
 - name: dev-backends

--- a/src/mail/package.json
+++ b/src/mail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mail_mjml",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "An util to generate html and text django's templates from mjml templates",
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
### Added

- ✨(backend) manage reconciliation requests for user accounts
- ✨(backend) add recursive folder export as ZIP archive
- ✨(frontend) add folder export action
- ✨(backend) background conversion of legacy Office files
- ✨(backend) allow grist file upload
- ✨(frontend) add CTA on public link for anonymous and authenticated users

### Changed

- 🐛(backend) replace VersionId by Etag for WOPI
- 🐛(backend) sanitize slash in template-created filenames

### Removed

- 🔥(backend) drop deprecated numchild columns from item