### PR TITLE
🔖(minor) bump release version 0.21.0

### DIFF
--- a/.github/workflows/crowdin_download.yml
+++ b/.github/workflows/crowdin_download.yml
@@ -10,7 +10,7 @@ jobs:
   install-front:
     uses: ./.github/workflows/front-dependencies-installation.yml
     with:
-      node_version: '20.x'
+      node_version: '22.x'
 
   synchronize-with-crowdin:
     runs-on: ubuntu-latest

--- a/.github/workflows/crowdin_upload.yml
+++ b/.github/workflows/crowdin_upload.yml
@@ -10,7 +10,7 @@ jobs:
   install-front:
     uses: ./.github/workflows/front-dependencies-installation.yml
     with:
-      node_version: '20.x'
+      node_version: '22.x'
 
   synchronize-with-crowdin:
     needs: install-front

--- a/.github/workflows/front-dependencies-installation.yml
+++ b/.github/workflows/front-dependencies-installation.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       node_version:
         required: false
-        default: '20.x'
+        default: '22.x'
         type: string
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [v0.21.0] - 2026-08-07
+
 ### Added
 
 - ✨(backend) make the upload ACL configurable to support GCS based storages
@@ -495,7 +497,8 @@ and this project adheres to
 - 🌐(front) add english translation for rename modal
 - 🐛(global) fix wrong Content-Type on specific s3 implementations
 
-[unreleased]: https://github.com/suitenumerique/drive/compare/v0.20.0...main
+[unreleased]: https://github.com/suitenumerique/drive/compare/v0.21.0...main
+[v0.21.0]: https://github.com/suitenumerique/drive/releases/v0.21.0
 [v0.20.0]: https://github.com/suitenumerique/drive/releases/v0.20.0
 [v0.19.0]: https://github.com/suitenumerique/drive/releases/v0.19.0
 [v0.18.0]: https://github.com/suitenumerique/drive/releases/v0.18.0

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "uv_build"
 
 [project]
 name = "drive"
-version = "0.20.0"
+version = "0.21.0"
 authors = [{ "name" = "DINUM", "email" = "dev@mail.numerique.gouv.fr" }]
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/src/backend/uv.lock
+++ b/src/backend/uv.lock
@@ -659,7 +659,7 @@ wheels = [
 
 [[package]]
 name = "drive"
-version = "0.20.0"
+version = "0.21.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/frontend/apps/drive/package.json
+++ b/src/frontend/apps/drive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drive",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "main",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "private": true,
   "workspaces": [
     "apps/*",

--- a/src/helm/drive/Chart.yaml
+++ b/src/helm/drive/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 type: application
 name: drive
-version: 0.20.0
+version: 0.21.0
 appVersion: latest

--- a/src/helm/helmfile.yaml.gotmpl
+++ b/src/helm/helmfile.yaml.gotmpl
@@ -1,7 +1,7 @@
 environments:
   dev:
     values:
-      - version: 0.20.0
+      - version: 0.21.0
 ---
 repositories:
 - name: dev-backends

--- a/src/mail/package.json
+++ b/src/mail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mail_mjml",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "An util to generate html and text django's templates from mjml templates",
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
### Added

- ✨(backend) make the upload ACL configurable to support GCS based storages
- ✨(frontend) show the messages widget button on the homepage
- ✨(frontend) open the messages widget from the help menu
- ✨(backend) add an item batch share endpoint gated by ALLOW_SHARE_IMPORT_FILE
- ✨(frontend) share an item with contacts imported from a file
- ✨(backend) add a quota_excluded flag on items
- ✨(backend) apply per-audience attributes to external api items
- ✨(backend) add a grant_unlimited_storage command

### Changed

- 🔧(docker) drop the unused pip upgrade and apk caches from the image
- ✨(backend) expose item existence in the malware detection admin
- ✨(backend) show human readable item size in the admin
- 🚚(global) move favorite items API endpoint to `/items/favorites/`

### Fixed

- 🐛(docker) pin collabora image and adapt to its new runtime contract
- 🐛(backend) delete malware detection record when purging an item
- 🔒️(backend) reject unsafe filenames requested by WOPI renames
- 🔒️(backend) analyze file content written through WOPI