### PR TITLE
✨(backend) accept configurable media-auth forward headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- ✨(backend) accept configurable media-auth forward headers
+
 ## [v0.21.0] - 2026-08-07
 
 ### Added

--- a/docs/env.md
+++ b/docs/env.md
@@ -72,6 +72,7 @@ This document lists all configurable environment variables for the Drive applica
 | `LOGGING_LEVEL_LOGGERS_APP` | Logging level for application loggers | `INFO` |
 | `LOGGING_LEVEL_LOGGERS_ROOT` | Logging level for root logger | `INFO` |
 | `MAX_PAGE_SIZE` | Limit the maximum page size the client may request | `200` |
+| `MEDIA_AUTH_FORWARD_HEADERS` | Headers carrying the original URL of a media auth subrequest, tried in order | `["X-Original-Url", "X-Forwarded-Uri"]` |
 | `MEDIA_BASE_URL` | Base URL for media files | `None` |
 | `OIDC_AUTH_REQUEST_EXTRA_PARAMS` | Extra parameters for OIDC auth requests | `{}` |
 | `OIDC_ALLOW_DUPLICATE_EMAILS` | Allow multiple users with same email | `False` |

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -1626,18 +1626,19 @@ class ItemViewSet(
 
     def _authorize_subrequest(self, request, pattern):
         """
-        Shared method to authorize access based on the original URL of an Nginx subrequest
-        and user permissions. Returns a dictionary of URL parameters if authorized.
+        Shared method to authorize access based on the original URL of a reverse proxy
+        auth subrequest and user permissions. Returns a dictionary of URL parameters if
+        authorized.
 
-        The original url is passed by nginx in the "HTTP_X_ORIGINAL_URL" header.
-        See corresponding ingress configuration in Helm chart and read about the
-        nginx.ingress.kubernetes.io/auth-url annotation to understand how the Nginx ingress
-        is configured to do this.
+        The original url is passed by the proxy in one of the headers listed in the
+        MEDIA_AUTH_FORWARD_HEADERS setting, which are tried in order. See the corresponding
+        ingress configuration in the Helm chart to understand how the proxy is configured to
+        do this.
 
-        Based on the original url and the logged in user, we must decide if we authorize Nginx
-        to let this request go through (by returning a 200 code) or if we block it (by returning
-        a 403 error). Note that we return 403 errors without any further details for security
-        reasons.
+        Based on the original url and the logged in user, we must decide if we authorize the
+        proxy to let this request go through (by returning a 200 code) or if we block it (by
+        returning a 403 error). Note that we return 403 errors without any further details for
+        security reasons.
 
         Parameters:
         - pattern: The regex pattern to extract identifiers from the URL.
@@ -1647,10 +1648,19 @@ class ItemViewSet(
         Raises:
         - PermissionDenied if authorization fails.
         """
-        # Extract the original URL from the request header
-        original_url = request.META.get("HTTP_X_ORIGINAL_URL")
+        # Extract the original URL from the first configured header that is present.
+        original_url = None
+        for header in settings.MEDIA_AUTH_FORWARD_HEADERS:
+            meta_key = "HTTP_" + header.upper().replace("-", "_")
+            original_url = request.META.get(meta_key)
+            if original_url:
+                break
+
         if not original_url:
-            logger.debug("Missing HTTP_X_ORIGINAL_URL header in subrequest")
+            logger.debug(
+                "Missing media auth header (tried %s) in subrequest",
+                ", ".join(settings.MEDIA_AUTH_FORWARD_HEADERS),
+            )
             raise drf.exceptions.PermissionDenied()
 
         parsed_url = urlparse(original_url)

--- a/src/backend/core/tests/items/test_api_items_media_auth.py
+++ b/src/backend/core/tests/items/test_api_items_media_auth.py
@@ -399,3 +399,54 @@ def test_api_items_media_auth_filename_with_hash():
         timeout=1,
     )
     assert response.content.decode("utf-8") == "my prose"
+
+
+def test_api_items_media_auth_forwarded_uri_header_public():
+    """
+    The media-auth endpoint should accept the "X-Forwarded-Uri" header as an
+    alternative to "X-Original-Url" and reach the same authorization decision (200).
+    """
+    item = factories.ItemFactory(
+        link_reach="public",
+        type=models.ItemTypeChoices.FILE,
+        update_upload_state=models.ItemUploadStateChoices.READY,
+    )
+
+    default_storage.save(item.file_key, BytesIO(b"my prose"))
+
+    original_url = f"http://localhost/media/{item.file_key:s}"
+    now = timezone.now()
+    with freeze_time(now):
+        response = APIClient().get("/api/v1.0/items/media-auth/", HTTP_X_FORWARDED_URI=original_url)
+
+    assert response.status_code == 200
+
+    authorization = response["Authorization"]
+    assert "AWS4-HMAC-SHA256 Credential=" in authorization
+    assert "SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=" in authorization
+    assert response["X-Amz-Date"] == now.strftime("%Y%m%dT%H%M%SZ")
+
+
+@pytest.mark.parametrize("reach", ["authenticated", "restricted"])
+def test_api_items_media_auth_forwarded_uri_header_blocked(reach):
+    """
+    Anonymous users must still be blocked (403) when the original URL is carried by
+    the "X-Forwarded-Uri" header, mirroring the "X-Original-Url" behaviour.
+    """
+    item = factories.ItemFactory(link_reach=reach)
+
+    filename = f"{uuid.uuid4()!s}.jpg"
+    media_url = f"http://localhost/media/item/{item.pk!s}/{filename:s}"
+
+    response = APIClient().get("/api/v1.0/items/media-auth/", HTTP_X_FORWARDED_URI=media_url)
+
+    assert response.status_code == 403
+    assert "Authorization" not in response
+
+
+def test_api_items_media_auth_no_forward_header():
+    """A subrequest carrying none of the accepted headers should be denied (403)."""
+    response = APIClient().get("/api/v1.0/items/media-auth/")
+
+    assert response.status_code == 403
+    assert "Authorization" not in response

--- a/src/backend/drive/settings.py
+++ b/src/backend/drive/settings.py
@@ -143,6 +143,15 @@ class Base(Configuration):
     MEDIA_ROOT = os.path.join(DATA_DIR, "media")
     MEDIA_BASE_URL = values.Value(None, environ_name="MEDIA_BASE_URL", environ_prefix=None)
 
+    # Request headers carrying the original URL of a media auth subrequest, tried in order.
+    # nginx ingress uses "X-Original-Url"; Traefik's ForwardAuth uses "X-Forwarded-Uri".
+    # Add other proxy header names here (or via the env var) as needed.
+    MEDIA_AUTH_FORWARD_HEADERS = values.ListValue(
+        ["X-Original-Url", "X-Forwarded-Uri"],
+        environ_name="MEDIA_AUTH_FORWARD_HEADERS",
+        environ_prefix=None,
+    )
+
     SITE_ID = 1
 
     STORAGES = {


### PR DESCRIPTION
## Summary

`ItemViewSet._authorize_subrequest()` only read `HTTP_X_ORIGINAL_URL`, an nginx-ingress convention. Behind a proxy that carries the original URL in a different header (for instance `X-Forwarded-Uri`) the lookup returns `None` and every `/media/...` subrequest is denied with a 403 — uploads succeed but downloads/previews never resolve.

This reads the original URL from the **first present** header in a new, configurable `MEDIA_AUTH_FORWARD_HEADERS` setting (default `["X-Original-Url", "X-Forwarded-Uri"]`, tried in order). Existing deployments are unaffected because `X-Original-Url` stays first; other proxies can be supported purely by overriding the env var, with no code change.

## Changes

- `core/api/viewsets.py` — iterate the configured headers, convert each to its `META` key (`HTTP_` prefix, uppercased, dashes→underscores) and use the first one present.
- `drive/settings.py` — new `MEDIA_AUTH_FORWARD_HEADERS` list setting (env `MEDIA_AUTH_FORWARD_HEADERS`).
- `docs/env.md` — document the new variable.
- `core/tests/items/test_api_items_media_auth.py` — mirror tests exercising `X-Forwarded-Uri` for the 200 (public) and 403 (authenticated/restricted) paths, plus a no-header 403 case.
- `CHANGELOG.md` — `Added` entry.

## Test plan

- [x] Existing `test_api_items_media_auth.py` suite still green (`X-Original-Url` path unchanged).
- [x] New `X-Forwarded-Uri` cases reach the same authorization decisions (200/403).
- [x] No-header subrequest still denied (403).
- [x] `ruff format --check .`, `ruff check .` clean; `pylint` 10.00/10 on the touched modules.
- [ ] Manual: behind a ForwardAuth-style middleware, `GET /media/<key>` returns 200 for an authorized user (previously 403).

`22 passed` locally (`DJANGO_CONFIGURATION=Test pytest core/tests/items/test_api_items_media_auth.py`).
