### PR TITLE
🐛(frontend) refresh the Recent view after item mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to
 
 ### Fixed
 
+- 🐛(frontend) refresh the Recent view after item mutations
 - 🐛(frontend) keep uploaded items usable while malware analysis runs
 - 🐛(backend) stream export files from S3 without buffering
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- 🐛(frontend) refresh the Recent view after item mutations
+
 ## [v0.22.0] - 2026-09-09
 
 ### Added

--- a/src/frontend/apps/drive/src/features/explorer/hooks/useRefreshItems.ts
+++ b/src/frontend/apps/drive/src/features/explorer/hooks/useRefreshItems.ts
@@ -10,14 +10,17 @@ import { generateTreeId } from "../components/GlobalExplorerContext";
 
 export const useGetQueryKeyToRefresh = () => {
   return (parentId?: string) => {
-    const queryKeys = [["items", "infinite"]];
+    const queryKeys = [
+      ["items", "infinite"],
+      // The Recent view has its own key prefix (useInfiniteRecentItems), so
+      // invalidating ["items", "infinite"] does not prefix-match it. Without this,
+      // a mutation performed while viewing Recent (create, convert, delete,
+      // rename, upload…) doesn't refresh the list until a manual reload.
+      ["items", "recent", "infinite"],
+    ];
     if (parentId) {
       queryKeys.push(["items", parentId, "children"]);
     }
-    // let queryKey = parentId ? ["items", parentId, "children"] : [];
-    // if (queryKeyForRoute.length > 0) {
-    //   queryKey = queryKeyForRoute;
-    // }
     return queryKeys;
   };
 };

--- a/src/frontend/apps/drive/src/features/explorer/hooks/useRefreshItems.ts
+++ b/src/frontend/apps/drive/src/features/explorer/hooks/useRefreshItems.ts
@@ -10,7 +10,14 @@ import { generateTreeId } from "../components/GlobalExplorerContext";
 
 export const useGetQueryKeyToRefresh = () => {
   return (parentId?: string) => {
-    const queryKeys = [["items", "infinite"]];
+    const queryKeys = [
+      ["items", "infinite"],
+      // The Recent view has its own key prefix (useInfiniteRecentItems), so
+      // invalidating ["items", "infinite"] does not prefix-match it. Without this,
+      // a mutation performed while viewing Recent (create, convert, delete,
+      // rename, upload…) doesn't refresh the list until a manual reload.
+      ["items", "recent", "infinite"],
+    ];
     if (parentId) {
       queryKeys.push(["items", parentId, "children"]);
     }


### PR DESCRIPTION
## Bug

A mutation performed while viewing the **Recent** page does not refresh the list — a newly created / converted / renamed / deleted item only shows up after a manual page reload. Other views (My files, Shared, Favorites) refresh correctly.

## Cause

`useGetQueryKeyToRefresh` returns `["items", "infinite"]` (plus `["items", <parentId>, "children"]` when a parent is known). React Query invalidation is **prefix-based**, so `["items", "infinite"]` matches the general list views but **not** the Recent view, whose query key is `["items", "recent", "infinite"]` (`useInfiniteRecentItems`). As a result no mutation ever invalidates the Recent list.

## Fix

Also invalidate `["items", "recent", "infinite"]` in the refresh helper.

## Steps to reproduce

1. Open the **Recent** view.
2. Create a document, convert a legacy file, or delete/rename an item.
3. Observe the list does not update until a manual reload.

With this change, Recent refreshes like the other views.
