### PR TITLE
📈(backend) add Sentry performance monitoring sample rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- 📈(backend) add a Sentry performance monitoring sample rate setting
+
 ### Fixed
 
 - 🐛(backend) prevent item deletion by a creator whose access was revoked

--- a/docs/env.md
+++ b/docs/env.md
@@ -118,6 +118,7 @@ This document lists all configurable environment variables for the Drive applica
 | `SEARCH_INDEXER_URL` | Find application endpoint for indexation | `None` |
 | `SEARCH_INDEXER_QUERY_LIMIT` | Maximum number of results expected from search endpoint | 50 |
 | `SENTRY_DSN` | Sentry DSN for error tracking | `None` |
+| `SENTRY_TRACES_SAMPLE_RATE` | Ratio of requests traced for Sentry performance monitoring (0 to 1) | `0.0` |
 | `SPECTACULAR_SETTINGS_ENABLE_DJANGO_DEPLOY_CHECK` | Enable Django deploy check in Spectacular | `False` |
 | `STORAGES_STATICFILES_BACKEND` | Backend for static files storage | `whitenoise.storage.CompressedManifestStaticFilesStorage` |
 | `TRASHBIN_CUTOFF_DAYS` | Number of days before items are automatically removed from trash after their soft deletion | `30` |

--- a/src/backend/drive/settings.py
+++ b/src/backend/drive/settings.py
@@ -997,6 +997,9 @@ class Base(Configuration):
 
     # Sentry
     SENTRY_DSN = values.Value(None, environ_name="SENTRY_DSN", environ_prefix=None)
+    SENTRY_TRACES_SAMPLE_RATE = values.FloatValue(
+        default=0.0, environ_name="SENTRY_TRACES_SAMPLE_RATE", environ_prefix=None
+    )
 
     ALLOW_SHARE_IMPORT_FILE = values.BooleanValue(
         default=False, environ_name="ALLOW_SHARE_IMPORT_FILE", environ_prefix=None
@@ -1572,6 +1575,7 @@ class Base(Configuration):
                 environment=cls.__name__.lower(),
                 release=get_release(),
                 integrations=[DjangoIntegration()],
+                traces_sample_rate=cls.SENTRY_TRACES_SAMPLE_RATE,
             )
             sentry_sdk.set_tag("application", "backend")
 


### PR DESCRIPTION
## Purpose

Enable Sentry performance monitoring (tracing) on the backend. The SDK is currently initialized without a `traces_sample_rate`, so only errors are reported and no transaction reaches Sentry.

## Proposal

Expose a `SENTRY_TRACES_SAMPLE_RATE` environment variable passed to `sentry_sdk.init()`. It defaults to `0` so existing deployments are unaffected; each environment can opt in with a low sampling ratio (e.g. `0.1`).