### PR TITLE
🐛(backend) delete malware detection record when purging an item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to
 ### Fixed
 
 - 🐛(docker) pin collabora image and adapt to its new runtime contract
+- 🐛(backend) delete malware detection record when purging an item
 
 ## [v0.20.0] - 2026-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to
 ### Changed
 
 - 🔧(docker) drop the unused pip upgrade and apk caches from the image
+- ✨(backend) expose item existence in the malware detection admin
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to
 
 - 🔧(docker) drop the unused pip upgrade and apk caches from the image
 - ✨(backend) expose item existence in the malware detection admin
+- ✨(backend) show human readable item size in the admin
 
 ### Fixed
 

--- a/src/backend/core/admin.py
+++ b/src/backend/core/admin.py
@@ -5,10 +5,16 @@ from functools import partial
 from django.contrib import admin, messages
 from django.contrib.auth import admin as auth_admin
 from django.db import transaction
+from django.db.models import Exists, OuterRef, Subquery, UUIDField
+from django.db.models.fields.json import KeyTextTransform
+from django.db.models.functions import Cast
 from django.shortcuts import redirect
+from django.template.defaultfilters import filesizeformat
 from django.utils.translation import gettext_lazy as _
 
 from lasuite.malware_detection import malware_detection
+from lasuite.malware_detection.admin import MalwareDetectionAdmin as BaseMalwareDetectionAdmin
+from lasuite.malware_detection.models import MalwareDetection
 
 from core import models
 from core.tasks.user_reconciliation import user_reconciliation_csv_import_job
@@ -261,3 +267,62 @@ class InvitationAdmin(admin.ModelAdmin):
     def save_model(self, request, obj, form, change):
         obj.issuer = request.user
         obj.save()
+
+
+class ItemExistsFilter(admin.SimpleListFilter):
+    """Filter malware detection records on the existence of their related item."""
+
+    title = _("item exists")
+    parameter_name = "item_exists"
+
+    def lookups(self, request, model_admin):
+        """Return the filter options."""
+        return [("yes", _("Yes")), ("no", _("No"))]
+
+    def queryset(self, request, queryset):
+        """Filter the queryset on the item_exists annotation."""
+        if self.value() == "yes":
+            return queryset.filter(item_exists=True)
+        if self.value() == "no":
+            return queryset.filter(item_exists=False)
+        return queryset
+
+
+admin.site.unregister(MalwareDetection)
+
+
+@admin.register(MalwareDetection)
+class MalwareDetectionAdmin(BaseMalwareDetectionAdmin):
+    """Admin class for the MalwareDetection model with item existence tooling."""
+
+    list_display = BaseMalwareDetectionAdmin.list_display + ("item_exists", "item_size")
+    list_filter = BaseMalwareDetectionAdmin.list_filter + (ItemExistsFilter,)
+
+    def get_queryset(self, request):
+        """Annotate records with the existence and size of their related item."""
+        related_items = models.Item.objects.filter(
+            id=Cast(
+                KeyTextTransform("item_id", OuterRef("parameters")),
+                output_field=UUIDField(),
+            )
+        )
+        return (
+            super()
+            .get_queryset(request)
+            .annotate(
+                item_exists=Exists(related_items),
+                item_size=Subquery(related_items.values("size")[:1]),
+            )
+        )
+
+    @admin.display(boolean=True, description=_("item exists"))
+    def item_exists(self, obj):
+        """Return whether the item of the record still exists."""
+        return obj.item_exists
+
+    @admin.display(description=_("item size"), ordering="item_size")
+    def item_size(self, obj):
+        """Return the human readable size of the item file."""
+        if obj.item_size is None:
+            return None
+        return filesizeformat(obj.item_size)

--- a/src/backend/core/admin.py
+++ b/src/backend/core/admin.py
@@ -165,7 +165,7 @@ class ItemAdmin(admin.ModelAdmin):
                     "id",
                     "title",
                     "filename",
-                    "size",
+                    "size_display",
                     "deleted_at",
                     "ancestors_deleted_at",
                     "malware_detection_info",
@@ -215,7 +215,7 @@ class ItemAdmin(admin.ModelAdmin):
         "numchild",
         "path",
         "filename",
-        "size",
+        "size_display",
         "deleted_at",
         "ancestors_deleted_at",
         "malware_detection_info",
@@ -230,6 +230,13 @@ class ItemAdmin(admin.ModelAdmin):
         queryset = queryset.annotate_with_numchild()
 
         return queryset
+
+    @admin.display(description=_("size"))
+    def size_display(self, obj):
+        """Return the human readable size of the item file."""
+        if obj.size is None:
+            return None
+        return filesizeformat(obj.size)
 
     def trigger_file_analysis(self, request, queryset):
         """Reanalyse the file of the items."""

--- a/src/backend/core/tasks/item.py
+++ b/src/backend/core/tasks/item.py
@@ -13,6 +13,7 @@ from django.utils import timezone
 
 import boto3
 import botocore
+from lasuite.malware_detection.models import MalwareDetection
 
 from core.api.utils import sanitize_filename
 from core.models import Item, ItemTypeChoices, ItemUploadStateChoices
@@ -66,6 +67,9 @@ def process_item_purge(item_id):
             except FileNotFoundError:
                 # File already absent from storage: ignore and continue
                 pass
+
+            # Drop any malware detection record so the analysis is not relaunched
+            MalwareDetection.objects.filter(path=item.file_key).delete()
 
         item.delete()
 

--- a/src/backend/core/tests/tasks/items/test_process_item_purge.py
+++ b/src/backend/core/tests/tasks/items/test_process_item_purge.py
@@ -9,6 +9,7 @@ from django.core.files.storage import default_storage
 from django.utils import timezone
 
 import pytest
+from lasuite.malware_detection.models import MalwareDetection, MalwareDetectionStatus
 
 from core import factories, models
 from core.tasks.item import process_item_purge
@@ -206,6 +207,28 @@ def test_process_item_purge_file_missing_from_storage():
     process_item_purge(item.id)
 
     assert not models.Item.objects.filter(id=item.id).exists()
+
+
+def test_process_item_purge_deletes_malware_detection_record():
+    """Test the process item purge task deletes the related malware detection record."""
+    item = factories.ItemFactory(
+        type=models.ItemTypeChoices.FILE,
+        filename="foo.txt",
+    )
+    item.soft_delete()
+    item.hard_delete()
+    default_storage.save(item.file_key, BytesIO(b"my prose"))
+    MalwareDetection.objects.create(
+        path=item.file_key,
+        status=MalwareDetectionStatus.PROCESSING,
+        parameters={"item_id": str(item.id)},
+    )
+
+    process_item_purge(item.id)
+
+    assert not models.Item.objects.filter(id=item.id).exists()
+    assert not default_storage.exists(item.file_key)
+    assert not MalwareDetection.objects.filter(path=item.file_key).exists()
 
 
 def test_process_item_purge_stops_on_subfolder_delete_failure(monkeypatch):

--- a/src/backend/core/tests/test_admin_malware_detection.py
+++ b/src/backend/core/tests/test_admin_malware_detection.py
@@ -1,0 +1,66 @@
+"""Tests for the malware detection admin class."""
+
+from django.contrib import admin
+from django.test import RequestFactory
+
+import pytest
+from lasuite.malware_detection.models import MalwareDetection, MalwareDetectionStatus
+
+from core import factories, models
+from core.admin import MalwareDetectionAdmin
+
+pytestmark = pytest.mark.django_db
+
+
+def _create_detections():
+    """Create one detection related to an existing item and one orphan detection."""
+    item = factories.ItemFactory(type=models.ItemTypeChoices.FILE, filename="foo.txt", size=1234)
+    detection = MalwareDetection.objects.create(
+        path=item.file_key,
+        status=MalwareDetectionStatus.PROCESSING,
+        parameters={"item_id": str(item.id)},
+    )
+    orphan = MalwareDetection.objects.create(
+        path="item/00000000-0000-0000-0000-000000000000/file.bin",
+        status=MalwareDetectionStatus.PROCESSING,
+        parameters={"item_id": "00000000-0000-0000-0000-000000000000"},
+    )
+    return detection, orphan
+
+
+def _changelist_queryset(admin_instance, params):
+    """Return the changelist queryset for the given GET parameters."""
+    request = RequestFactory().get("/", params)
+    request.user = factories.UserFactory(is_staff=True, is_superuser=True)
+    changelist = admin_instance.get_changelist_instance(request)
+    return changelist.get_queryset(request)
+
+
+def test_admin_malware_detection_annotates_item_existence():
+    """The admin queryset annotates each record with the existence of its item."""
+    detection, orphan = _create_detections()
+
+    queryset = MalwareDetectionAdmin(MalwareDetection, admin.site).get_queryset(None)
+
+    assert queryset.get(pk=detection.pk).item_exists is True
+    assert queryset.get(pk=orphan.pk).item_exists is False
+
+
+def test_admin_malware_detection_annotates_item_size():
+    """The admin queryset annotates each record with the size of its item."""
+    detection, orphan = _create_detections()
+
+    queryset = MalwareDetectionAdmin(MalwareDetection, admin.site).get_queryset(None)
+
+    assert queryset.get(pk=detection.pk).item_size == 1234
+    assert queryset.get(pk=orphan.pk).item_size is None
+
+
+def test_admin_malware_detection_item_exists_filter():
+    """The item exists filter splits records on the existence of their item."""
+    detection, orphan = _create_detections()
+    admin_instance = MalwareDetectionAdmin(MalwareDetection, admin.site)
+
+    assert list(_changelist_queryset(admin_instance, {"item_exists": "yes"})) == [detection]
+    assert list(_changelist_queryset(admin_instance, {"item_exists": "no"})) == [orphan]
+    assert set(_changelist_queryset(admin_instance, {})) == {detection, orphan}


### PR DESCRIPTION
## Purpose

When an item is purged while its malware analysis is still pending or
processing, the detection record is left behind. The analysis keeps
being relaunched and crashes on the missing file: records stay stuck
in processing and hold analysis slots.

## Proposal

- [x] delete the malware detection record when purging an item
- [x] add an "item exists" column and filter to the malware detection
  admin, to help cleaning up orphan records already accumulated
- [x] show human readable item sizes in the admin