### PR TITLE
✨(backend) add malware detection queue recovery tooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 ### Added
 
 - 🔧(helm) schedule the malware detection reconciliation commands
+- ✨(admin) add actions to abandon malware analyses
 
 ## [v0.21.1] - 2026-08-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to
 - 🔧(helm) schedule the malware detection reconciliation commands
 - ✨(admin) add actions to abandon malware analyses
 
+### Fixed
+
+- 🐛(backend) fix malware analysis processing slots exhaustion
+
 ## [v0.21.1] - 2026-08-21
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- 🔧(helm) schedule the malware detection reconciliation commands
+
 ## [v0.21.1] - 2026-08-21
 
 ### Fixed

--- a/src/backend/core/admin.py
+++ b/src/backend/core/admin.py
@@ -225,7 +225,11 @@ class ItemAdmin(admin.ModelAdmin):
     search_fields = ("id", "title", "creator__email")
     list_filter = ("upload_state", "link_reach", "link_role")
     show_facets = admin.ShowFacets.ALWAYS
-    actions = ("trigger_file_analysis",)
+    actions = (
+        "trigger_file_analysis",
+        "mark_items_ready",
+        "mark_items_file_too_large",
+    )
 
     def get_queryset(self, request):
         queryset = super().get_queryset(request)
@@ -248,6 +252,29 @@ class ItemAdmin(admin.ModelAdmin):
                 malware_detection.analyse_file(item.file_key, item_id=item.id)
 
         self.message_user(request, "The files have been scheduled for a new analysis.")
+
+    def _force_upload_state(self, request, queryset, upload_state):
+        """Force the upload state of the selected file items and drop their detections."""
+        items = queryset.filter(type=models.ItemTypeChoices.FILE)
+        paths = [item.file_key for item in items]
+        deleted, _details = MalwareDetection.objects.filter(path__in=paths).delete()
+        updated = items.update(upload_state=upload_state)
+        self.message_user(
+            request,
+            f"{updated} items marked as {upload_state}, {deleted} detections deleted.",
+        )
+
+    @admin.action(description=_("Mark items as ready"))
+    def mark_items_ready(self, request, queryset):
+        """Force selected file items to the ready state."""
+        self._force_upload_state(request, queryset, models.ItemUploadStateChoices.READY)
+
+    @admin.action(description=_("Mark items as too large to analyze"))
+    def mark_items_file_too_large(self, request, queryset):
+        """Force selected file items to the too large to analyze state."""
+        self._force_upload_state(
+            request, queryset, models.ItemUploadStateChoices.FILE_TOO_LARGE_TO_ANALYZE
+        )
 
 
 @admin.register(models.Invitation)
@@ -306,6 +333,34 @@ class MalwareDetectionAdmin(BaseMalwareDetectionAdmin):
 
     list_display = BaseMalwareDetectionAdmin.list_display + ("item_exists", "item_size")
     list_filter = BaseMalwareDetectionAdmin.list_filter + (ItemExistsFilter,)
+    actions = BaseMalwareDetectionAdmin.actions + (
+        "abandon_analysis_mark_item_ready",
+        "abandon_analysis_mark_item_file_too_large",
+    )
+
+    def _abandon_analyses(self, request, queryset, upload_state):
+        """Delete the selected detections and force the upload state of their items."""
+        item_ids = [
+            item_id for item_id in queryset.values_list("parameters__item_id", flat=True) if item_id
+        ]
+        updated = models.Item.objects.filter(id__in=item_ids).update(upload_state=upload_state)
+        deleted, _details = queryset.delete()
+        self.message_user(
+            request,
+            f"{deleted} detections deleted, {updated} items marked as {upload_state}.",
+        )
+
+    @admin.action(description=_("Abandon analysis and mark item as ready"))
+    def abandon_analysis_mark_item_ready(self, request, queryset):
+        """Delete selected detections and mark their items as ready."""
+        self._abandon_analyses(request, queryset, models.ItemUploadStateChoices.READY)
+
+    @admin.action(description=_("Abandon analysis and mark item as too large to analyze"))
+    def abandon_analysis_mark_item_file_too_large(self, request, queryset):
+        """Delete selected detections and mark their items as too large to analyze."""
+        self._abandon_analyses(
+            request, queryset, models.ItemUploadStateChoices.FILE_TOO_LARGE_TO_ANALYZE
+        )
 
     def get_queryset(self, request):
         """Annotate records with the existence and size of their related item."""

--- a/src/backend/core/tests/test_admin_items.py
+++ b/src/backend/core/tests/test_admin_items.py
@@ -1,0 +1,64 @@
+"""Tests for the item admin class."""
+
+from unittest import mock
+
+from django.contrib import admin
+from django.test import RequestFactory
+
+import pytest
+from lasuite.malware_detection.models import MalwareDetection, MalwareDetectionStatus
+
+from core import factories, models
+from core.admin import ItemAdmin
+
+pytestmark = pytest.mark.django_db
+
+
+def _create_analyzing_item():
+    """Create a file item stuck in the analyzing state with its detection record."""
+    item = factories.ItemFactory(
+        type=models.ItemTypeChoices.FILE,
+        filename="foo.txt",
+        update_upload_state=models.ItemUploadStateChoices.ANALYZING,
+    )
+    MalwareDetection.objects.create(
+        path=item.file_key,
+        status=MalwareDetectionStatus.PROCESSING,
+        parameters={"item_id": str(item.id)},
+    )
+    return item
+
+
+def test_admin_items_mark_items_ready():
+    """The action marks selected file items as ready and drops their detections."""
+    item = _create_analyzing_item()
+    folder = factories.ItemFactory(type=models.ItemTypeChoices.FOLDER)
+    admin_instance = ItemAdmin(models.Item, admin.site)
+    request = RequestFactory().post("/")
+
+    queryset = models.Item.objects.filter(pk__in=[item.pk, folder.pk])
+    with mock.patch.object(ItemAdmin, "message_user") as message_user:
+        admin_instance.mark_items_ready(request, queryset)
+
+    item.refresh_from_db()
+    assert item.upload_state == models.ItemUploadStateChoices.READY
+    assert not MalwareDetection.objects.exists()
+    message_user.assert_called_once_with(request, "1 items marked as ready, 1 detections deleted.")
+
+
+def test_admin_items_mark_items_file_too_large():
+    """The action marks selected file items as too large to analyze."""
+    item = _create_analyzing_item()
+    admin_instance = ItemAdmin(models.Item, admin.site)
+    request = RequestFactory().post("/")
+
+    queryset = models.Item.objects.filter(pk=item.pk)
+    with mock.patch.object(ItemAdmin, "message_user") as message_user:
+        admin_instance.mark_items_file_too_large(request, queryset)
+
+    item.refresh_from_db()
+    assert item.upload_state == models.ItemUploadStateChoices.FILE_TOO_LARGE_TO_ANALYZE
+    assert not MalwareDetection.objects.exists()
+    message_user.assert_called_once_with(
+        request, "1 items marked as file_too_large_to_analyze, 1 detections deleted."
+    )

--- a/src/backend/core/tests/test_admin_malware_detection.py
+++ b/src/backend/core/tests/test_admin_malware_detection.py
@@ -1,5 +1,7 @@
 """Tests for the malware detection admin class."""
 
+from unittest import mock
+
 from django.contrib import admin
 from django.test import RequestFactory
 
@@ -64,3 +66,45 @@ def test_admin_malware_detection_item_exists_filter():
     assert list(_changelist_queryset(admin_instance, {"item_exists": "yes"})) == [detection]
     assert list(_changelist_queryset(admin_instance, {"item_exists": "no"})) == [orphan]
     assert set(_changelist_queryset(admin_instance, {})) == {detection, orphan}
+
+
+def test_admin_malware_detection_abandon_analysis_mark_item_ready():
+    """The abandon action deletes selected detections and marks their items as ready."""
+    detection, orphan = _create_detections()
+    item = models.Item.objects.get(pk=detection.parameters["item_id"])
+    duplicate = MalwareDetection.objects.create(
+        path=detection.path,
+        status=MalwareDetectionStatus.PENDING,
+        parameters=detection.parameters,
+    )
+    admin_instance = MalwareDetectionAdmin(MalwareDetection, admin.site)
+    request = RequestFactory().post("/")
+
+    queryset = MalwareDetection.objects.filter(pk__in=[detection.pk, duplicate.pk])
+    with mock.patch.object(MalwareDetectionAdmin, "message_user") as message_user:
+        admin_instance.abandon_analysis_mark_item_ready(request, queryset)
+
+    item.refresh_from_db()
+    assert item.upload_state == models.ItemUploadStateChoices.READY
+    assert not MalwareDetection.objects.filter(pk__in=[detection.pk, duplicate.pk]).exists()
+    assert MalwareDetection.objects.filter(pk=orphan.pk).exists()
+    message_user.assert_called_once_with(request, "2 detections deleted, 1 items marked as ready.")
+
+
+def test_admin_malware_detection_abandon_analysis_mark_item_file_too_large():
+    """The abandon action deletes selected detections and marks their items as too large."""
+    detection, orphan = _create_detections()
+    item = models.Item.objects.get(pk=detection.parameters["item_id"])
+    admin_instance = MalwareDetectionAdmin(MalwareDetection, admin.site)
+    request = RequestFactory().post("/")
+
+    queryset = MalwareDetection.objects.filter(pk__in=[detection.pk, orphan.pk])
+    with mock.patch.object(MalwareDetectionAdmin, "message_user") as message_user:
+        admin_instance.abandon_analysis_mark_item_file_too_large(request, queryset)
+
+    item.refresh_from_db()
+    assert item.upload_state == models.ItemUploadStateChoices.FILE_TOO_LARGE_TO_ANALYZE
+    assert not MalwareDetection.objects.exists()
+    message_user.assert_called_once_with(
+        request, "2 detections deleted, 1 items marked as file_too_large_to_analyze."
+    )

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "django-cors-headers==4.9.0",
     "django-countries==8.2.0",
     "django-filter==25.2",
-    "django-lasuite[all]==0.0.28",
+    "django-lasuite[all]==0.0.29",
     "django-ltree==0.6.0",
     "django-parler==2.3",
     "django-pydantic-field==0.5.4",

--- a/src/backend/uv.lock
+++ b/src/backend/uv.lock
@@ -480,7 +480,7 @@ wheels = [
 
 [[package]]
 name = "django-lasuite"
-version = "0.0.28"
+version = "0.0.29"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "django" },
@@ -491,9 +491,9 @@ dependencies = [
     { name = "requests" },
     { name = "requests-toolbelt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/00/07/015974a4051c72959a495afc0ed9a1811c51be17607cabb67fb877f3b533/django_lasuite-0.0.28.tar.gz", hash = "sha256:1c0cf66aa32a22e78ba0ad70d73884796e32e0ba602e9e0339a136de83dcb603", size = 35151, upload-time = "2026-08-21T13:12:42.381Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/ab/72a79b7133fb2d17835bef40f45f7e6d2b4343469c37fd00386122e9068d/django_lasuite-0.0.29.tar.gz", hash = "sha256:831cb859e45e33963c9d89168c2de14f9844e805000b0f0d1512ffd0b9731a39", size = 35248, upload-time = "2026-08-25T13:03:43.597Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/5e/37ff49d85c58c333d0897c36038bcc3639786f39a8ce1796d72d3acbed44/django_lasuite-0.0.28-py3-none-any.whl", hash = "sha256:d1ee30fc19f42a6dbbe883e442ab3c1708368cfa46421ab4e1eba8523df40b8e", size = 54785, upload-time = "2026-08-21T13:12:41.001Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/cf/86648643221816f18ebd5a3e59b6d2a85ee85b38b19c7abe939f798a2845/django_lasuite-0.0.29-py3-none-any.whl", hash = "sha256:33bcff90ced2709190ef01241badb17ceed08a32725b9cdd3105650b36da303b", size = 54899, upload-time = "2026-08-25T13:03:42.212Z" },
 ]
 
 [package.optional-dependencies]
@@ -739,7 +739,7 @@ requires-dist = [
     { name = "django-debug-toolbar", marker = "extra == 'dev'", specifier = "==6.3.0" },
     { name = "django-extensions", marker = "extra == 'dev'", specifier = "==4.1" },
     { name = "django-filter", specifier = "==25.2" },
-    { name = "django-lasuite", extras = ["all"], specifier = "==0.0.28" },
+    { name = "django-lasuite", extras = ["all"], specifier = "==0.0.29" },
     { name = "django-ltree", specifier = "==0.6.0" },
     { name = "django-parler", specifier = "==2.3" },
     { name = "django-pydantic-field", specifier = "==0.5.4" },

--- a/src/helm/drive/values.yaml
+++ b/src/helm/drive/values.yaml
@@ -272,6 +272,18 @@ backend:
         - "/bin/sh"
         - "-c"
         - python manage.py purge_deleted_items
+    - name: check-pending-malware-analysis-tasks
+      schedule: "*/5 * * * *"
+      command:
+        - "/bin/sh"
+        - "-c"
+        - python manage.py check_analysis_pending
+    - name: reschedule-processing-malware-analysis
+      schedule: "0 4 * * *"
+      command:
+        - "/bin/sh"
+        - "-c"
+        - python manage.py reschedule_processing_analysis
 
   ## @param backend.themeCustomization.enabled Enable theme customization
   ## @param backend.themeCustomization.file_content Content of the theme customization file. Must be a json object.


### PR DESCRIPTION
## Purpose

The malware detection queue only moves forward on upload or analysis
completion events. When an analysis task dies without reporting its result,
its processing slot leaks: pending analyses stall forever and stuck items
can only be fixed through a database shell.

## Proposal

- [x] Ship the django-lasuite reconciliation commands
  (`check_analysis_pending`, `reschedule_processing_analysis`) as default
  cronjobs in the helm chart
- [x] Add admin actions to abandon selected detections and force their
  items to a final upload state, and to mark selected items as `ready` or
  `file_too_large_to_analyze` from the item list
- [x] Update django-lasuite to 0.0.29, which fixes the processing slots
  leaks that deadlocked the queue