### PR TITLE
✨(frontend) open the messages widget from the help menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to
 ### Added
 
 - ✨(backend) make the upload ACL configurable to support GCS based storages
+- ✨(frontend) show the messages widget button on the homepage
+- ✨(frontend) open the messages widget from the help menu
 
 ### Changed
 

--- a/src/frontend/apps/drive/src/features/drivers/types.ts
+++ b/src/frontend/apps/drive/src/features/drivers/types.ts
@@ -222,6 +222,7 @@ export type ApiConfig = {
       legalNoticeUrl?: string;
     };
     supportEmail?: string;
+    supportMessagesWidget?: boolean;
   };
   FRONTEND_THEME?: string;
   FRONTEND_HIDE_GAUFRE?: boolean;

--- a/src/frontend/apps/drive/src/features/feedback/useMessagesWidget.tsx
+++ b/src/frontend/apps/drive/src/features/feedback/useMessagesWidget.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from "react-i18next";
 import { useAuth } from "../auth/Auth";
 import { useConfig } from "../config/ConfigProvider";
+import { WidgetHelper } from "./widget-helper";
 
 /**
  * Hook that opens the feedback widget
@@ -14,59 +15,71 @@ export const useMessagesWidget = () => {
   const widgetPath = config?.FRONTEND_FEEDBACK_MESSAGES_WIDGET_PATH;
   const channel = config?.FRONTEND_FEEDBACK_MESSAGES_WIDGET_CHANNEL;
 
-  const title: string = t("feedback_widget.title");
-  const placeholder: string = t("feedback_widget.placeholder");
-  const emailPlaceholder: string = t("feedback_widget.email_placeholder");
-  const submitText: string = t("feedback_widget.submit_text");
-  const successText: string = t("feedback_widget.success_text");
-  const successText2: string = t("feedback_widget.success_text2");
+  const getWidgetConfig = () => {
+    const title: string = t("feedback_widget.title");
+    const placeholder: string = t("feedback_widget.placeholder");
+    const emailPlaceholder: string = t("feedback_widget.email_placeholder");
+    const submitText: string = t("feedback_widget.submit_text");
+    const successText: string = t("feedback_widget.success_text");
+    const successText2: string = t("feedback_widget.success_text2");
+    return {
+      title,
+      placeholder,
+      emailPlaceholder,
+      submitText,
+      successText,
+      successText2,
+    };
+  };
+
+  const canLoadWidget = Boolean(channel && apiUrl && widgetPath);
 
   const showWidget = () => {
-    if (!channel || !apiUrl || !widgetPath) {
+    if (!canLoadWidget) {
       throw new Error(
-        "FRONTEND_FEEDBACK_MESSAGES_WIDGET_API_URL, FRONTEND_FEEDBACK_MESSAGES_WIDGET_PATH or FRONTEND_FEEDBACK_MESSAGES_WIDGET_CHANNEL is not set"
+        "FRONTEND_FEEDBACK_MESSAGES_WIDGET_API_URL, FRONTEND_FEEDBACK_MESSAGES_WIDGET_PATH or FRONTEND_FEEDBACK_MESSAGES_WIDGET_CHANNEL is not set",
       );
     }
 
-    // Initialize the widget array if it doesn't exist
-    if (typeof window !== "undefined" && widgetPath) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (window as any)._stmsg_widget = (window as any)._stmsg_widget || [];
+    WidgetHelper.pushCommand([
+      "feedback",
+      "init",
+      {
+        api: apiUrl,
+        channel,
+        ...getWidgetConfig(),
+        // Add email parameter if user is logged in
+        ...(user?.email && { email: user.email }),
+      },
+    ]);
 
-      // Construct script URLs from the base path
-      const feedbackScript = `${widgetPath}feedback.js`;
+    WidgetHelper.loadScript(`${widgetPath}feedback.js`);
+  };
 
-      // Push the widget configuration
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (window as any)._stmsg_widget.push([
-        "feedback",
-        "init",
-        {
-          title,
+  const showButton = () => {
+    if (!canLoadWidget) {
+      throw new Error(
+        "FRONTEND_FEEDBACK_MESSAGES_WIDGET_API_URL, FRONTEND_FEEDBACK_MESSAGES_WIDGET_PATH or FRONTEND_FEEDBACK_MESSAGES_WIDGET_CHANNEL is not set",
+      );
+    }
+
+    WidgetHelper.pushCommand([
+      "loader",
+      "init",
+      {
+        params: {
           api: apiUrl,
           channel,
-          placeholder,
-          emailPlaceholder,
-          submitText,
-          successText,
-          successText2,
+          ...getWidgetConfig(),
           // Add email parameter if user is logged in
           ...(user?.email && { email: user.email }),
         },
-      ]);
+        script: `${widgetPath}feedback.js`,
+      },
+    ]);
 
-      // Load the loader script if not already loaded
-      if (!document.querySelector(`script[src="${feedbackScript}"]`)) {
-        const script = document.createElement("script");
-        script.async = true;
-        script.src = feedbackScript;
-        const firstScript = document.getElementsByTagName("script")[0];
-        if (firstScript && firstScript.parentNode) {
-          firstScript.parentNode.insertBefore(script, firstScript);
-        }
-      }
-    }
+    WidgetHelper.loadScript(`${widgetPath}loader.js`);
   };
 
-  return { showWidget };
+  return { showWidget, showButton, canLoadWidget };
 };

--- a/src/frontend/apps/drive/src/features/feedback/widget-helper.ts
+++ b/src/frontend/apps/drive/src/features/feedback/widget-helper.ts
@@ -1,0 +1,34 @@
+// Widget helper functions to share common logic
+
+declare global {
+  interface Window {
+    _lasuite_widget?: unknown[];
+    _stmsg_widget?: unknown[];
+  }
+}
+
+export class WidgetHelper {
+  // Both keys are populated so that legacy and current widget runtimes
+  // can consume the same command queue.
+  static #QUEUE_KEYS = ["_lasuite_widget", "_stmsg_widget"] as const;
+
+  static pushCommand(command: unknown[]) {
+    for (const key of WidgetHelper.#QUEUE_KEYS) {
+      const queue = window[key] ?? [];
+      queue.push(command);
+      window[key] = queue;
+    }
+  }
+
+  static loadScript(scriptUrl: string) {
+    if (document.querySelector(`script[src="${scriptUrl}"]`)) return;
+
+    const script = document.createElement("script");
+    script.async = true;
+    script.src = scriptUrl;
+    const firstScript = document.getElementsByTagName("script")[0];
+    if (firstScript && firstScript.parentNode) {
+      firstScript.parentNode.insertBefore(script, firstScript);
+    }
+  }
+}

--- a/src/frontend/apps/drive/src/features/layouts/components/explorer/ExplorerLayout.tsx
+++ b/src/frontend/apps/drive/src/features/layouts/components/explorer/ExplorerLayout.tsx
@@ -43,6 +43,7 @@ import i18n from "@/features/i18n/initI18n";
 import { useMemo } from "react";
 import { UserProfile } from "@/features/ui/components/user/UserProfile";
 import { Gaufre } from "@/features/ui/components/gaufre/Gaufre";
+import { useMessagesWidget } from "@/features/feedback/useMessagesWidget";
 
 export const getGlobalExplorerLayout = (page: React.ReactElement) => {
   return <GlobalExplorerLayout>{page}</GlobalExplorerLayout>;
@@ -199,20 +200,26 @@ const HelpMenuButton = () => {
   const helpMenuConfig = config?.FRONTEND_HELP_MENU_CONFIG;
   const hasHelpMenu =
     !!helpMenuConfig && Object.keys(helpMenuConfig).length > 0;
+  const { showWidget } = useMessagesWidget();
 
   if (!hasHelpMenu) {
     return null;
   }
 
+  const getOnContactUs = () => {
+    if (helpMenuConfig.supportMessagesWidget) {
+      return () => showWidget();
+    }
+    return helpMenuConfig.supportEmail
+      ? () => window.open(helpMenuConfig.supportEmail)
+      : undefined;
+  };
+
   return (
     <HelpMenu
       documentationUrl={helpMenuConfig.documentationUrl}
       legal={helpMenuConfig.legal}
-      onContactUs={
-        helpMenuConfig.supportEmail
-          ? () => window.open(helpMenuConfig.supportEmail)
-          : undefined
-      }
+      onContactUs={getOnContactUs()}
     />
   );
 };

--- a/src/frontend/apps/drive/src/pages/index.tsx
+++ b/src/frontend/apps/drive/src/pages/index.tsx
@@ -18,6 +18,7 @@ import { useThemeCustomization } from "@/hooks/useThemeCustomization";
 import { Feedback } from "@/features/feedback/Feedback";
 import { useRedirectAfterLogin } from "@/hooks/useRedirectAfterLogin";
 import { LeftPanelFooter } from "@/features/layouts/components/explorer/ExplorerLayout";
+import { useMessagesWidget } from "@/features/feedback/useMessagesWidget";
 
 export default function HomePage() {
   const { t } = useTranslation();
@@ -70,6 +71,7 @@ const HomePageContent = () => {
   const { config } = useConfig();
   const footerCustommization = useThemeCustomization("footer");
   const [redirectFailed, setRedirectFailed] = useState(false);
+  const { canLoadWidget, showButton } = useMessagesWidget();
 
   useEffect(() => {
     const checkSiteAndRedirect = async () => {
@@ -91,6 +93,12 @@ const HomePageContent = () => {
 
     checkSiteAndRedirect();
   }, [config?.FRONTEND_EXTERNAL_HOME_URL]);
+
+  useEffect(() => {
+    if (canLoadWidget) {
+      showButton();
+    }
+  }, [canLoadWidget]);
 
   if (config?.FRONTEND_EXTERNAL_HOME_URL && !redirectFailed) {
     return null;

--- a/src/frontend/apps/e2e/__tests__/app-drive/help-menu.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-drive/help-menu.spec.ts
@@ -12,6 +12,7 @@ const HELP_MENU_CONFIG = {
 const overrideHelpMenuConfig = async (
   page: import("@playwright/test").Page,
   helpMenuConfig: unknown,
+  extraConfig: Record<string, unknown> = {},
 ) => {
   await page.route("**/api/v1.0/config/", async (route) => {
     const response = await route.fetch();
@@ -21,7 +22,22 @@ const overrideHelpMenuConfig = async (
     } else {
       json.FRONTEND_HELP_MENU_CONFIG = helpMenuConfig;
     }
+    Object.assign(json, extraConfig);
     await route.fulfill({ response, json });
+  });
+};
+
+// Records window.open calls so that mailto links can be asserted without
+// relying on the browser actually opening them.
+const spyOnWindowOpen = async (page: import("@playwright/test").Page) => {
+  await page.addInitScript(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).__openedUrls = [];
+    window.open = (url?: string | URL) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (window as any).__openedUrls.push(String(url));
+      return null;
+    };
   });
 };
 
@@ -58,6 +74,69 @@ test.describe("Help menu", () => {
     await expect(
       page.getByRole("menuitem", { name: "Contact us" }),
     ).toHaveCount(0);
+  });
+
+  test("opens the support email when clicking on contact us", async ({
+    page,
+  }) => {
+    await overrideHelpMenuConfig(page, HELP_MENU_CONFIG);
+    await spyOnWindowOpen(page);
+    await login(page, "drive@example.com");
+    await page.goto("/");
+
+    const footer = page.locator(".c__left-panel__footer__drive");
+    await footer.getByRole("button", { name: "Help" }).click();
+    await page.getByRole("menuitem", { name: "Contact us" }).click();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const openedUrls = await page.evaluate(() => (window as any).__openedUrls);
+    expect(openedUrls).toEqual([HELP_MENU_CONFIG.supportEmail]);
+  });
+
+  test("opens the messages widget when clicking on contact us", async ({
+    page,
+  }) => {
+    const widgetPath = "https://widget.example.com/";
+    await overrideHelpMenuConfig(
+      page,
+      {
+        ...HELP_MENU_CONFIG,
+        supportMessagesWidget: true,
+      },
+      {
+        FRONTEND_FEEDBACK_MESSAGES_WIDGET_API_URL: "https://widget.example.com/api/",
+        FRONTEND_FEEDBACK_MESSAGES_WIDGET_PATH: widgetPath,
+        FRONTEND_FEEDBACK_MESSAGES_WIDGET_CHANNEL: "drive",
+      },
+    );
+    // Serve an empty widget script so the injected loader does not hit the
+    // network for real.
+    await page.route(`${widgetPath}feedback.js`, (route) =>
+      route.fulfill({ contentType: "application/javascript", body: "" }),
+    );
+    await spyOnWindowOpen(page);
+    await login(page, "drive@example.com");
+    await page.goto("/");
+
+    const footer = page.locator(".c__left-panel__footer__drive");
+    await footer.getByRole("button", { name: "Help" }).click();
+    await page.getByRole("menuitem", { name: "Contact us" }).click();
+
+    // The widget queues an init call and injects its loader script.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const widgetCalls = await page.evaluate(() => (window as any)._stmsg_widget);
+    expect(widgetCalls).toHaveLength(1);
+    expect(widgetCalls[0][0]).toBe("feedback");
+    expect(widgetCalls[0][1]).toBe("init");
+    expect(widgetCalls[0][2].channel).toBe("drive");
+    await expect(
+      page.locator(`script[src="${widgetPath}feedback.js"]`),
+    ).toHaveCount(1);
+
+    // The widget takes precedence over the support email.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const openedUrls = await page.evaluate(() => (window as any).__openedUrls);
+    expect(openedUrls).toEqual([]);
   });
 
   test("does not render the help menu when the config is empty", async ({

--- a/src/frontend/apps/e2e/__tests__/app-drive/help-menu.spec.ts
+++ b/src/frontend/apps/e2e/__tests__/app-drive/help-menu.spec.ts
@@ -139,6 +139,37 @@ test.describe("Help menu", () => {
     expect(openedUrls).toEqual([]);
   });
 
+  test("shows the messages widget button on the homepage when configured", async ({
+    page,
+  }) => {
+    const widgetPath = "https://widget.example.com/";
+    await overrideHelpMenuConfig(page, HELP_MENU_CONFIG, {
+      FRONTEND_FEEDBACK_MESSAGES_WIDGET_API_URL: "https://widget.example.com/api/",
+      FRONTEND_FEEDBACK_MESSAGES_WIDGET_PATH: widgetPath,
+      FRONTEND_FEEDBACK_MESSAGES_WIDGET_CHANNEL: "drive",
+    });
+    // Serve an empty loader script so the injected loader does not hit the
+    // network for real.
+    await page.route(`${widgetPath}loader.js`, (route) =>
+      route.fulfill({ contentType: "application/javascript", body: "" }),
+    );
+    // No login: the home page only renders for anonymous users, and it is
+    // where the widget button is shown.
+    await page.goto("/");
+
+    // The button loader queues an init call and injects its loader script.
+    await expect(
+      page.locator(`script[src="${widgetPath}loader.js"]`),
+    ).toHaveCount(1);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const widgetCalls = await page.evaluate(() => (window as any)._stmsg_widget);
+    expect(widgetCalls).toHaveLength(1);
+    expect(widgetCalls[0][0]).toBe("loader");
+    expect(widgetCalls[0][1]).toBe("init");
+    expect(widgetCalls[0][2].params.channel).toBe("drive");
+    expect(widgetCalls[0][2].script).toBe(`${widgetPath}feedback.js`);
+  });
+
   test("does not render the help menu when the config is empty", async ({
     page,
   }) => {


### PR DESCRIPTION
## Purpose

Some instances use the messages widget for support instead of a plain mailto link and display the messages widget on homepage if configured.

## Proposal

### Connected
<img width="800" height="251" alt="CleanShot 2026-07-27 at 16 35 21" src="https://github.com/user-attachments/assets/0fb513ba-4c98-42e3-bf45-072e55cd4bb7" />

### Anon
<img width="1280" height="757" alt="Capture d’écran 2026-07-27 à 17 14 56" src="https://github.com/user-attachments/assets/709b9404-d1c4-45e6-a348-d681673340ee" />


- Add a `supportMessagesWidget` flag to the help menu config
- When enabled, the "Contact us" entry opens the messages widget, taking precedence over the support email
- Add messages widget on homepage for anon users
- Add e2e tests 