### PR TITLE
🐛(backend) stream export files from S3 without buffering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to
 ### Fixed
 
 - 🐛(frontend) keep uploaded items usable while malware analysis runs
+- 🐛(backend) stream export files from S3 without buffering
 
 ## [v0.19.0] - 2026-06-09
 

--- a/src/backend/core/services/item_exports.py
+++ b/src/backend/core/services/item_exports.py
@@ -1,19 +1,33 @@
 """Service for exporting item folders as streaming ZIP archives."""
 
+import logging
+
 from django.core.files.storage import default_storage
 
 from zipstream import ZipStream
 
 from core import models
 
-DEFAULT_STORAGE_READ_CHUNK_SIZE = 1024
+logger = logging.getLogger(__name__)
+
+DEFAULT_STORAGE_READ_CHUNK_SIZE = 64 * 1024
 
 
 def iter_storage_chunks(file_key, chunk_size=DEFAULT_STORAGE_READ_CHUNK_SIZE):
     """Yield bytes from object storage without buffering the whole file."""
-    with default_storage.open(file_key, "rb") as fh:
-        while chunk := fh.read(chunk_size):
-            yield chunk
+    # default_storage.open() would download the whole object in memory before
+    # the first read, so stream straight from the boto3 response body instead.
+    s3_client = default_storage.connection.meta.client
+    bucket_name = default_storage.bucket_name
+    try:
+        response = s3_client.get_object(Bucket=bucket_name, Key=file_key)
+    except s3_client.exceptions.NoSuchKey:
+        # A database row references an object that is gone from storage:
+        # aborting would make the folder export fail forever, so keep the
+        # archive going with an empty entry for this file.
+        logger.warning("Export: object %s is missing from storage, skipped", file_key)
+        return
+    yield from response["Body"].iter_chunks(chunk_size)
 
 
 def export_descendants(folder):

--- a/src/backend/core/tests/items/test_api_items_export.py
+++ b/src/backend/core/tests/items/test_api_items_export.py
@@ -5,6 +5,8 @@ Tests for the recursive folder export endpoint.
 import io
 import zipfile
 
+from django.core.files.storage import default_storage
+
 import pytest
 from rest_framework.test import APIClient
 
@@ -220,6 +222,42 @@ def test_api_items_export_skips_non_uploaded_files(upload_state):
 
     assert response.status_code == 200
     assert _zip_names(response) == ["ready.txt"]
+
+
+def test_api_items_export_file_missing_from_storage():
+    """A file whose object is missing from storage becomes an empty entry."""
+    user = factories.UserFactory()
+    client = APIClient()
+    client.force_login(user)
+
+    folder = factories.ItemFactory(
+        type=models.ItemTypeChoices.FOLDER,
+        users=[(user, models.RoleChoices.OWNER)],
+    )
+    factories.ItemFactory(
+        parent=folder,
+        type=models.ItemTypeChoices.FILE,
+        update_upload_state=models.ItemUploadStateChoices.READY,
+        upload_bytes=b"kept",
+        upload_bytes__filename="kept.txt",
+    )
+    orphan = factories.ItemFactory(
+        parent=folder,
+        type=models.ItemTypeChoices.FILE,
+        update_upload_state=models.ItemUploadStateChoices.READY,
+        upload_bytes=b"gone",
+        upload_bytes__filename="gone.txt",
+    )
+    default_storage.delete(orphan.file_key)
+
+    response = client.get(f"/api/v1.0/items/{folder.pk}/export/")
+
+    assert response.status_code == 200
+    payload = b"".join(response.streaming_content)
+    with zipfile.ZipFile(io.BytesIO(payload)) as archive:
+        assert sorted(archive.namelist()) == ["gone.txt", "kept.txt"]
+        assert archive.read("kept.txt") == b"kept"
+        assert archive.read("gone.txt") == b""
 
 
 def test_api_items_export_empty_folder():

--- a/src/backend/core/tests/test_services_item_exports.py
+++ b/src/backend/core/tests/test_services_item_exports.py
@@ -2,6 +2,7 @@
 
 import uuid
 from io import BytesIO
+from unittest import mock
 
 from django.core.files.storage import default_storage
 
@@ -41,6 +42,25 @@ def test_services_item_exports_iter_storage_chunks_respects_chunk_size(stored_bl
     assert len(chunks) > 1
     assert all(len(chunk) <= 8 for chunk in chunks)
     assert b"".join(chunks) == payload
+
+
+def test_services_item_exports_iter_storage_chunks_streams_without_full_download(stored_blob):
+    """Chunks come from a streamed S3 response, not a full in-memory download."""
+    key, payload = stored_blob
+
+    with mock.patch(
+        "storages.backends.s3.S3File.file",
+        new_callable=mock.PropertyMock,
+        side_effect=AssertionError("default_storage buffered the whole file in memory"),
+    ):
+        assert b"".join(iter_storage_chunks(key)) == payload
+
+
+def test_services_item_exports_iter_storage_chunks_missing_object():
+    """A key missing from object storage yields no chunks instead of raising."""
+    key = f"test/iter_storage_chunks-missing-{uuid.uuid4()}.bin"
+
+    assert not list(iter_storage_chunks(key))
 
 
 def test_services_item_exports_iter_storage_chunks_empty_file():


### PR DESCRIPTION
## Purpose

Exporting a folder holding large files can exhaust the worker memory:
`default_storage.open()` downloads each whole object in memory before
the first read.

## Proposal

- Stream files straight from the boto3 response body
- Raise the read chunk size from 1 KB to 64 KB