### PR TITLE
♻️(settings) replace empty upload ACL with a "default" sentinel

### DIFF
--- a/docs/env.md
+++ b/docs/env.md
@@ -15,7 +15,7 @@ This document lists all configurable environment variables for the Drive applica
 | `AWS_S3_DOMAIN_REPLACE` | The S3 domain to used by the frontend application. Used by the docker compose stack. | `None` |
 | `AWS_S3_REGION_NAME` | AWS S3 region name for file storage | `None` |
 | `AWS_S3_SECRET_ACCESS_KEY` | AWS S3 secret access key for file storage | `None` |
-| `AWS_S3_UPLOAD_ACL` | ACL applied to uploaded objects, set to an empty string for storages that do not support ACLs (e.g. GCS based providers). When empty, objects get the bucket's default object ACL: make sure it keeps objects private | `private` |
+| `AWS_S3_UPLOAD_ACL` | ACL applied to uploaded objects, set to `default` for storages that do not support ACLs (e.g. GCS based providers). With `default`, objects get the bucket's default object ACL: make sure it keeps objects private | `private` |
 | `AWS_S3_UPLOAD_POLICY_EXPIRATION` | AWS S3 upload policy expiration time in seconds | `86400` (24h) |
 | `AWS_STORAGE_BUCKET_NAME` | AWS S3 bucket name for file storage | `drive-media-storage` |
 | `CACHES_DEFAULT_TIMEOUT` | Default cache timeout in seconds | `30` |

--- a/src/backend/core/api/utils.py
+++ b/src/backend/core/api/utils.py
@@ -131,7 +131,7 @@ def generate_upload_policy(item):
         s3_client = default_storage.connection.meta.client
 
     params = {"Bucket": default_storage.bucket_name, "Key": key}
-    if settings.AWS_S3_UPLOAD_ACL:
+    if settings.AWS_S3_UPLOAD_ACL and settings.AWS_S3_UPLOAD_ACL != "default":
         params["ACL"] = settings.AWS_S3_UPLOAD_ACL
 
     # Generate the policy

--- a/src/backend/core/tests/items/test_api_items_create.py
+++ b/src/backend/core/tests/items/test_api_items_create.py
@@ -138,9 +138,9 @@ def test_api_items_create_file_authenticated_success():
     assert len(query_params) == 0
 
 
-@override_settings(AWS_S3_UPLOAD_ACL="")
+@override_settings(AWS_S3_UPLOAD_ACL="default")
 def test_api_items_create_file_authenticated_success_without_upload_acl():
-    """The upload policy should not sign an ACL when AWS_S3_UPLOAD_ACL is empty."""
+    """The upload policy should not sign an ACL when AWS_S3_UPLOAD_ACL is "default"."""
     user = factories.UserFactory()
 
     client = APIClient()

--- a/src/backend/drive/settings.py
+++ b/src/backend/drive/settings.py
@@ -213,8 +213,9 @@ class Base(Configuration):
         environ_prefix=None,
     )
     # ACL applied to uploaded objects and signed in the upload policy. Set it
-    # to an empty string for object storages that do not support ACLs (e.g.
-    # Google Cloud Storage based providers).
+    # to "default" to let the bucket's default object ACL apply, for object
+    # storages that do not support ACLs (e.g. Google Cloud Storage based
+    # providers).
     AWS_S3_UPLOAD_ACL = values.Value(
         "private",
         environ_name="AWS_S3_UPLOAD_ACL",

--- a/src/frontend/apps/drive/src/features/drivers/implementations/StandardDriver.ts
+++ b/src/frontend/apps/drive/src/features/drivers/implementations/StandardDriver.ts
@@ -533,7 +533,7 @@ const jsonToItem = (data: any): Item => {
  * Upload a file, using XHR so we can report on progress through a handler.
  * @param url The URL to PUT the file to.
  * @param file The file to upload.
- * @param acl The ACL signed in the upload policy, empty when the policy signs none.
+ * @param acl The ACL signed in the upload policy, absent when the policy signs none.
  * @param progressHandler A handler that receives progress updates as a single integer `0 <= x <= 100`.
  */
 export const uploadFile = (

--- a/src/frontend/apps/drive/src/features/explorer/hooks/useUpload.tsx
+++ b/src/frontend/apps/drive/src/features/explorer/hooks/useUpload.tsx
@@ -561,7 +561,10 @@ export const useUploadZone = ({ item }: { item: Item }) => {
           filename: file.name,
           file,
           parentId: file.parentId,
-          uploadAcl: config.AWS_S3_UPLOAD_ACL,
+          uploadAcl:
+            config.AWS_S3_UPLOAD_ACL === "default"
+              ? undefined
+              : config.AWS_S3_UPLOAD_ACL,
           progressHandler: (progress) => {
             setUploadingState((prev) => ({
               ...prev,


### PR DESCRIPTION
## Purpose

Follow-up to #780. An empty `AWS_S3_UPLOAD_ACL` in an env file is easy to
mistake for an unset variable, while unset must keep meaning `private`.

## Proposal

Use the explicit `default` value to let the bucket's default object ACL
apply (GCS based storages): the backend skips the ACL in the upload policy
when the setting is `default`, and the frontend translates it to "no ACL
header" where the config is read.