### PR TITLE
Move favorite API endpoint to `/items/favorites/`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to
 - 🔧(docker) drop the unused pip upgrade and apk caches from the image
 - ✨(backend) expose item existence in the malware detection admin
 - ✨(backend) show human readable item size in the admin
+- 🚚(global) move favorite items API endpoint to `/items/favorites/`
 
 ### Fixed
 

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -365,7 +365,7 @@ class ItemViewSet(
     3. **Favorite**: Get list of favorite items for a user. Mark or unmark
         a item as favorite.
         Examples:
-        - GET /items/favorite/
+        - GET /items/favorites/
         - POST, DELETE /items/{id}/favorite/
 
     4. **Link Configuration**: Update item link configuration.
@@ -915,6 +915,7 @@ class ItemViewSet(
         detail=False,
         methods=["get"],
         permission_classes=[permissions.IsAuthenticated],
+        url_path="favorites",
     )
     def favorite_list(self, request, *args, **kwargs):
         """Get list of favorite items for the current user."""

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -356,8 +356,8 @@ class ItemViewSet(
        Example: DELETE /items/{id}/
 
     ### Additional Actions:
-    1. **Trashbin**: List soft deleted items for a item owner
-        Example: GET /items/{id}/trashbin/
+    1. **Trashbin**: List soft deleted items for an items owner
+        Example: GET /items/trashbin/
 
     2. **Children**: List or create child items.
         Example: GET, POST /items/{id}/children/

--- a/src/backend/core/tests/items/test_api_items_favorite_list.py
+++ b/src/backend/core/tests/items/test_api_items_favorite_list.py
@@ -13,7 +13,7 @@ def test_api_item_favorite_list_anonymous():
 
     client = APIClient()
 
-    response = client.get("/api/v1.0/items/favorite_list/")
+    response = client.get("/api/v1.0/items/favorites/")
 
     assert response.status_code == 401
 
@@ -27,7 +27,7 @@ def test_api_item_favorite_list_authenticated_no_favorite():
 
     client.force_login(user)
 
-    response = client.get("/api/v1.0/items/favorite_list/")
+    response = client.get("/api/v1.0/items/favorites/")
 
     assert response.status_code == 200
 
@@ -59,7 +59,7 @@ def test_api_item_favorite_list_authenticated_with_favorite():
         item__update_upload_state=models.ItemUploadStateChoices.READY,
     ).item
 
-    response = client.get("/api/v1.0/items/favorite_list/")
+    response = client.get("/api/v1.0/items/favorites/")
 
     assert response.status_code == 200
 
@@ -139,7 +139,7 @@ def test_api_item_favorite_list_with_suspicious_items():
     )
 
     # Non-creator should only see normal item in favorite list, not suspicious one
-    response = client.get("/api/v1.0/items/favorite_list/")
+    response = client.get("/api/v1.0/items/favorites/")
     assert response.status_code == 200
     content = response.json()
 
@@ -151,7 +151,7 @@ def test_api_item_favorite_list_with_suspicious_items():
 
     # Creator should see all their favorited items including suspicious one
     client.force_login(creator)
-    response = client.get("/api/v1.0/items/favorite_list/")
+    response = client.get("/api/v1.0/items/favorites/")
     assert response.status_code == 200
     content = response.json()
 
@@ -184,7 +184,7 @@ def test_api_item_favorite_list_children():
 
     factories.UserItemAccessFactory(item=parent_item, user=user)
 
-    response = client.get("/api/v1.0/items/favorite_list/")
+    response = client.get("/api/v1.0/items/favorites/")
     assert response.status_code == 200
     content = response.json()
     assert content["count"] == 1
@@ -215,7 +215,7 @@ def test_api_item_favorite_list_filtering(django_assert_num_queries):
     )
 
     with django_assert_num_queries(6):
-        response = client.get("/api/v1.0/items/favorite_list/?type=folder")
+        response = client.get("/api/v1.0/items/favorites/?type=folder")
 
     assert response.status_code == 200
     content = response.json()
@@ -223,7 +223,7 @@ def test_api_item_favorite_list_filtering(django_assert_num_queries):
     assert content["results"][0]["id"] == str(child_item.id)
 
     with django_assert_num_queries(6):
-        response = client.get("/api/v1.0/items/favorite_list/?type=file")
+        response = client.get("/api/v1.0/items/favorites/?type=file")
 
     assert response.status_code == 200
     content = response.json()
@@ -279,7 +279,7 @@ def test_api_item_favorite_list_ordering_by_fields(ordering, django_assert_num_q
     querystring = f"?ordering={ordering}"
 
     with django_assert_num_queries(6):
-        response = client.get(f"/api/v1.0/items/favorite_list/{querystring:s}")
+        response = client.get(f"/api/v1.0/items/favorites/{querystring:s}")
     assert response.status_code == 200
     results = response.json()["results"]
     assert len(results) == 2
@@ -313,7 +313,7 @@ def test_api_items_favorite_list_filter_category():
         update_upload_state=models.ItemUploadStateChoices.READY,
     )
 
-    response = client.get("/api/v1.0/items/favorite_list/?category=image")
+    response = client.get("/api/v1.0/items/favorites/?category=image")
 
     assert response.status_code == 200
     ids = {result["id"] for result in response.json()["results"]}

--- a/src/frontend/apps/drive/src/features/drivers/implementations/StandardDriver.ts
+++ b/src/frontend/apps/drive/src/features/drivers/implementations/StandardDriver.ts
@@ -342,7 +342,7 @@ export class StandardDriver extends Driver {
   async getFavoriteItems(
     filters?: ItemFilters,
   ): Promise<PaginatedChildrenResult> {
-    const response = await fetchAPI(`items/favorite_list/`, {
+    const response = await fetchAPI(`items/favorites/`, {
       params: { ...convertFiltersToQueryParams(filters ?? {}), page_size: 200 },
     });
 


### PR DESCRIPTION
## Purpose

Current favorite items listing endpoint path is `/items/favorite_list/`. To respect current API semantic (_e.g._ `/items/{id}/favorite/`), we think we can make a shorter version of the endpoint path without being less explicit 😜

## Proposal

- [x] 📝(backend) fix documented `trashbin` API endpoint
- [x] 🚚(global) move favorite items API endpoint to `/items/favorites/`
