### PR TITLE
🐛(backend) fix malware re-analysis of a file already scanned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- 🐛(backend) fix malware re-analysis of a file already scanned
+
 ## [v0.21.0] - 2026-08-07
 
 ### Added

--- a/src/backend/core/admin.py
+++ b/src/backend/core/admin.py
@@ -12,11 +12,11 @@ from django.shortcuts import redirect
 from django.template.defaultfilters import filesizeformat
 from django.utils.translation import gettext_lazy as _
 
-from lasuite.malware_detection import malware_detection
 from lasuite.malware_detection.admin import MalwareDetectionAdmin as BaseMalwareDetectionAdmin
 from lasuite.malware_detection.models import MalwareDetection
 
 from core import models
+from core.malware_detection import reanalyse_file
 from core.tasks.user_reconciliation import user_reconciliation_csv_import_job
 
 
@@ -245,7 +245,7 @@ class ItemAdmin(admin.ModelAdmin):
 
         for item in queryset:
             if item.type == models.ItemTypeChoices.FILE:
-                malware_detection.analyse_file(item.file_key, item_id=item.id)
+                reanalyse_file(item.file_key, item_id=item.id)
 
         self.message_user(request, "The files have been scheduled for a new analysis.")
 

--- a/src/backend/core/malware_detection.py
+++ b/src/backend/core/malware_detection.py
@@ -7,6 +7,7 @@ import time
 from django.conf import settings
 from django.db import connection
 
+from lasuite.malware_detection import malware_detection
 from lasuite.malware_detection.backends.dummy import DummyBackend
 from lasuite.malware_detection.enums import ReportStatus
 
@@ -31,6 +32,16 @@ class SleepyDummyBackend(DummyBackend):
                 connection.close()
 
         threading.Thread(target=report_later, daemon=True).start()
+
+
+def reanalyse_file(file_path, **kwargs):
+    """Trigger a new analysis of a file already known to the backend."""
+    # The JCOP backend keeps one detection record per path and fails when
+    # one already exists: drop it before scheduling the new analysis.
+    delete_detection = getattr(malware_detection, "delete_detection", None)
+    if delete_detection:
+        delete_detection(file_path)
+    malware_detection.analyse_file(file_path, **kwargs)
 
 
 def malware_detection_callback(file_path, status, error_info, **kwargs):

--- a/src/backend/core/tests/test_admin_item.py
+++ b/src/backend/core/tests/test_admin_item.py
@@ -1,0 +1,30 @@
+"""Tests for the item admin class."""
+
+from unittest import mock
+
+from django.contrib import admin
+from django.test import RequestFactory
+
+import pytest
+
+from core import factories, models
+from core.admin import ItemAdmin
+
+pytestmark = pytest.mark.django_db
+
+
+def test_admin_item_trigger_file_analysis():
+    """The action reanalyses the file of each selected file item."""
+    file_item = factories.ItemFactory(type=models.ItemTypeChoices.FILE, filename="foo.txt")
+    factories.ItemFactory(type=models.ItemTypeChoices.FOLDER)
+    admin_instance = ItemAdmin(models.Item, admin.site)
+    request = RequestFactory().post("/")
+    request.user = factories.UserFactory(is_staff=True, is_superuser=True)
+
+    with (
+        mock.patch("core.admin.reanalyse_file") as mock_reanalyse_file,
+        mock.patch.object(admin_instance, "message_user"),
+    ):
+        admin_instance.trigger_file_analysis(request, models.Item.objects.all())
+
+    mock_reanalyse_file.assert_called_once_with(file_item.file_key, item_id=file_item.id)

--- a/src/backend/core/tests/test_malware_detection.py
+++ b/src/backend/core/tests/test_malware_detection.py
@@ -1,10 +1,13 @@
 """Test malware detection callback"""
 
+from unittest import mock
+
 import pytest
+from lasuite.malware_detection import malware_detection
 from lasuite.malware_detection.enums import ReportStatus
 
 from core import factories
-from core.malware_detection import malware_detection_callback
+from core.malware_detection import malware_detection_callback, reanalyse_file
 from core.models import ItemTypeChoices, ItemUploadStateChoices
 
 pytestmark = pytest.mark.django_db
@@ -120,3 +123,26 @@ def test_malware_detection_callback_item_does_not_exist(caplog):
             item_id=1,
         )
         assert "Item 1 does not exist anymore" in caplog.text
+
+
+def test_reanalyse_file_deletes_previous_detection():
+    """The previous detection record is deleted before the new analysis."""
+    with (
+        mock.patch.object(malware_detection, "analyse_file") as mock_analyse_file,
+        mock.patch.object(
+            malware_detection, "delete_detection", create=True
+        ) as mock_delete_detection,
+    ):
+        reanalyse_file("item/foo/bar.txt", item_id="123")
+
+    mock_delete_detection.assert_called_once_with("item/foo/bar.txt")
+    mock_analyse_file.assert_called_once_with("item/foo/bar.txt", item_id="123")
+
+
+def test_reanalyse_file_backend_without_delete_detection():
+    """Backends without detection records are only asked for the analysis."""
+    assert not hasattr(malware_detection, "delete_detection")
+    with mock.patch.object(malware_detection, "analyse_file") as mock_analyse_file:
+        reanalyse_file("item/foo/bar.txt", item_id="123")
+
+    mock_analyse_file.assert_called_once_with("item/foo/bar.txt", item_id="123")

--- a/src/backend/wopi/viewsets.py
+++ b/src/backend/wopi/viewsets.py
@@ -13,13 +13,13 @@ from django.db import transaction
 from django.http import StreamingHttpResponse
 from django.utils.timezone import now
 
-from lasuite.malware_detection import malware_detection
 from rest_framework import viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from sentry_sdk import capture_exception
 
 from core.api.utils import get_item_file_head_object
+from core.malware_detection import reanalyse_file
 from core.models import Item
 from wopi.authentication import WopiAccessTokenAuthentication, get_access_token
 from wopi.exceptions import WopiRequestSignatureError
@@ -248,7 +248,7 @@ class WopiViewSet(viewsets.ViewSet):
         # non-READY files in WOPI.
         item.save(update_fields=["size", "updated_at"])
 
-        malware_detection.analyse_file(item.file_key, item_id=item.id)
+        reanalyse_file(item.file_key, item_id=item.id)
 
         head_response = s3_client.head_object(Bucket=default_storage.bucket_name, Key=item.file_key)
         return Response(


### PR DESCRIPTION
## Purpose

Saving a document through WOPI PutFile returns a 500 when the file
already has a malware detection record (pending, processing or failed):
the JCOP backend creates one record per file path and fails on the
unique constraint. The admin "trigger file analysis" action has the
same issue.

## Proposal

- [x] add a `reanalyse_file` helper that drops the previous detection
  record, when the backend supports it, before scheduling the analysis
- [x] use it in WOPI PutFile and in the admin reanalysis action
