### PR TITLE
✨(backend) add upload-only ("file request") link mode (RFC for #770)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Added
 
+- ✨(backend) add upload-only ("file request") link mode (#770)
 - ✨(backend) allow converting a file while it is being analyzed
 - ✨(frontend) add file type, contact and modification date topbar filters
 - ✨(frontend) add location, file type, contact and date search filters

--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -248,6 +248,7 @@ class ListItemSerializer(serializers.ModelSerializer):
             "is_favorite",
             "link_role",
             "link_reach",
+            "link_upload_only",
             "nb_accesses",
             "numchild",
             "numchild_folder",
@@ -282,6 +283,7 @@ class ListItemSerializer(serializers.ModelSerializer):
             "is_favorite",
             "link_role",
             "link_reach",
+            "link_upload_only",
             "nb_accesses",
             "path",
             "updated_at",
@@ -478,6 +480,7 @@ class ItemSerializer(ListItemSerializer):
             "is_favorite",
             "link_role",
             "link_reach",
+            "link_upload_only",
             "nb_accesses",
             "numchild",
             "numchild_folder",
@@ -583,6 +586,7 @@ class CreateItemSerializer(ItemSerializer):
             "is_favorite",
             "link_role",
             "link_reach",
+            "link_upload_only",
             "nb_accesses",
             "numchild",
             "numchild_folder",
@@ -614,6 +618,7 @@ class CreateItemSerializer(ItemSerializer):
             "is_favorite",
             "link_role",
             "link_reach",
+            "link_upload_only",
             "nb_accesses",
             "path",
             "updated_at",
@@ -746,6 +751,7 @@ class LinkItemSerializer(serializers.ModelSerializer):
         fields = [
             "link_role",
             "link_reach",
+            "link_upload_only",
         ]
 
     def validate(self, attrs):

--- a/src/backend/core/migrations/0025_item_link_upload_only.py
+++ b/src/backend/core/migrations/0025_item_link_upload_only.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0024_alter_item_upload_state"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="item",
+            name="link_upload_only",
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -970,6 +970,11 @@ class Item(TreeModel, BaseModel):
     link_role = models.CharField(
         max_length=20, choices=LinkRoleChoices.choices, default=LinkRoleChoices.READER
     )
+    # When enabled on a link with PUBLIC/AUTHENTICATED reach, the link grants
+    # upload-only (write-only) access: recipients may add files but cannot list,
+    # download, or edit existing contents. Enables "file request" collection
+    # without exposing the folder. See issue #770.
+    link_upload_only = models.BooleanField(default=False)
     creator = models.ForeignKey(
         User,
         on_delete=models.RESTRICT,
@@ -1296,18 +1301,27 @@ class Item(TreeModel, BaseModel):
         link_definition = self.computed_link_definition
 
         link_reach = link_definition["link_reach"]
-        if link_reach == LinkReachChoices.PUBLIC or (
+        link_applies = link_reach == LinkReachChoices.PUBLIC or (
             link_reach == LinkReachChoices.AUTHENTICATED and user.is_authenticated
-        ):
+        )
+        # An upload-only ("file request") link grants create-only access: it must
+        # NOT raise the user's role (which would grant read/list/download), it only
+        # permits uploads into the folder. See issue #770.
+        is_upload_only = link_applies and self.link_upload_only
+        if link_applies and not is_upload_only:
             # Set the user role to the highest role between the item role and the link role
             # Needed for a user with an access lower than link_role
             # Needed for a user without access to determine the role he has.
             role = RoleChoices.max(role, link_definition["link_role"])
         can_get = bool(role) and not is_deleted
-        retrieve = can_get or is_owner
+        # Upload-only recipients can see the target folder itself (to upload into
+        # it) but not its contents: children_list/download stay tied to can_get.
+        retrieve = can_get or is_owner or is_upload_only
         can_manage = is_owner_or_admin and not is_deleted
         can_update = (is_owner_or_admin or role == RoleChoices.EDITOR) and not is_deleted
-        can_create_children = can_update and user.is_authenticated
+        # Upload-only links intentionally allow anonymous creation, unlike the
+        # normal path which requires an authenticated editor.
+        can_create_children = (can_update and user.is_authenticated) or is_upload_only
         can_hard_delete = (
             is_owner
             if self.is_root

--- a/src/backend/core/tests/test_models_items.py
+++ b/src/backend/core/tests/test_models_items.py
@@ -1394,3 +1394,43 @@ def test_models_items_restore_complex_bis():
     assert item.ancestors_deleted_at == item.deleted_at
     assert child1.ancestors_deleted_at == item.deleted_at
     assert child2.ancestors_deleted_at == item.deleted_at
+
+
+def test_models_items_get_abilities_upload_only_link_anonymous():
+    """
+    An upload-only ("file request") public link lets an anonymous user create
+    children (upload) but not list, download, or edit existing contents. See #770.
+    """
+    item = factories.ItemFactory(
+        link_reach="public",
+        link_role="reader",
+        link_upload_only=True,
+        type=models.ItemTypeChoices.FOLDER,
+    )
+    abilities = item.get_abilities(AnonymousUser())
+
+    # Can contribute files...
+    assert abilities["children_create"] is True
+    # ...but cannot see or touch what is already there.
+    assert abilities["children_list"] is False
+    assert abilities["download"] is False
+    assert abilities["update"] is False
+    assert abilities["accesses_view"] is False
+    # Can still see the target folder itself, in order to upload into it.
+    assert abilities["retrieve"] is True
+
+
+def test_models_items_get_abilities_upload_only_ignored_when_restricted():
+    """
+    The upload-only flag only takes effect for a link that actually applies
+    (PUBLIC / AUTHENTICATED reach); a restricted link grants nothing anonymously.
+    """
+    item = factories.ItemFactory(
+        link_reach="restricted",
+        link_upload_only=True,
+        type=models.ItemTypeChoices.FOLDER,
+    )
+    abilities = item.get_abilities(AnonymousUser())
+
+    assert abilities["children_create"] is False
+    assert abilities["retrieve"] is False


### PR DESCRIPTION
Draft / RFC for #770.

## What

Adds an **upload-only ("file request")** link mode: a `link_upload_only` flag on `Item` that, on a link with PUBLIC/AUTHENTICATED reach, grants **create-only** access. An (anonymous) recipient can add files but cannot list, download, or edit the folder's existing contents.

This is the confidentiality-preserving variant of #706: today the only way to let outsiders upload is Public + Editor, which exposes (and lets them edit) everything already in the folder — a leak for the common "collect documents from many separate people" use case (a therapist collecting client documents, a teacher receiving homework, a posting receiving CVs).

## Backend changes

- `Item.link_upload_only` boolean + migration `0025`.
- `get_abilities`: an upload-only link no longer raises the user's role (read / list / download stay off), but `children_create` is granted even to anonymous users; `retrieve` stays on so the recipient can see the target folder to upload into.
- Exposed read-only on `ItemSerializer`, writable via `LinkItemSerializer` (the `link-configuration` endpoint).
- Tests for the ability behaviour (anonymous upload-only; restricted reach grants nothing).

## Deliberately not here yet

- **Frontend**: a drop-zone-only recipient view (no file listing) + the share-modal option. Fast-follow once the backend approach is agreed.
- **Main design question** 🙏: I kept this a **Drive-local flag** to avoid touching `django-lasuite`. If you'd rather model it as a new **link role** in `django-lasuite` (consistent across La Suite apps), I'm happy to reshape it — that's the main thing I'd like your steer on.
- Anti-abuse (per-link size / quota / rate limits) and validation that upload-only requires a non-restricted reach.

Context: we run Drive in production at [email.eu](https://email.eu) and hit this with a real customer, so we're keen to see it through. Feedback very welcome.
