### PR TITLE
✨(frontend) show the user's workspaces in the sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Added
 
+- ✨(frontend) show the user's workspaces (personal + shared/team drives) in the sidebar
 - ✨(backend) allow converting a file while it is being analyzed
 - ✨(frontend) add file type, contact and modification date topbar filters
 - ✨(frontend) add location, file type, contact and date search filters

--- a/src/frontend/apps/drive/src/features/explorer/components/GlobalExplorerContext.tsx
+++ b/src/frontend/apps/drive/src/features/explorer/components/GlobalExplorerContext.tsx
@@ -331,6 +331,18 @@ const TreeProviderInitializer = ({
     };
 
     items.push(favoritesNode);
+
+    // The user's workspaces (root items) as top-level sidebar entries: the
+    // personal main workspace ("Espace de stockage") plus every shared/team
+    // drive they can access. Each node is lazily expandable through the tree's
+    // onLoadChildren handler, like any other item.
+    const workspaces = await getDriver().getItems({ type: ItemType.FOLDER });
+    items.push(
+      ...(itemsToTreeItems(
+        workspaces.children,
+      ) as TreeViewDataType<TreeItem>[]),
+    );
+
     treeContext?.treeData.resetTree(items);
     setTreeIsInitialized(true);
   };


### PR DESCRIPTION
## Purpose

The sidebar tree is seeded with the **Favorites** node only (`resetTree([favoritesNode])`), even though its own comment says _"root items (aka workspaces)"_. As a result a user's **workspaces never appear as sidebar entries** — the personal main workspace and any shared/team drive are only reachable inside the _My files_ / _Shared with me_ content views. This also matches the sidebar in `docs/assets/Drive_screenshot.png` ("Espace de stockage"), which the current build doesn't render.

## What changes

Seed the sidebar tree with the user's root items in addition to Favorites — each becomes a first-class, lazily-expandable entry through the existing `onLoadChildren` handler. The personal main workspace already renders as "Espace de stockage" via `getItemTitle`. No new components or endpoints.

## Result

- Personal main workspace + every shared/team drive the user can access appear in the sidebar.
- Pairs naturally with team-based access (#762 / #763): a team-shared "Company drive" becomes a persistent sidebar entry for every member.

## Notes

This touches a design-led area — happy to align with your Figma and adjust ordering, grouping, or styling. Opening it as a concrete, working starting point rather than a spec.

_Context: deploying Drive as the "drive" pillar of email.eu, a sovereign EU business workspace._
