### PR TITLE
✨ Make the upload ACL configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- ✨(backend) make the upload ACL configurable to support GCS based storages
+
 ### Changed
 
 - 🔧(docker) drop the unused pip upgrade and apk caches from the image

--- a/docs/env.md
+++ b/docs/env.md
@@ -15,6 +15,7 @@ This document lists all configurable environment variables for the Drive applica
 | `AWS_S3_DOMAIN_REPLACE` | The S3 domain to used by the frontend application. Used by the docker compose stack. | `None` |
 | `AWS_S3_REGION_NAME` | AWS S3 region name for file storage | `None` |
 | `AWS_S3_SECRET_ACCESS_KEY` | AWS S3 secret access key for file storage | `None` |
+| `AWS_S3_UPLOAD_ACL` | ACL applied to uploaded objects, set to an empty string for storages that do not support ACLs (e.g. GCS based providers). When empty, objects get the bucket's default object ACL: make sure it keeps objects private | `private` |
 | `AWS_S3_UPLOAD_POLICY_EXPIRATION` | AWS S3 upload policy expiration time in seconds | `86400` (24h) |
 | `AWS_STORAGE_BUCKET_NAME` | AWS S3 bucket name for file storage | `drive-media-storage` |
 | `CACHES_DEFAULT_TIMEOUT` | Default cache timeout in seconds | `30` |

--- a/src/backend/core/api/utils.py
+++ b/src/backend/core/api/utils.py
@@ -130,10 +130,14 @@ def generate_upload_policy(item):
     else:
         s3_client = default_storage.connection.meta.client
 
+    params = {"Bucket": default_storage.bucket_name, "Key": key}
+    if settings.AWS_S3_UPLOAD_ACL:
+        params["ACL"] = settings.AWS_S3_UPLOAD_ACL
+
     # Generate the policy
     policy = s3_client.generate_presigned_url(
         ClientMethod="put_object",
-        Params={"Bucket": default_storage.bucket_name, "Key": key, "ACL": "private"},
+        Params=params,
         ExpiresIn=settings.AWS_S3_UPLOAD_POLICY_EXPIRATION,
     )
 

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -2243,6 +2243,7 @@ class ConfigView(drf.views.APIView):
             Return a dictionary of public settings.
         """
         array_settings = [
+            "AWS_S3_UPLOAD_ACL",
             "CRISP_WEBSITE_ID",
             "DATA_UPLOAD_MAX_MEMORY_SIZE",
             "ENVIRONMENT",

--- a/src/backend/core/tests/items/test_api_items_create.py
+++ b/src/backend/core/tests/items/test_api_items_create.py
@@ -6,6 +6,7 @@ from concurrent.futures import ThreadPoolExecutor
 from urllib.parse import parse_qs, urlparse
 from uuid import uuid4
 
+from django.test import override_settings
 from django.utils import timezone
 
 import pytest
@@ -135,6 +136,30 @@ def test_api_items_create_file_authenticated_success():
     assert query_params.pop("X-Amz-Signature") is not None
 
     assert len(query_params) == 0
+
+
+@override_settings(AWS_S3_UPLOAD_ACL="")
+def test_api_items_create_file_authenticated_success_without_upload_acl():
+    """The upload policy should not sign an ACL when AWS_S3_UPLOAD_ACL is empty."""
+    user = factories.UserFactory()
+
+    client = APIClient()
+    client.force_login(user)
+
+    response = client.post(
+        "/api/v1.0/items/",
+        {
+            "type": ItemTypeChoices.FILE,
+            "filename": "file.txt",
+        },
+        format="json",
+    )
+    assert response.status_code == 201
+
+    policy_parsed = urlparse(response.json()["policy"])
+    query_params = parse_qs(policy_parsed.query)
+
+    assert query_params["X-Amz-SignedHeaders"] == ["host"]
 
 
 def test_api_items_create_file_authenticated_extension_not_allowed():

--- a/src/backend/core/tests/test_api_config.py
+++ b/src/backend/core/tests/test_api_config.py
@@ -18,6 +18,7 @@ pytestmark = pytest.mark.django_db
 
 
 @override_settings(
+    AWS_S3_UPLOAD_ACL="private",
     CRISP_WEBSITE_ID="123",
     DATA_UPLOAD_MAX_MEMORY_SIZE=2048,
     FRONTEND_THEME="test-theme",
@@ -59,6 +60,7 @@ def test_api_config(is_authenticated):
     response = client.get("/api/v1.0/config/")
     assert response.status_code == HTTP_200_OK
     assert response.json() == {
+        "AWS_S3_UPLOAD_ACL": "private",
         "CRISP_WEBSITE_ID": "123",
         "DATA_UPLOAD_MAX_MEMORY_SIZE": 2048,
         "ENVIRONMENT": "test",

--- a/src/backend/drive/settings.py
+++ b/src/backend/drive/settings.py
@@ -212,6 +212,14 @@ class Base(Configuration):
         environ_name="AWS_S3_SIGNATURE_VERSION",
         environ_prefix=None,
     )
+    # ACL applied to uploaded objects and signed in the upload policy. Set it
+    # to an empty string for object storages that do not support ACLs (e.g.
+    # Google Cloud Storage based providers).
+    AWS_S3_UPLOAD_ACL = values.Value(
+        "private",
+        environ_name="AWS_S3_UPLOAD_ACL",
+        environ_prefix=None,
+    )
     AWS_S3_UPLOAD_POLICY_EXPIRATION = values.Value(
         60,  # 1 minute
         environ_name="AWS_S3_UPLOAD_POLICY_EXPIRATION",

--- a/src/frontend/apps/drive/src/features/drivers/Driver.ts
+++ b/src/frontend/apps/drive/src/features/drivers/Driver.ts
@@ -160,6 +160,7 @@ export abstract class Driver {
     parentId?: string;
     filename: string;
     file: File;
+    uploadAcl?: string;
     progressHandler?: (progress: number) => void;
   }): { promise: Promise<Item>; abort: () => Promise<void> };
   abstract createFileFromTemplate(data: {

--- a/src/frontend/apps/drive/src/features/drivers/implementations/StandardDriver.ts
+++ b/src/frontend/apps/drive/src/features/drivers/implementations/StandardDriver.ts
@@ -355,6 +355,7 @@ export class StandardDriver extends Driver {
     parentId?: string;
     file: File;
     filename: string;
+    uploadAcl?: string;
     progressHandler?: (progress: number) => void;
   }): { promise: Promise<Item>; abort: () => Promise<void> } {
     let abortUpload: (() => void) | undefined;
@@ -368,7 +369,7 @@ export class StandardDriver extends Driver {
     };
 
     const promise = (async () => {
-      const { parentId, file, progressHandler, ...rest } = data;
+      const { parentId, file, uploadAcl, progressHandler, ...rest } = data;
       const url = parentId ? `items/${parentId}/children/` : `items/`;
       const response = await fetchAPI(
         url,
@@ -401,9 +402,12 @@ export class StandardDriver extends Driver {
         progressHandler?.(proxiedProgress);
       };
 
-      const upload = uploadFile(item.policy, file, (progress) => {
-        progressHandlerProxy(progress);
-      });
+      const upload = uploadFile(
+        item.policy,
+        file,
+        uploadAcl,
+        progressHandlerProxy,
+      );
       abortUpload = upload.abort;
 
       if (aborted) {
@@ -529,17 +533,21 @@ const jsonToItem = (data: any): Item => {
  * Upload a file, using XHR so we can report on progress through a handler.
  * @param url The URL to PUT the file to.
  * @param file The file to upload.
+ * @param acl The ACL signed in the upload policy, empty when the policy signs none.
  * @param progressHandler A handler that receives progress updates as a single integer `0 <= x <= 100`.
  */
 export const uploadFile = (
   url: string,
   file: File,
+  acl: string | undefined,
   progressHandler: (progress: number) => void,
 ): { promise: Promise<unknown>; abort: () => void } => {
   const xhr = new XMLHttpRequest();
   const promise = new Promise((resolve, reject) => {
     xhr.open("PUT", url);
-    xhr.setRequestHeader("X-amz-acl", "private");
+    if (acl) {
+      xhr.setRequestHeader("X-amz-acl", acl);
+    }
     xhr.setRequestHeader("Content-Type", file.type);
 
     xhr.addEventListener("error", reject);

--- a/src/frontend/apps/drive/src/features/drivers/implementations/__tests__/StandardDriver.uploadFile.test.ts
+++ b/src/frontend/apps/drive/src/features/drivers/implementations/__tests__/StandardDriver.uploadFile.test.ts
@@ -1,0 +1,60 @@
+import { uploadFile } from "../StandardDriver";
+
+class FakeXMLHttpRequest {
+  static instances: FakeXMLHttpRequest[] = [];
+  headers: Record<string, string> = {};
+  upload = { addEventListener: jest.fn() };
+  open = jest.fn();
+  send = jest.fn();
+  abort = jest.fn();
+  addEventListener = jest.fn();
+
+  constructor() {
+    FakeXMLHttpRequest.instances.push(this);
+  }
+
+  setRequestHeader(name: string, value: string) {
+    this.headers[name] = value;
+  }
+}
+
+describe("uploadFile", () => {
+  const originalXMLHttpRequest = global.XMLHttpRequest;
+  const file = new File(["content"], "file.txt", { type: "text/plain" });
+
+  beforeEach(() => {
+    FakeXMLHttpRequest.instances = [];
+    global.XMLHttpRequest =
+      FakeXMLHttpRequest as unknown as typeof XMLHttpRequest;
+  });
+
+  afterEach(() => {
+    global.XMLHttpRequest = originalXMLHttpRequest;
+  });
+
+  it("does not send an ACL header when the ACL is undefined", () => {
+    uploadFile("https://example.com/upload", file, undefined, jest.fn());
+    expect(FakeXMLHttpRequest.instances[0].headers).not.toHaveProperty(
+      "X-amz-acl",
+    );
+  });
+
+  it("sends the configured ACL header", () => {
+    uploadFile(
+      "https://example.com/upload",
+      file,
+      "bucket-owner-full-control",
+      jest.fn(),
+    );
+    expect(FakeXMLHttpRequest.instances[0].headers["X-amz-acl"]).toBe(
+      "bucket-owner-full-control",
+    );
+  });
+
+  it("does not send an ACL header when the ACL is empty", () => {
+    uploadFile("https://example.com/upload", file, "", jest.fn());
+    expect(FakeXMLHttpRequest.instances[0].headers).not.toHaveProperty(
+      "X-amz-acl",
+    );
+  });
+});

--- a/src/frontend/apps/drive/src/features/drivers/types.ts
+++ b/src/frontend/apps/drive/src/features/drivers/types.ts
@@ -201,6 +201,7 @@ export interface ThemeCustomization {
 }
 
 export type ApiConfig = {
+  AWS_S3_UPLOAD_ACL?: string;
   DATA_UPLOAD_MAX_MEMORY_SIZE?: number;
   POSTHOG_KEY?: string;
   POSTHOG_HOST?: string;

--- a/src/frontend/apps/drive/src/features/explorer/hooks/useUpload.tsx
+++ b/src/frontend/apps/drive/src/features/explorer/hooks/useUpload.tsx
@@ -561,6 +561,7 @@ export const useUploadZone = ({ item }: { item: Item }) => {
           filename: file.name,
           file,
           parentId: file.parentId,
+          uploadAcl: config.AWS_S3_UPLOAD_ACL,
           progressHandler: (progress) => {
             setUploadingState((prev) => ({
               ...prev,


### PR DESCRIPTION
## Purpose

Uploads fail on GCS based object storages such as S3NS: their S3
compatibility layer consumes the `x-amz-acl` header, so the presigned
PUT URL signing it is rejected with a `MalformedSecurityHeader` error.
See https://documentation.s3ns.fr/storage/docs/aws-simple-migration

## Proposal

- [x] add an `AWS_S3_UPLOAD_ACL` setting (default `private`, behavior
  unchanged), signed in the upload policy only when non empty and
  exposed in the config endpoint
- [x] send the `X-amz-acl` header from the frontend only when the
  configured ACL is non empty

Setting `AWS_S3_UPLOAD_ACL=""` enables uploads to storages that do not
support ACLs.