### PR TITLE
🐛(frontend) prevent share modal crash on team-based accesses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to
 
 ### Fixed
 
+- 🐛(frontend) prevent the share modal from crashing on team-based accesses
 - 🐛(frontend) keep uploaded items usable while malware analysis runs
 - 🐛(backend) stream export files from S3 without buffering
 

--- a/src/frontend/apps/drive/src/features/explorer/components/modals/share/ItemShareModal.tsx
+++ b/src/frontend/apps/drive/src/features/explorer/components/modals/share/ItemShareModal.tsx
@@ -147,6 +147,13 @@ export const ItemShareModal = ({
     const accessesByUserId = new Map<string, Access>();
 
     data.forEach((access) => {
+      // Team-based accesses (access.team set, user null) grant a whole team, not a
+      // single user. This member list is keyed by user id and renders per-user
+      // rows, so skip them — otherwise `access.user.id` null-derefs and the whole
+      // modal crashes (a client-side exception).
+      if (access.team) {
+        return;
+      }
       const existing = accessesByUserId.get(access.user.id);
 
       if (!existing) {


### PR DESCRIPTION
`ItemShareModal` builds its member list keyed by `access.user.id`, but a team-based access grants a whole team and has a null `user`. The first team access hits `access.user.id` and throws `TypeError: null is not an object`, so the ErrorBoundary unmounts the **entire** share modal ("a client-side exception has occurred") for any item that is shared with a team.

## Fix

Skip team-based accesses (identified by their non-empty `team`) when building the per-user member list, so the null `user` is never dereferenced.

Team-based accesses are not yet rendered as rows in the modal (a follow-up); this change only stops the crash so the modal opens and per-user sharing keeps working on items that also have a team access.

## Test

- Share an item with a team (an access with `team` set and `user: null`), then open the share modal: on `main` it crashes; with this change it opens normally.
