### PR TITLE
✨(backend) exclude external service items from storage quota

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to
 - ✨(frontend) open the messages widget from the help menu
 - ✨(backend) add an item batch share endpoint gated by ALLOW_SHARE_IMPORT_FILE
 - ✨(frontend) share an item with contacts imported from a file
+- ✨(backend) add a quota_excluded flag on items
+- ✨(backend) apply per-audience attributes to external api items
+- ✨(backend) add a grant_unlimited_storage command
 
 ### Changed
 

--- a/docs/env.md
+++ b/docs/env.md
@@ -47,6 +47,7 @@ This document lists all configurable environment variables for the Drive applica
 | `EMAIL_URL_APP` | URL used in emails to link back to the app | `None` |
 | `EMAIL_USE_SSL` | Use SSL for SMTP connection | `False` |
 | `EMAIL_USE_TLS` | Use TLS for SMTP connection | `False` |
+| `EXTERNAL_API_AUD_ITEM_ATTRIBUTES` | Extra attributes applied to items created through the external API, keyed by the token audience of the request, e.g. `{"some_audience": {"quota_excluded": true}}` | `{}` |
 | `FEATURES_ALPHA` | Enable alpha features | `False` |
 | `FEATURES_INDEXED_SEARCH` | Enable the search of indexed files through the API | `True` |
 | `FILE_EXTENSIONS_ALLOWED` | List of file extension allowed to be uploaded | See in the settings.py file |

--- a/docs/resource_server.md
+++ b/docs/resource_server.md
@@ -55,6 +55,25 @@ EXTERNAL_API = {
 
 Each endpoint has `enabled` (boolean) and `actions` (list of allowed actions). Only actions explicitly listed are accessible.
 
+## Customise created item attributes per audience
+
+Configure the `EXTERNAL_API_AUD_ITEM_ATTRIBUTES` setting to apply extra attributes to items
+created through the external API, depending on the token audience of the request (the claim
+configured by `OIDC_RS_AUDIENCE_CLAIM`). Set it via the `EXTERNAL_API_AUD_ITEM_ATTRIBUTES`
+environment variable (as JSON) or in Django settings.
+
+```python
+EXTERNAL_API_AUD_ITEM_ATTRIBUTES = {
+    "some_audience": {
+        "quota_excluded": True,
+    },
+}
+```
+
+With this configuration, every item created by a request authenticated with the
+`some_audience` audience is excluded from its creator's storage quota computation.
+Audiences without an entry keep the default item attributes.
+
 ## Request Drive
 
 In order to request drive from an external resource provider, you need to implement the basic setup of `django-lasuite` [Using the OIDC Authentication Backend to request a resource server](https://github.com/suitenumerique/django-lasuite/blob/main/documentation/how-to-use-oidc-call-to-resource-server.md)

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -664,6 +664,10 @@ class ItemViewSet(
         item.size = len(template_content)
         item.save(update_fields=["upload_state", "mimetype", "size", "updated_at"])
 
+    def get_create_extra_attributes(self):
+        """Extra model attributes applied to items created by this viewset (subclass hook)."""
+        return {}
+
     def perform_create(self, serializer):
         """Set the current user as creator and owner of the newly created object."""
         extension = serializer.validated_data.pop("extension", None)
@@ -672,6 +676,7 @@ class ItemViewSet(
             creator=self.request.user,
             link_reach=LinkReachChoices.RESTRICTED,
             **serializer.validated_data,
+            **self.get_create_extra_attributes(),
         )
         if extension:
             self._create_file_from_template(obj, extension)
@@ -1121,6 +1126,7 @@ class ItemViewSet(
                 creator=request.user,
                 parent=item,
                 **serializer.validated_data,
+                **self.get_create_extra_attributes(),
             )
 
             if extension:

--- a/src/backend/core/external_api/viewsets.py
+++ b/src/backend/core/external_api/viewsets.py
@@ -45,6 +45,11 @@ class ResourceServerItemViewSet(ResourceServerRestrictionMixin, ItemViewSet):
         """Build resource_server_actions from settings."""
         return self._get_resource_server_actions("items")
 
+    def get_create_extra_attributes(self):
+        """Apply per-audience item attributes from EXTERNAL_API_AUD_ITEM_ATTRIBUTES."""
+        audience = getattr(self.request, "resource_server_token_audience", None)
+        return dict(settings.EXTERNAL_API_AUD_ITEM_ATTRIBUTES.get(audience) or {})
+
 
 class ResourceServerUserViewSet(ResourceServerRestrictionMixin, UserViewSet):
     """Resource Server Viewset for the Drive app."""

--- a/src/backend/core/management/commands/grant_unlimited_storage.py
+++ b/src/backend/core/management/commands/grant_unlimited_storage.py
@@ -1,0 +1,64 @@
+"""Grant unlimited storage to users already using more than a threshold."""
+
+from django.core.management.base import BaseCommand
+from django.db.models import Q, Sum
+
+from core.models import User
+
+
+class Command(BaseCommand):
+    """
+    Set storage_limit_override to 0 (unlimited) for every user whose quota
+    counted storage exceeds the given threshold. Users with an existing
+    override are left untouched so explicit per-user decisions are never
+    clobbered.
+    """
+
+    help = "Set storage_limit_override=0 (unlimited) for users above a storage threshold"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--threshold-gb",
+            type=float,
+            required=True,
+            help="Storage threshold in GB, users strictly above it are granted unlimited storage",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Only report the users that would be updated",
+        )
+
+    def handle(self, *args, **options):
+        threshold = int(options["threshold_gb"] * 1000**3)
+
+        # Same item filter as CreatorStorageComputeBackend.compute_storage_used
+        # so the command agrees with the quota enforcement.
+        users = (
+            User.objects.filter(storage_limit_override__isnull=True)
+            .annotate(
+                total_size=Sum(
+                    "items_created__size",
+                    filter=Q(
+                        items_created__hard_deleted_at__isnull=True,
+                        items_created__quota_excluded=False,
+                    ),
+                    default=0,
+                )
+            )
+            .filter(total_size__gt=threshold)
+        )
+
+        if options["dry_run"]:
+            for email in users.values_list("email", flat=True):
+                self.stdout.write(f"[dry-run] Would grant unlimited storage to {email}")
+            self.stdout.write(
+                f"[dry-run] Would grant unlimited storage to {users.count()} user(s)."
+            )
+            return
+
+        user_ids = list(users.values_list("id", flat=True))
+        count = User.objects.filter(id__in=user_ids).update(storage_limit_override=0)
+        # No cache invalidation needed: only the storage used is cached and
+        # this command changes the limit, which is read fresh on every call.
+        self.stdout.write(f"Granted unlimited storage to {count} user(s).")

--- a/src/backend/core/migrations/0027_item_quota_excluded.py
+++ b/src/backend/core/migrations/0027_item_quota_excluded.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0026_item_item_creator_size_not_hdel_idx'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='item',
+            name='quota_excluded',
+            field=models.BooleanField(default=False, help_text="Exclude this item from its creator's storage quota computation."),
+        ),
+    ]

--- a/src/backend/core/migrations/0028_item_creator_size_quota_idx.py
+++ b/src/backend/core/migrations/0028_item_creator_size_quota_idx.py
@@ -1,0 +1,26 @@
+from django.contrib.postgres.operations import AddIndexConcurrently, RemoveIndexConcurrently
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    # CREATE/DROP INDEX CONCURRENTLY cannot run inside a transaction. It avoids
+    # locking writes on the item table while the index is being built. The new
+    # index is added before the old one is removed so the storage used
+    # aggregation never loses index support during the deployment.
+    atomic = False
+
+    dependencies = [
+        ('core', '0027_item_quota_excluded'),
+    ]
+
+    operations = [
+        AddIndexConcurrently(
+            model_name='item',
+            index=models.Index(condition=models.Q(('hard_deleted_at__isnull', True), ('quota_excluded', False)), fields=['creator'], include=('size',), name='item_creator_size_quota_idx'),
+        ),
+        RemoveIndexConcurrently(
+            model_name='item',
+            name='item_creator_size_not_hdel_idx',
+        ),
+    ]

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -49,7 +49,7 @@ from wopi.conversion.policy import target_extension_for
 logger = getLogger(__name__)
 
 # Item fields whose update can change the storage used by a user.
-STORAGE_USED_FIELDS = {"size", "creator", "creator_id", "hard_deleted_at"}
+STORAGE_USED_FIELDS = {"size", "creator", "creator_id", "hard_deleted_at", "quota_excluded"}
 
 
 def get_trashbin_cutoff():
@@ -1021,6 +1021,10 @@ class Item(TreeModel, BaseModel):
     mimetype = models.CharField(max_length=255, null=True, blank=True)
     main_workspace = models.BooleanField(default=False)
     size = models.BigIntegerField(null=True, blank=True)
+    quota_excluded = models.BooleanField(
+        default=False,
+        help_text=_("Exclude this item from its creator's storage quota computation."),
+    )
     description = models.TextField(null=True, blank=True)
     malware_detection_info = models.JSONField(
         null=True,
@@ -1054,8 +1058,8 @@ class Item(TreeModel, BaseModel):
             models.Index(
                 fields=["creator"],
                 include=["size"],
-                condition=models.Q(hard_deleted_at__isnull=True),
-                name="item_creator_size_not_hdel_idx",
+                condition=models.Q(hard_deleted_at__isnull=True, quota_excluded=False),
+                name="item_creator_size_quota_idx",
             ),
         ]
 

--- a/src/backend/core/storage/creator_storage_compute_backend.py
+++ b/src/backend/core/storage/creator_storage_compute_backend.py
@@ -15,6 +15,6 @@ class CreatorStorageComputeBackend(StorageComputeBackend):
         """
         Compute the total storage used by a set of users.
         """
-        return Item.objects.filter(creator__in=users, hard_deleted_at__isnull=True).aggregate(
-            total_size=Sum("size", default=0)
-        )["total_size"]
+        return Item.objects.filter(
+            creator__in=users, hard_deleted_at__isnull=True, quota_excluded=False
+        ).aggregate(total_size=Sum("size", default=0))["total_size"]

--- a/src/backend/core/tests/commands/test_grant_unlimited_storage.py
+++ b/src/backend/core/tests/commands/test_grant_unlimited_storage.py
@@ -1,0 +1,91 @@
+"""Tests for the grant_unlimited_storage management command."""
+
+from io import StringIO
+
+from django.core.management import CommandError, call_command
+
+import pytest
+
+from core import factories
+
+pytestmark = pytest.mark.django_db
+
+GB = 1000**3
+
+
+def test_grants_unlimited_to_users_above_threshold():
+    """Users using more than the threshold should get an unlimited storage override."""
+    heavy_user = factories.UserFactory()
+    factories.ItemFactory(creator=heavy_user, size=2 * GB)
+    light_user = factories.UserFactory()
+    factories.ItemFactory(creator=light_user, size=GB // 2)
+
+    out = StringIO()
+    call_command("grant_unlimited_storage", "--threshold-gb=1", stdout=out)
+
+    heavy_user.refresh_from_db()
+    light_user.refresh_from_db()
+    assert heavy_user.storage_limit_override == 0
+    assert light_user.storage_limit_override is None
+    assert "Granted unlimited storage to 1 user(s)." in out.getvalue()
+
+
+def test_ignores_users_at_threshold():
+    """Users using exactly the threshold should not be granted unlimited storage."""
+    user = factories.UserFactory()
+    factories.ItemFactory(creator=user, size=GB)
+
+    call_command("grant_unlimited_storage", "--threshold-gb=1")
+
+    user.refresh_from_db()
+    assert user.storage_limit_override is None
+
+
+def test_skips_users_with_existing_override():
+    """Users with an explicit override should never be modified."""
+    limited_user = factories.UserFactory(storage_limit_override=5 * GB)
+    factories.ItemFactory(creator=limited_user, size=10 * GB)
+    unlimited_user = factories.UserFactory(storage_limit_override=0)
+    factories.ItemFactory(creator=unlimited_user, size=10 * GB)
+
+    call_command("grant_unlimited_storage", "--threshold-gb=1")
+
+    limited_user.refresh_from_db()
+    unlimited_user.refresh_from_db()
+    assert limited_user.storage_limit_override == 5 * GB
+    assert unlimited_user.storage_limit_override == 0
+
+
+def test_excludes_hard_deleted_and_quota_excluded_items_from_total():
+    """Hard-deleted and quota excluded items should not count toward the total."""
+    user = factories.UserFactory()
+    factories.ItemFactory(creator=user, size=GB // 2)
+    factories.ItemFactory(creator=user, size=GB, quota_excluded=True)
+    hard_deleted = factories.ItemFactory(creator=user, size=GB)
+    hard_deleted.soft_delete()
+    hard_deleted.hard_delete()
+
+    call_command("grant_unlimited_storage", "--threshold-gb=1")
+
+    user.refresh_from_db()
+    assert user.storage_limit_override is None
+
+
+def test_dry_run_does_not_write():
+    """The dry-run mode should report the users without updating them."""
+    user = factories.UserFactory()
+    factories.ItemFactory(creator=user, size=2 * GB)
+
+    out = StringIO()
+    call_command("grant_unlimited_storage", "--threshold-gb=1", "--dry-run", stdout=out)
+
+    user.refresh_from_db()
+    assert user.storage_limit_override is None
+    assert f"[dry-run] Would grant unlimited storage to {user.email}" in out.getvalue()
+    assert "[dry-run] Would grant unlimited storage to 1 user(s)." in out.getvalue()
+
+
+def test_threshold_is_required():
+    """The command should fail when no threshold is given."""
+    with pytest.raises(CommandError):
+        call_command("grant_unlimited_storage")

--- a/src/backend/core/tests/external_api/items/test_external_api_items.py
+++ b/src/backend/core/tests/external_api/items/test_external_api_items.py
@@ -194,6 +194,100 @@ def test_api_items_upload_root_resource_server_using_access_token(
     assert response.status_code == 200
 
 
+@override_settings(
+    EXTERNAL_API_AUD_ITEM_ATTRIBUTES={"some_service_provider": {"quota_excluded": True}}
+)
+def test_api_items_create_root_resource_server_applies_aud_attributes(
+    user_token, resource_server_backend, user_specific_sub
+):
+    """Items created at the root should get the attributes configured for the token audience."""
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Bearer {user_token}")
+
+    response = client.post(
+        "/external_api/v1.0/items/",
+        {
+            "type": models.ItemTypeChoices.FILE,
+            "filename": "file.txt",
+        },
+    )
+
+    assert response.status_code == 201
+    child = models.Item.objects.get(id=response.json()["id"])
+    assert child.quota_excluded is True
+
+
+@override_settings(
+    EXTERNAL_API_AUD_ITEM_ATTRIBUTES={"some_service_provider": {"quota_excluded": True}}
+)
+def test_api_items_create_children_resource_server_applies_aud_attributes(
+    user_token, resource_server_backend, user_specific_sub
+):
+    """Items created as children should get the attributes configured for the token audience."""
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Bearer {user_token}")
+    item = factories.ItemFactory(
+        link_reach=models.LinkReachChoices.RESTRICTED,
+        type=models.ItemTypeChoices.FOLDER,
+    )
+    factories.UserItemAccessFactory(
+        item=item, user=user_specific_sub, role=models.RoleChoices.OWNER
+    )
+
+    response = client.post(
+        f"/external_api/v1.0/items/{item.id!s}/children/",
+        {
+            "type": models.ItemTypeChoices.FILE,
+            "filename": "file.txt",
+        },
+    )
+
+    assert response.status_code == 201
+    child = models.Item.objects.get(id=response.json()["id"])
+    assert child.quota_excluded is True
+
+
+@override_settings(EXTERNAL_API_AUD_ITEM_ATTRIBUTES={"other_audience": {"quota_excluded": True}})
+def test_api_items_create_resource_server_aud_not_configured(
+    user_token, resource_server_backend, user_specific_sub
+):
+    """Items created with an audience missing from the setting should keep default attributes."""
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Bearer {user_token}")
+
+    response = client.post(
+        "/external_api/v1.0/items/",
+        {
+            "type": models.ItemTypeChoices.FILE,
+            "filename": "file.txt",
+        },
+    )
+
+    assert response.status_code == 201
+    child = models.Item.objects.get(id=response.json()["id"])
+    assert child.quota_excluded is False
+
+
+def test_api_items_create_resource_server_no_aud_attributes_setting(
+    user_token, resource_server_backend, user_specific_sub
+):
+    """Items created with the default empty setting should keep default attributes."""
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Bearer {user_token}")
+
+    response = client.post(
+        "/external_api/v1.0/items/",
+        {
+            "type": models.ItemTypeChoices.FILE,
+            "filename": "file.txt",
+        },
+    )
+
+    assert response.status_code == 201
+    child = models.Item.objects.get(id=response.json()["id"])
+    assert child.quota_excluded is False
+
+
 # Non allowed actions on resource server.
 
 

--- a/src/backend/core/tests/items/test_api_items_create.py
+++ b/src/backend/core/tests/items/test_api_items_create.py
@@ -59,6 +59,29 @@ def test_api_items_create_authenticated_success():
     assert item.type == ItemTypeChoices.FOLDER
 
 
+@override_settings(
+    EXTERNAL_API_AUD_ITEM_ATTRIBUTES={"some_service_provider": {"quota_excluded": True}}
+)
+def test_api_items_create_authenticated_ignores_aud_item_attributes():
+    """Per-audience attributes only apply to the external API, never to the regular API."""
+    user = factories.UserFactory()
+
+    client = APIClient()
+    client.force_login(user)
+
+    response = client.post(
+        "/api/v1.0/items/",
+        {
+            "title": "my item",
+            "type": ItemTypeChoices.FOLDER,
+        },
+        format="json",
+    )
+    assert response.status_code == 201
+    item = Item.objects.get()
+    assert item.quota_excluded is False
+
+
 def test_api_items_create_file_authenticated_no_filename():
     """
     Creating a file item without providing a filename should fail.

--- a/src/backend/core/tests/storage/test_creator_storage_compute_backend.py
+++ b/src/backend/core/tests/storage/test_creator_storage_compute_backend.py
@@ -39,3 +39,21 @@ def test_compute_storage_used_keeps_soft_deleted_items():
     soft_deleted.soft_delete()
 
     assert CreatorStorageComputeBackend().compute_storage_used([user]) == 350
+
+
+def test_compute_storage_used_excludes_quota_excluded_items():
+    """Items flagged as quota excluded should not count toward the storage used."""
+    user = factories.UserFactory()
+    factories.ItemFactory(creator=user, size=100)
+    factories.ItemFactory(creator=user, size=250, quota_excluded=True)
+
+    assert CreatorStorageComputeBackend().compute_storage_used([user]) == 100
+
+
+def test_compute_storage_used_only_quota_excluded_items():
+    """A user owning only quota excluded items should have a storage used of zero."""
+    user = factories.UserFactory()
+    factories.ItemFactory(creator=user, size=100, quota_excluded=True)
+    factories.ItemFactory(creator=user, size=250, quota_excluded=True)
+
+    assert CreatorStorageComputeBackend().compute_storage_used([user]) == 0

--- a/src/backend/core/tests/test_api_entitlements_local.py
+++ b/src/backend/core/tests/test_api_entitlements_local.py
@@ -419,6 +419,31 @@ def test_api_entitlements_local_cache_invalidated_on_item_save(
     assert response.json()["quota"]["usage"] == 700
 
 
+@override_settings(
+    ENTITLEMENTS_BACKEND=LOCAL_BACKEND,
+    ENTITLEMENTS_BACKEND_PARAMETERS={"default_storage_limit": 1000},
+)
+def test_api_entitlements_local_cache_invalidated_on_quota_excluded(
+    django_capture_on_commit_callbacks,
+):
+    """Flagging an item as quota excluded should invalidate the creator's cached usage."""
+    client = APIClient()
+    user = factories.UserFactory()
+    item = factories.ItemFactory(type=models.ItemTypeChoices.FILE, creator=user, size=400)
+    client.force_authenticate(user)
+
+    response = client.get("/api/v1.0/entitlements/")
+    assert response.json()["quota"]["usage"] == 400
+
+    item.quota_excluded = True
+    with django_capture_on_commit_callbacks(execute=True):
+        item.save(update_fields=["quota_excluded"])
+
+    assert cache.get(get_storage_used_cache_key(user.id)) is None
+    response = client.get("/api/v1.0/entitlements/")
+    assert response.json()["quota"]["usage"] == 0
+
+
 def test_api_entitlements_local_cache_invalidated_on_hard_delete(
     django_capture_on_commit_callbacks,
 ):

--- a/src/backend/drive/settings.py
+++ b/src/backend/drive/settings.py
@@ -1296,6 +1296,15 @@ class Base(Configuration):
         environ_prefix=None,
     )
 
+    # Extra attributes applied to items created through the external API,
+    # keyed by the token audience of the request,
+    # e.g. {"some_audience": {"quota_excluded": True}}
+    EXTERNAL_API_AUD_ITEM_ATTRIBUTES = values.DictValue(
+        default={},
+        environ_name="EXTERNAL_API_AUD_ITEM_ATTRIBUTES",
+        environ_prefix=None,
+    )
+
     OIDC_RS_PRIVATE_KEY_STR = values.Value(
         default=None,
         environ_name="OIDC_RS_PRIVATE_KEY_STR",


### PR DESCRIPTION
## Purpose

Allow external services consuming the resource server API to create items that do not
count against their creator's storage quota, and provide an operational path to enable
quotas on existing instances without blocking heavy users.

## Proposal

- **`quota_excluded` flag on `Item`**: items flagged are ignored by
  `CreatorStorageComputeBackend` and the flag participates in the storage-used cache
  invalidation. The covering index is replaced by `item_creator_size_quota_idx`, whose
  condition also filters out excluded rows so the aggregation stays index-only.
- **`EXTERNAL_API_AUD_ITEM_ATTRIBUTES` setting**: maps a resource server token audience
  to attributes applied to items at creation, e.g.
  `{"some_audience": {"quota_excluded": true}}`. Applied on both the root create and
  `children` creation paths of the external API only; the regular API is unaffected.
  Documented in `docs/resource_server.md`.
- **`grant_unlimited_storage` command**: sets `storage_limit_override=0` (unlimited) for
  users above a threshold (`--threshold-gb`, decimal GB), skipping users with an existing
  override. Supports `--dry-run`. The aggregation uses the same filter as the storage
  compute backend so it agrees with quota enforcement.
- Migration `0028` swaps the covering index with `CREATE`/`DROP INDEX CONCURRENTLY`
  (non-atomic): no write locks, but if it fails mid-run it can leave an INVALID index to
  drop manually before retrying.