### PR TITLE
🐛(backend) fix search filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to
 
 ### Fixed
 
+- 🐛(backend) exclude folders from file type search results
 - 🐛(frontend) keep uploaded items usable while malware analysis runs
 - 🐛(backend) stream export files from S3 without buffering
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to
 
 ### Fixed
 
+- 🐛(backend) find deleted root items when searching the trashbin
 - 🐛(backend) exclude folders from file type search results
 - 🐛(frontend) keep uploaded items usable while malware analysis runs
 - 🐛(backend) stream export files from S3 without buffering

--- a/src/backend/core/api/filters.py
+++ b/src/backend/core/api/filters.py
@@ -191,6 +191,16 @@ class SearchItemFilter(ItemFilter):
         """
         return queryset
 
+    def filter_category(self, queryset, name, value):
+        """
+        Filter files by file type category, excluding folders.
+
+        Unlike the explorer listings, a search is not a navigation: folders have no
+        file type and would only add noise to the results.
+        """
+        queryset = super().filter_category(queryset, name, value)
+        return queryset.exclude(type=models.ItemTypeChoices.FOLDER)
+
     def filter_scope(self, queryset, name, value):
         """Filter items based on their scopes."""
         to_filter = Q()

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -1356,11 +1356,14 @@ class ItemViewSet(
 
         workspace = filterset.form.cleaned_data.get("workspace")
 
-        # First look for all top level items user has access to
+        # First look for all top level items user has access to. Soft deleted items
+        # are kept: a deleted root item is its own access holder and would become
+        # unreachable, even from the trashbin. The scope filter excludes them from
+        # the results.
         user = request.user
         item_access_queryset = models.ItemAccess.objects.select_related("item").filter(
             db.Q(user=user) | db.Q(team__in=user.teams),
-            item__deleted_at__isnull=True,
+            item__hard_deleted_at__isnull=True,
         )
 
         # Remove items with upload_state SUSPICIOUS for non-creators

--- a/src/backend/core/tests/items/test_api_items_search.py
+++ b/src/backend/core/tests/items/test_api_items_search.py
@@ -784,3 +784,44 @@ def test_api_items_search_excludes_pending_items():
     result_ids = [r["id"] for r in response.json()["results"]]
     assert str(ready_file.id) in result_ids
     assert len(result_ids) == 1
+
+
+def test_api_items_search_filter_category_excludes_folders():
+    """Searching by a file type category should not return folders."""
+    user = factories.UserFactory()
+    client = APIClient()
+    client.force_login(user)
+
+    workspace = factories.ItemFactory(
+        title="Workspace",
+        creator=user,
+        users=[(user, models.RoleChoices.OWNER)],
+        type=models.ItemTypeChoices.FOLDER,
+    )
+    factories.ItemFactory(
+        title="Reports",
+        parent=workspace,
+        creator=user,
+        type=models.ItemTypeChoices.FOLDER,
+    )
+    spreadsheet = factories.ItemFactory(
+        title="Data",
+        filename="data.xlsx",
+        parent=workspace,
+        creator=user,
+        type=models.ItemTypeChoices.FILE,
+        update_upload_state=models.ItemUploadStateChoices.READY,
+    )
+    factories.ItemFactory(
+        title="Report",
+        filename="report.pdf",
+        parent=workspace,
+        creator=user,
+        type=models.ItemTypeChoices.FILE,
+        update_upload_state=models.ItemUploadStateChoices.READY,
+    )
+
+    response = client.get("/api/v1.0/items/search/?category=calc")
+
+    assert response.status_code == 200
+    assert [item["id"] for item in response.json()["results"]] == [str(spreadsheet.id)]

--- a/src/backend/core/tests/items/test_api_items_search.py
+++ b/src/backend/core/tests/items/test_api_items_search.py
@@ -825,3 +825,49 @@ def test_api_items_search_filter_category_excludes_folders():
 
     assert response.status_code == 200
     assert [item["id"] for item in response.json()["results"]] == [str(spreadsheet.id)]
+
+
+def test_api_items_search_trashbin_finds_deleted_root_item():
+    """A deleted root item should still be reachable from the trashbin location."""
+    user = factories.UserFactory()
+    client = APIClient()
+    client.force_login(user)
+
+    # A root item carries its own access: deleting it removes the only access
+    # pointing at it.
+    item = factories.ItemFactory(
+        title="ywh_export_report.pdf",
+        filename="ywh_export_report.pdf",
+        creator=user,
+        users=[(user, models.RoleChoices.OWNER)],
+        type=models.ItemTypeChoices.FILE,
+        update_upload_state=models.ItemUploadStateChoices.READY,
+    )
+    item.soft_delete()
+
+    response = client.get("/api/v1.0/items/search/?location=trashbin&title=ywh_export")
+
+    assert response.status_code == 200
+    assert [result["id"] for result in response.json()["results"]] == [str(item.id)]
+
+
+def test_api_items_search_excludes_deleted_root_item_by_default():
+    """A deleted root item should stay out of the search results without a scope."""
+    user = factories.UserFactory()
+    client = APIClient()
+    client.force_login(user)
+
+    item = factories.ItemFactory(
+        title="ywh_export_report.pdf",
+        filename="ywh_export_report.pdf",
+        creator=user,
+        users=[(user, models.RoleChoices.OWNER)],
+        type=models.ItemTypeChoices.FILE,
+        update_upload_state=models.ItemUploadStateChoices.READY,
+    )
+    item.soft_delete()
+
+    response = client.get("/api/v1.0/items/search/?title=ywh_export")
+
+    assert response.status_code == 200
+    assert response.json()["results"] == []


### PR DESCRIPTION
## Purpose

Filtering by file type category on `/items/search/` also returned folders.
Folders have no file type, and a search is not a navigation.

Searching the trashbin never returned root items. A root item holds its own
access, and `search()` skipped accesses whose item was soft deleted, so a
deleted root item became unreachable from every location.

## Proposal

- [x] Exclude folders from `/items/search/?category=`, keeping them on the
      explorer listings (`list`, `children`, `recents`, `favorites`)
- [x] Rebuild the search root paths from `hard_deleted_at` instead of
      `deleted_at`, so soft deleted root items stay reachable
