### PR TITLE
Keep files accessible and convertible during malware analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- 🐛(frontend) keep uploaded items usable while malware analysis runs
+
 ## [v0.19.0] - 2026-06-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- ✨(backend) allow converting a file while it is being analyzed
+
 ### Fixed
 
 - 🐛(frontend) keep uploaded items usable while malware analysis runs

--- a/env.d/development/common
+++ b/env.d/development/common
@@ -98,6 +98,12 @@ SEARCH_INDEXER_QUERY_URL="http://find:8000/api/v1.0/documents/search/"
 # Enables the search of indexed files through the API
 FEATURES_INDEXED_SEARCH=True
 
+# Malware detection
+# Delay the "safe" result so the frontend can observe the "analyzing" upload
+# state (polling + badge). Tune the delay with MALWARE_DETECTION_DUMMY_SLEEP.
+MALWARE_DETECTION_BACKEND=core.malware_detection.SleepyDummyBackend
+MALWARE_DETECTION_DUMMY_SLEEP=10
+
 # Store OIDC tokens in the session
 # OIDC_STORE_ACCESS_TOKEN = True
 # OIDC_STORE_REFRESH_TOKEN = True # Store the encrypted refresh token in the session.

--- a/env.d/development/common.e2e
+++ b/env.d/development/common.e2e
@@ -1,2 +1,4 @@
 FRONTEND_RELEASE_NOTE_ENABLED=False
 WOPI_CLIENTS="collabora"
+# Report uploads as safe synchronously so files are ready instantly in e2e.
+MALWARE_DETECTION_BACKEND=lasuite.malware_detection.backends.dummy.DummyBackend

--- a/src/backend/core/malware_detection.py
+++ b/src/backend/core/malware_detection.py
@@ -1,13 +1,36 @@
 """Malware detection callbacks"""
 
 import logging
+import threading
+import time
 
+from django.conf import settings
+from django.db import connection
+
+from lasuite.malware_detection.backends.dummy import DummyBackend
 from lasuite.malware_detection.enums import ReportStatus
 
 from core.models import Item, ItemUploadStateChoices
 
 logger = logging.getLogger(__name__)
 security_logger = logging.getLogger("drive.security")
+
+
+class SleepyDummyBackend(DummyBackend):
+    """Delay the dummy safe result."""
+
+    def analyse_file(self, file_path, **kwargs):
+        """Report the file as safe after a delay."""
+        report_safe = super().analyse_file
+
+        def report_later():
+            time.sleep(settings.MALWARE_DETECTION_DUMMY_SLEEP)
+            try:
+                report_safe(file_path, **kwargs)
+            finally:
+                connection.close()
+
+        threading.Thread(target=report_later, daemon=True).start()
 
 
 def malware_detection_callback(file_path, status, error_info, **kwargs):

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -1297,7 +1297,11 @@ class Item(TreeModel, BaseModel):
         can_convert = (
             can_update
             and self.type == ItemTypeChoices.FILE
-            and self.upload_state == ItemUploadStateChoices.READY
+            and self.upload_state
+            in (
+                ItemUploadStateChoices.READY,
+                ItemUploadStateChoices.ANALYZING,
+            )
             and bool(target_extension_for(self.extension))
             and bool(settings.WOPI_ONLYOFFICE_CONVERT_JWT_SECRET)
         )

--- a/src/backend/core/tests/test_models_items.py
+++ b/src/backend/core/tests/test_models_items.py
@@ -238,6 +238,19 @@ def test_models_items_get_abilities_convert(extension, expected, settings):
     assert item.get_abilities(user)["convert"] is expected
 
 
+def test_models_items_get_abilities_convert_while_analyzing(settings):
+    """Flag convert while malware analysis is still running on the source."""
+    settings.WOPI_ONLYOFFICE_CONVERT_JWT_SECRET = "test-jwt-secret"
+    user = factories.UserFactory()
+    item = factories.ItemFactory(
+        users=[(user, "editor")],
+        type=models.ItemTypeChoices.FILE,
+        filename="file.doc",
+        update_upload_state=models.ItemUploadStateChoices.ANALYZING,
+    )
+    assert item.get_abilities(user)["convert"] is True
+
+
 def test_models_items_get_abilities_convert_disabled_without_jwt_secret(settings):
     """Disable convert ability when the JWT secret is not configured."""
     settings.WOPI_ONLYOFFICE_CONVERT_JWT_SECRET = None

--- a/src/backend/drive/settings.py
+++ b/src/backend/drive/settings.py
@@ -1457,6 +1457,12 @@ class Base(Configuration):
             environ_prefix=None,
         ),
     }
+    # Delay in seconds for the development SleepyDummyBackend safe result.
+    MALWARE_DETECTION_DUMMY_SLEEP = values.PositiveIntegerValue(
+        3,
+        environ_name="MALWARE_DETECTION_DUMMY_SLEEP",
+        environ_prefix=None,
+    )
 
     # Metrics
     METRICS_ENABLED = values.BooleanValue(

--- a/src/backend/wopi/conversion/services.py
+++ b/src/backend/wopi/conversion/services.py
@@ -23,12 +23,15 @@ from wopi.conversion.source_url import build_source_url
 MIME_SNIFF_BYTES = 2048
 
 
-def _validate_conversion(item, user):
+def _validate_conversion(item, user, require_ready=True):
     """Run pre-flight checks and return the target extension and client options."""
     if item.type != models.ItemTypeChoices.FILE:
         raise ConversionRejected("Source item is not a file.")
 
-    if item.upload_state != models.ItemUploadStateChoices.READY:
+    ready_states = [models.ItemUploadStateChoices.READY]
+    if not require_ready:
+        ready_states.append(models.ItemUploadStateChoices.ANALYZING)
+    if item.upload_state not in ready_states:
         raise ConversionRejected("Source item is not ready.")
 
     if not item.get_abilities(user).get("update"):
@@ -95,7 +98,7 @@ def prepare_conversion(source_item, user):
     UI can display the converting state right away. The actual OnlyOffice
     conversion happens later in a celery task.
     """
-    target_extension, _ = _validate_conversion(source_item, user)
+    target_extension, _ = _validate_conversion(source_item, user, require_ready=False)
     parent = _resolve_destination_parent(source_item, user)
     target_filename = _target_filename(source_item, target_extension, parent, user)
 

--- a/src/backend/wopi/tasks/conversion.py
+++ b/src/backend/wopi/tasks/conversion.py
@@ -12,6 +12,12 @@ from drive.celery_app import app
 
 logger = logging.getLogger(__name__)
 
+# Seconds to wait before re-checking a source still under malware analysis,
+# and how many times to wait before giving up (~10 minutes total, matching the
+# frontend polling timeout).
+ANALYSIS_RETRY_COUNTDOWN = 30
+ANALYSIS_MAX_RETRIES = 20
+
 
 class ConvertFileTask(app.Task):
     """Celery task base deleting the placeholder when conversion ultimately fails."""
@@ -32,6 +38,7 @@ class ConvertFileTask(app.Task):
 
 
 @app.task(
+    bind=True,
     base=ConvertFileTask,
     autoretry_for=(ConversionProviderError,),
     retry_backoff=True,
@@ -39,7 +46,7 @@ class ConvertFileTask(app.Task):
     retry_jitter=True,
     max_retries=3,
 )
-def convert_file(source_item_id, converted_item_id, user_id):
+def convert_file(self, source_item_id, converted_item_id, user_id):
     """Convert the source item and attach the result to the placeholder."""
     User = get_user_model()  # pylint: disable=invalid-name
 
@@ -70,6 +77,13 @@ def convert_file(source_item_id, converted_item_id, user_id):
     except User.DoesNotExist:
         logger.error("convert_file: user %s does not exist, aborting", user_id)
         return
+
+    if source.upload_state == models.ItemUploadStateChoices.ANALYZING:
+        logger.info(
+            "convert_file: source %s still analyzing, retrying conversion later",
+            source_item_id,
+        )
+        raise self.retry(countdown=ANALYSIS_RETRY_COUNTDOWN, max_retries=ANALYSIS_MAX_RETRIES)
 
     try:
         perform_conversion(source, placeholder, user)

--- a/src/backend/wopi/tests/conversion/test_services.py
+++ b/src/backend/wopi/tests/conversion/test_services.py
@@ -341,6 +341,33 @@ def test_prepare_conversion_returns_placeholder_in_converting_state(settings):
     assert placeholder.parent().id == parent.id
 
 
+def test_prepare_conversion_accepts_analyzing_source(settings):
+    """Queue a conversion while the source is still being analyzed."""
+    _configure_wopi(settings)
+    user = factories.UserFactory()
+    item = _file(user, update_upload_state=models.ItemUploadStateChoices.ANALYZING)
+
+    placeholder = services.prepare_conversion(item, user)
+
+    assert placeholder.upload_state == models.ItemUploadStateChoices.CONVERTING
+
+
+def test_perform_conversion_rejects_analyzing_source(settings):
+    """Never convert the bytes before analysis confirmed the source is safe."""
+    _configure_wopi(settings)
+    user = factories.UserFactory()
+    item = _file(user, update_upload_state=models.ItemUploadStateChoices.ANALYZING)
+    placeholder = factories.ItemFactory(
+        users=[(user, models.RoleChoices.EDITOR)],
+        type=models.ItemTypeChoices.FILE,
+        filename="document.docx",
+        update_upload_state=models.ItemUploadStateChoices.CONVERTING,
+    )
+
+    with pytest.raises(exceptions.ConversionRejected, match="not ready"):
+        services.perform_conversion(item, placeholder, user)
+
+
 def test_prepare_conversion_rejects_unsupported_extensions(settings):
     """Skip placeholder creation for files that cannot be converted."""
     _configure_wopi(settings)

--- a/src/backend/wopi/tests/tasks/test_conversion.py
+++ b/src/backend/wopi/tests/tasks/test_conversion.py
@@ -3,12 +3,16 @@
 from unittest import mock
 
 import pytest
+from celery.exceptions import Retry
 
 from core import factories, models
 from wopi.conversion import exceptions
 from wopi.tasks import conversion
 
 pytestmark = pytest.mark.django_db
+
+# As the task is bound, we need to ignore this error.
+# pylint: disable=no-value-for-parameter
 
 
 def _source_and_placeholder():
@@ -97,6 +101,27 @@ def test_convert_file_aborts_when_placeholder_state_changed():
             user_id=str(user.id),
         )
 
+    perform_mock.assert_not_called()
+
+
+def test_convert_file_retries_while_source_analyzing():
+    """Wait for malware analysis to finish before converting the source bytes."""
+    user, source, placeholder = _source_and_placeholder()
+    source.upload_state = models.ItemUploadStateChoices.ANALYZING
+    source.save(update_fields=["upload_state", "updated_at"])
+
+    with (
+        mock.patch.object(conversion.convert_file, "retry", side_effect=Retry()) as retry_mock,
+        mock.patch.object(conversion, "perform_conversion") as perform_mock,
+    ):
+        with pytest.raises(Retry):
+            conversion.convert_file(
+                source_item_id=str(source.id),
+                converted_item_id=str(placeholder.id),
+                user_id=str(user.id),
+            )
+
+    retry_mock.assert_called_once()
     perform_mock.assert_not_called()
 
 

--- a/src/frontend/apps/drive/src/features/drivers/types.ts
+++ b/src/frontend/apps/drive/src/features/drivers/types.ts
@@ -27,10 +27,18 @@ export enum ItemUploadState {
   READY = "ready",
 }
 
+// States that lock the item in the UI: it is a placeholder with no usable
+// content yet, so selection, actions and navigation must stay disabled.
 export const TRANSIENT_UPLOAD_STATES: string[] = [
-  ItemUploadState.ANALYZING,
   ItemUploadState.DUPLICATING,
   ItemUploadState.CONVERTING,
+];
+
+// States that must be polled until they settle. Analysis runs in the
+// background on an already accessible item, so it is polled but not transient.
+export const POLLED_UPLOAD_STATES: string[] = [
+  ItemUploadState.ANALYZING,
+  ...TRANSIENT_UPLOAD_STATES,
 ];
 
 export type ItemBreadcrumb = {

--- a/src/frontend/apps/drive/src/features/explorer/components/modals/ConvertLegacyFileModal.tsx
+++ b/src/frontend/apps/drive/src/features/explorer/components/modals/ConvertLegacyFileModal.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { Button, Modal, ModalSize } from "@gouvfr-lasuite/cunningham-react";
 import { useTranslation } from "react-i18next";
-import { Item } from "@/features/drivers/types";
+import { Item, ItemUploadState } from "@/features/drivers/types";
 import { useMutationConvertItem } from "@/features/explorer/hooks/useMutations";
 
 type Props = {
@@ -58,7 +58,12 @@ export const ConvertLegacyFileModal = ({ item, isOpen, onClose }: Props) => {
         {error ? (
           <p className="clr-error-500">{error}</p>
         ) : (
-          t("explorer.actions.convert.modal.content")
+          <>
+            {t("explorer.actions.convert.modal.content")}
+            {item.upload_state === ItemUploadState.ANALYZING && (
+              <p>{t("explorer.actions.convert.modal.analyzing_notice")}</p>
+            )}
+          </>
         )}
       </div>
     </Modal>

--- a/src/frontend/apps/drive/src/features/explorer/hooks/useTransientItem.ts
+++ b/src/frontend/apps/drive/src/features/explorer/hooks/useTransientItem.ts
@@ -14,7 +14,6 @@ export const useTransientItem = (item: Item): TransientItem => {
   const { t } = useTranslation();
   const isTransient = TRANSIENT_UPLOAD_STATES.includes(item.upload_state);
   const transientLabels: Record<string, string> = {
-    [ItemUploadState.ANALYZING]: t("explorer.item.analyzing"),
     [ItemUploadState.CONVERTING]: t("explorer.item.converting"),
     [ItemUploadState.DUPLICATING]: t("explorer.item.duplicating"),
   };

--- a/src/frontend/apps/drive/src/features/explorer/hooks/useTransientItemsPoller.tsx
+++ b/src/frontend/apps/drive/src/features/explorer/hooks/useTransientItemsPoller.tsx
@@ -2,7 +2,11 @@ import { useMemo, useEffect, useRef } from "react";
 import { useQueries, useQueryClient } from "@tanstack/react-query";
 import { APIError } from "@/features/api/APIError";
 import { getDriver } from "@/features/config/Config";
-import { Item, TRANSIENT_UPLOAD_STATES } from "@/features/drivers/types";
+import {
+  Item,
+  ItemUploadState,
+  POLLED_UPLOAD_STATES,
+} from "@/features/drivers/types";
 import { useRefreshItemCache } from "./useRefreshItems";
 import { useRemoveItemsFromPaginatedList } from "./useOptimisticPagination";
 import {
@@ -24,7 +28,7 @@ export const useTransientItemsPoller = (items: Item[]) => {
 
   const transientItems = useMemo(
     () =>
-      items.filter((i) => TRANSIENT_UPLOAD_STATES.includes(i.upload_state)),
+      items.filter((i) => POLLED_UPLOAD_STATES.includes(i.upload_state)),
     [items],
   );
 
@@ -48,7 +52,7 @@ export const useTransientItemsPoller = (items: Item[]) => {
       queryFn: async (): Promise<Item | null> => {
         try {
           const updatedItem = await getDriver().getItem(item.id);
-          if (!TRANSIENT_UPLOAD_STATES.includes(updatedItem.upload_state)) {
+          if (!POLLED_UPLOAD_STATES.includes(updatedItem.upload_state)) {
             await refreshItemCache(item.id, updatedItem);
           }
           return updatedItem;
@@ -56,7 +60,11 @@ export const useTransientItemsPoller = (items: Item[]) => {
           if (error instanceof APIError && error.code === 404) {
             removeItems(["items"], [item.id]);
             queryClient.removeQueries({ queryKey: ["items", item.id] });
-            if (!failedToastShownRef.current.has(item.id)) {
+            // Only a conversion placeholder vanishing is a failure worth a
+            // toast; an analyzed item may simply have been deleted meanwhile.
+            const isConverting =
+              item.upload_state === ItemUploadState.CONVERTING;
+            if (isConverting && !failedToastShownRef.current.has(item.id)) {
               failedToastShownRef.current.add(item.id);
               addToast(
                 <ToasterItem type="error">
@@ -76,7 +84,7 @@ export const useTransientItemsPoller = (items: Item[]) => {
         if (data === null) {
           return false;
         }
-        if (data && !TRANSIENT_UPLOAD_STATES.includes(data.upload_state)) {
+        if (data && !POLLED_UPLOAD_STATES.includes(data.upload_state)) {
           return false;
         }
         const startTime = startTimesRef.current.get(item.id) ?? Date.now();

--- a/src/frontend/apps/drive/src/features/i18n/translations.json
+++ b/src/frontend/apps/drive/src/features/i18n/translations.json
@@ -490,7 +490,8 @@
               "content": "This file needs to be converted before it can be edited. A copy will be created: your original file stays untouched.",
               "cancel": "Cancel",
               "confirm": "Convert",
-              "error": "Conversion failed. Please try again."
+              "error": "Conversion failed. Please try again.",
+              "analyzing_notice": "This file is still being analyzed for malware. The conversion will start automatically once the analysis is complete."
             }
           }
         },
@@ -1101,7 +1102,8 @@
               "content": "Ce fichier nécessite une conversion pour être édité. Une copie sera créée : votre fichier original reste intact.",
               "cancel": "Annuler",
               "confirm": "Convertir",
-              "error": "La conversion a échoué. Veuillez réessayer."
+              "error": "La conversion a échoué. Veuillez réessayer.",
+              "analyzing_notice": "Ce fichier est encore en cours d'analyse antivirus. La conversion démarrera automatiquement une fois l'analyse terminée."
             }
           }
         },
@@ -1706,7 +1708,8 @@
               "content": "Dit bestand moet worden geconverteerd om te kunnen bewerken. Er wordt een kopie gemaakt: uw originele bestand blijft ongewijzigd.",
               "cancel": "Annuleren",
               "confirm": "Converteren",
-              "error": "Conversie mislukt. Probeer het opnieuw."
+              "error": "Conversie mislukt. Probeer het opnieuw.",
+              "analyzing_notice": "Dit bestand wordt nog gecontroleerd op malware. De conversie start automatisch zodra de analyse is voltooid."
             }
           }
         },

--- a/src/frontend/apps/drive/src/features/i18n/translations.json
+++ b/src/frontend/apps/drive/src/features/i18n/translations.json
@@ -511,8 +511,7 @@
             "delete": "Delete"
           },
           "duplicating": "duplication in progress",
-          "converting": "conversion in progress",
-          "analyzing": "analysis in progress"
+          "converting": "conversion in progress"
         }
       },
       "anonymous_cta": {
@@ -1123,8 +1122,7 @@
             "delete": "Supprimer"
           },
           "duplicating": "duplication en cours",
-          "converting": "conversion en cours",
-          "analyzing": "analyse en cours"
+          "converting": "conversion en cours"
         }
       },
       "anonymous_cta": {
@@ -1729,8 +1727,7 @@
             "delete": "Verwijder"
           },
           "duplicating": "duplicatie bezig",
-          "converting": "conversie bezig",
-          "analyzing": "analyse bezig"
+          "converting": "conversie bezig"
         }
       },
       "anonymous_cta": {


### PR DESCRIPTION
## Purpose

After upload, a file is scanned for malware in the background (`analyzing`
state). It belongs to the user who just uploaded it and must stay fully
usable meanwhile. Instead, such items were locked in the UI, and converting
a legacy Office file was only offered once the analysis had finished.

## Proposal

- Keep `analyzing` items accessible: they are polled to refresh their
  abilities but no longer treated as transient/locked; the "analysis in
  progress" text becomes a non-blocking badge.
- Allow converting a file while it is still being analyzed: the convert
  ability and the conversion request are accepted during `analyzing`, but
  the real conversion is deferred until analysis confirms the source is safe
  (`ready`), and aborts if the file turns suspicious.
- Dev: the dummy malware backend now delays its result so the `analyzing`
  state is observable locally.