### PR TITLE
🔒(backend) constrain joserfc >=1.6.8 for CVE-2026-49852

### DIFF
--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -99,6 +99,10 @@ constraint-dependencies = [
     # (FITS GZIP decompression bomb). Pulled transitively via
     # easy_thumbnails, which has no upper bound on pillow.
     "pillow>=12.2.0",
+    # Pin joserfc above the version vulnerable to CVE-2026-49852
+    # (HMAC verify accepts an empty key). Pulled transitively via
+    # django-lasuite, which has no upper bound on joserfc.
+    "joserfc>=1.6.8",
 ]
 
 [tool.uv.build-backend]

--- a/src/backend/uv.lock
+++ b/src/backend/uv.lock
@@ -3,7 +3,10 @@ revision = 3
 requires-python = "==3.13.*"
 
 [manifest]
-constraints = [{ name = "pillow", specifier = ">=12.2.0" }]
+constraints = [
+    { name = "joserfc", specifier = ">=1.6.8" },
+    { name = "pillow", specifier = ">=12.2.0" },
+]
 
 [[package]]
 name = "amqp"
@@ -989,14 +992,14 @@ wheels = [
 
 [[package]]
 name = "joserfc"
-version = "1.6.3"
+version = "1.7.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ce/90/b8cc8635c4ce2e5e8104bf26ef147f6e599478f6329107283cdc53aae97f/joserfc-1.6.3.tar.gz", hash = "sha256:c00c2830db969b836cba197e830e738dd9dda0955f1794e55d3c636f17f5c9a6", size = 229090, upload-time = "2026-02-25T15:33:38.167Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/26/abe1ad855eb334b5ebc9c6495d4798e12bee70e5e8e815d54570710b8312/joserfc-1.7.2.tar.gz", hash = "sha256:537ffb8888b2df039cb5b6d017d7cff6f09d521ce65d89cc9b8ab752b1cff947", size = 233183, upload-time = "2026-06-29T09:03:10.868Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/4f/124b3301067b752f44f292f0b9a74e837dd75ff863ee39500a082fc4c733/joserfc-1.6.3-py3-none-any.whl", hash = "sha256:6beab3635358cbc565cb94fb4c53d0557e6d10a15b933e2134939351590bda9a", size = 70465, upload-time = "2026-02-25T15:33:36.997Z" },
+    { url = "https://files.pythonhosted.org/packages/13/80/d1b30336582cced4dce0dae776508a6011723e32f907bc7a702c0b25890a/joserfc-1.7.2-py3-none-any.whl", hash = "sha256:ddd818c0ca9b4f17bbc2d72cb3966e6ded7502be089316c62c3cc64ae86132b5", size = 70426, upload-time = "2026-06-29T09:03:09.393Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Purpose

Trivy flagged joserfc for CVE-2026-49852: versions <=1.6.7 accept an
empty HMAC key when verifying a JWT, allowing token forgery if the
secret is misconfigured. Pulled transitively via django-lasuite, which
doesn't pin a minimum.

## Proposal

Add a `joserfc>=1.6.8` constraint in `pyproject.toml`.