### PR TITLE
⚡️(backend) speed up folder listings, top-level roots and search

### DIFF
--- a/bin/compare_bench.py
+++ b/bin/compare_bench.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Compare benchmark JSON without Django: python3 bin/compare_bench.py before after.
+
+Exit 0: compatible declared protocol/configuration; 1: incompatible or unknown;
+2: invalid input. Missing legacy metadata never implies proven compatibility.
+Percentages are descriptive changes in medians, not statistical significance.
+"""
+
+import argparse
+import json
+import math
+from pathlib import Path
+
+CONFIG_KEYS = (
+    "reps", "page_size", "nb_children", "nb_subtrees", "subtree_depth",
+    "nb_files", "restricted_every", "nb_redundant_users",
+)
+
+
+def metrics(stats):
+    """Normalize historical and PgHero metrics without relabeling SQL as API time."""
+    if "api" in stats:
+        duration, calls = stats["api"]["median_ms"], stats["sql_calls"]
+        minimum = stats["api"].get("min_ms")
+    else:
+        duration, calls = stats["ms_median"], stats["queries"]
+        minimum = stats.get("ms_min")
+    for value in (duration, calls) + ((minimum,) if minimum is not None else ()):
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise ValueError("Metrics must be numeric")
+        if not math.isfinite(value) or value < 0:
+            raise ValueError("Metrics must be finite and nonnegative")
+    return duration, calls, minimum
+
+
+def change(before, after):
+    """Percentage change, or n/a without a positive baseline or a value."""
+    if not before or after is None:
+        return "n/a"
+    return f"{(after / before - 1) * 100:+.1f}%"
+
+
+def load(path):
+    """Validate relevant fields before comparing."""
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(data, dict) or not isinstance(data.get("scenarios"), dict):
+        raise ValueError("Expected an object with a scenarios mapping")
+    if not data["scenarios"]:
+        raise ValueError("No benchmark scenarios")
+    for stats in data["scenarios"].values():
+        metrics(stats)
+    if not isinstance(data.get("config", {}), dict):
+        raise ValueError("config must be an object")
+    return data
+
+
+def compatibility(before, after):
+    """Return hard mismatches separately from unverified conditions."""
+    mismatches, unknown = [], []
+    for key in ("mode", "protocol_version", "postgres", "python", "cache_backend"):
+        left, right = before.get(key), after.get(key)
+        if left is None or right is None:
+            unknown.append(f"{key}: metadata missing")
+        elif left != right:
+            mismatches.append(f"{key}: {left!r} -> {right!r}")
+    left_config, right_config = before.get("config", {}), after.get("config", {})
+    for key in CONFIG_KEYS:
+        left, right = left_config.get(key), right_config.get(key)
+        if left is None or right is None:
+            unknown.append(f"config.{key}: missing")
+        elif left != right:
+            mismatches.append(f"config.{key}: {left} -> {right}")
+    left = left_config.get("with_restrictions", before.get("has_restricted"))
+    right = right_config.get("with_restrictions", after.get("has_restricted"))
+    if left is None or right is None:
+        unknown.append("restriction setting missing")
+    elif left != right:
+        mismatches.append(f"restrictions: {left} -> {right}")
+    if left or right:
+        # Early big archives predate this explicit sample-size knob.
+        a, b = left_config.get("nb_abilities_sample"), right_config.get("nb_abilities_sample")
+        if a is None or b is None:
+            unknown.append("config.nb_abilities_sample: missing")
+        elif a != b:
+            mismatches.append(f"config.nb_abilities_sample: {a} -> {b}")
+    for key in ("dataset_items", "dataset_accesses"):
+        a, b = before.get(key), after.get(key)
+        if a is not None and b is not None and a != b:
+            mismatches.append(f"{key}: {a} -> {b}")
+    if set(before["scenarios"]) != set(after["scenarios"]):
+        mismatches.append("scenario sets differ (only common names are displayed)")
+    for name in before["scenarios"].keys() & after["scenarios"].keys():
+        a, b = before["scenarios"][name], after["scenarios"][name]
+        if ("api" in a) != ("api" in b):
+            mismatches.append(f"{name}: different timing instrumentation")
+        for key in ("rows", "count"):
+            if key in a and key in b and a[key] != b[key]:
+                mismatches.append(f"{name}.{key}: {a[key]} -> {b[key]}")
+    for name in before.get("extra", {}).keys() & after.get("extra", {}).keys():
+        if before["extra"][name] != after["extra"][name]:
+            mismatches.append(f"extra.{name}: result sizes differ")
+    return mismatches, unknown
+
+
+def report(before, after):
+    """Build a Markdown report, including non-comparable results as observations."""
+    mismatches, unknown = compatibility(before, after)
+    status = "INCOMPATIBLE" if mismatches else "PROVISIONAL" if unknown else "COMPATIBLE"
+    lines = [f"Comparison: {status}", ""]
+    for label, data in (("Before", before), ("After", after)):
+        source = data.get("source", {})
+        lines.append(f"{label}: commit={source.get('commit') or 'unknown'}, "
+                     f"tracked_dirty={source.get('tracked_dirty', 'unknown')}")
+    lines.extend(["", *[f"- {note}" for note in mismatches + unknown], ""])
+    if mismatches or unknown:
+        lines.append("Descriptive values only; these are not validated performance gains.")
+    lines.extend(["", "| Scenario | Median before → after | Change | Min before → after | Change "
+                  "| Calls before → after |", "|---|---:|---:|---:|---:|---:|"])
+    for name in sorted(before["scenarios"].keys() & after["scenarios"].keys()):
+        a, ac, amin = metrics(before["scenarios"][name])
+        b, bc, bmin = metrics(after["scenarios"][name])
+        minimum = f"{amin:.3f} → {bmin:.3f}" if amin is not None and bmin is not None else "n/a"
+        lines.append(f"| {name} | {a:.3f} → {b:.3f} | {change(a, b)} | {minimum} "
+                     f"| {change(amin, bmin)} | {ac} → {bc} |")
+    lines.extend(["", "Negative duration changes mean faster runs. SQL call counts are not timings.",
+                  "The minimum resists load spikes on the machine better than the median.",
+                  "Matching metadata does not control machine load or prove statistical significance."])
+    return "\n".join(lines), bool(mismatches or unknown)
+
+
+def main():
+    """Print comparison and return an automation-friendly status."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("before", type=Path)
+    parser.add_argument("after", type=Path)
+    args = parser.parse_args()
+    try:
+        rendered, uncertain = report(load(args.before), load(args.after))
+    except (OSError, ValueError, KeyError, TypeError) as error:
+        parser.error(str(error))
+    print(rendered)
+    return int(uncertain)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bin/tests/test_compare_bench.py
+++ b/bin/tests/test_compare_bench.py
@@ -1,0 +1,104 @@
+"""Comparison contract tests, runnable without Django or PostgreSQL."""
+
+import copy
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "compare_bench.py"
+SPEC = importlib.util.spec_from_file_location("compare_bench", SCRIPT)
+BENCH = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(BENCH)
+
+
+def sample():
+    return {
+        "mode": "historical", "protocol_version": "restricted_2-v1",
+        "postgres": "test", "python": "test", "cache_backend": "test",
+        "config": {**dict.fromkeys(BENCH.CONFIG_KEYS, 10), "with_restrictions": False},
+        "scenarios": {"children": {"ms_median": 100, "queries": 10}},
+    }
+
+
+class ComparisonTests(unittest.TestCase):
+    def test_matching_protocol_and_percentage(self):
+        before = sample()
+        after = copy.deepcopy(before)
+        after["scenarios"]["children"] = {"ms_median": 75, "queries": 5}
+        report, uncertain = BENCH.report(before, after)
+        self.assertFalse(uncertain)
+        self.assertIn("-25.0%", report)
+        self.assertIn("10 → 5", report)
+
+    def test_minimum_column(self):
+        before, after = sample(), sample()
+        for data, median, minimum in ((before, 100, 90), (after, 80, 45)):
+            data["scenarios"]["children"] = {
+                "api": {"median_ms": median, "min_ms": minimum}, "sql_calls": 4,
+            }
+        report, _ = BENCH.report(before, after)
+        self.assertIn("100.000 → 80.000", report)
+        self.assertIn("90.000 → 45.000", report)
+        self.assertIn("-50.0%", report)
+
+    def test_legacy_is_provisional(self):
+        legacy = sample()
+        del legacy["protocol_version"]
+        report, uncertain = BENCH.report(legacy, sample())
+        self.assertTrue(uncertain)
+        self.assertIn("PROVISIONAL", report)
+
+    def test_different_dataset_and_protocol(self):
+        after = sample()
+        after["config"]["nb_children"] = 1000
+        after["protocol_version"] = "other"
+        mismatches, _ = BENCH.compatibility(sample(), after)
+        self.assertTrue(any("nb_children" in entry for entry in mismatches))
+        self.assertTrue(any("protocol_version" in entry for entry in mismatches))
+
+    def test_different_response_and_instrumentation(self):
+        before = sample()
+        after = sample()
+        before["scenarios"]["children"]["rows"] = 20
+        after["scenarios"]["children"] = {
+            "api": {"median_ms": 80}, "sql_calls": 4, "rows": 10,
+        }
+        mismatches, _ = BENCH.compatibility(before, after)
+        self.assertTrue(any("instrumentation" in entry for entry in mismatches))
+        self.assertTrue(any("rows" in entry for entry in mismatches))
+
+    def test_zero_baseline(self):
+        before = sample()
+        before["scenarios"]["children"]["ms_median"] = 0
+        self.assertIn("n/a", BENCH.report(before, sample())[0])
+
+    def test_invalid_metrics(self):
+        for duration in (-1, float("nan"), "100", True):
+            with self.subTest(duration=duration), self.assertRaises(ValueError):
+                BENCH.metrics({"ms_median": duration, "queries": 1})
+
+    def test_cli_exit_statuses(self):
+        with tempfile.TemporaryDirectory() as directory:
+            a, b = Path(directory) / "a.json", Path(directory) / "b.json"
+            a.write_text(json.dumps(sample()))
+            b.write_text(json.dumps(sample()))
+            def run():
+                return subprocess.run(
+                    [sys.executable, str(SCRIPT), str(a), str(b)],
+                    capture_output=True, check=False,
+                ).returncode
+            self.assertEqual(run(), 0)
+            changed = sample()
+            changed["config"]["page_size"] = 200
+            b.write_text(json.dumps(changed))
+            self.assertEqual(run(), 1)
+            b.write_text("invalid")
+            self.assertEqual(run(), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,0 +1,80 @@
+# Query benchmarks
+
+Run from the repository root:
+
+```bash
+bin/manage benchmark --mode pghero --profile smoke
+bin/manage benchmark --mode historical --profile big --restrictions
+```
+
+The command creates a uniquely named PostgreSQL database, runs migrations, measures
+requests and drops that database on success or failure. The configured database
+is not populated. The database user needs `CREATE DATABASE` permission. A forced
+process kill can leave the temporary database behind; its name is printed at startup.
+
+Requests use local caches, email and entitlement backends with external search
+disabled. The workload runs in a rolled-back transaction so background jobs
+registered with `on_commit` do not run.
+
+## Options
+
+| Option | Default | Description |
+|---|---|---|
+| `--mode` | `pghero` | `pghero` or `historical` |
+| `--profile` | `smoke` | `smoke`, `big`, `xl`, `xxl`; `large` aliases `xxl` |
+| `--reps` | Mode-dependent | At least 2 repetitions after warmup |
+| `--restrictions` | Disabled | Include restricted folders |
+| `--output` | `bench_results/bench_<mode>_<timestamp>.json` | New file; existing files are never overwritten |
+| `--commit` | Detected with Git, otherwise unknown | Revision represented by the measurements |
+
+Paths are relative to the command's working directory. With `bin/manage`, the
+container runs in `/app`, mounted from `src/backend`, so default results appear
+in `src/backend/bench_results` on the host.
+
+```bash
+bin/manage benchmark --mode pghero --profile xxl --reps 10 \
+  --restrictions --commit "$(git rev-parse HEAD)"
+```
+
+The old `DRIVE_BENCH_*` environment variables are no longer used.
+
+## Modes
+
+`pghero` measures nine scenarios: folder listings as owner and editor with two
+sort orders, a second page, nested children, accessible roots, shared roots and
+search. It records API wall times, then profiles SQL in a separate pass. The
+fixture contains direct shares, link traces and favorites; `ANALYZE` runs before
+measurement.
+
+`historical` retains the `restricted_2` fixture, scenarios, session authentication
+and timing instrumentation. It measures listings, search and export, plus abilities
+and lifting a restriction when restrictions are enabled. Timing includes SQL
+capture overhead. It does not run an explicit `ANALYZE`.
+
+Command results use new protocol versions because isolation settings and fixture
+creation differ from the former pytest runner. Neither mode recreates the older
+boolean restriction implementation.
+
+| Profile | Direct folders | Nested chains | Chain depth | Files per chain | Page size |
+|---|---:|---:|---:|---:|---:|
+| smoke | 60 | 20 | 3 | 4 | 20 |
+| big | 500 | 100 | 3 | 5 | 100 |
+| xl | 5,000 | 1,500 | 8 | 20 | 100 |
+| xxl | 10,000 | 5,000 | 10 | 25 | 200 |
+
+Files sit in the first folder of each chain. PgHero mode defaults to 10 repetitions;
+historical mode uses 10, 5, 3 and 3 respectively.
+
+## Compare
+
+```bash
+python3 bin/compare_bench.py before.json after.json
+```
+
+Use identical modes, profiles, repetitions and restriction settings on the same
+machine. The report shows the median and the minimum of the API samples: the
+minimum is less sensitive to other processes running on the machine. The
+comparator labels missing metadata as provisional and differing
+protocols/configurations as incompatible. Its exit status is 0 for compatible
+metadata, 1 for incompatible or provisional comparisons, and 2 for invalid
+input.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -66,6 +66,17 @@ boolean restriction implementation.
 Files sit in the first folder of each chain. PgHero mode defaults to 10 repetitions;
 historical mode uses 10, 5, 3 and 3 respectively.
 
+## Browse the dataset
+
+```bash
+bin/manage create_demo --bench big --bench-role reader
+```
+
+Builds the `pghero` dataset, with restrictions, in the configured database and
+copies the accesses and link traces of one bench user (`alice`, `bob` or
+`reader`, default `bob`) to the development users. Files have no content in
+object storage. Run `make resetdb` before building it again.
+
 ## Compare
 
 ```bash

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -40,10 +40,11 @@ The old `DRIVE_BENCH_*` environment variables are no longer used.
 
 ## Modes
 
-`pghero` measures nine scenarios: folder listings as owner and editor with two
-sort orders, a second page, nested children, accessible roots, shared roots and
-search. It records API wall times, then profiles SQL in a separate pass. The
-fixture contains direct shares, link traces and favorites; `ANALYZE` runs before
+`pghero` measures ten scenarios: folder listings as owner and editor with two
+sort orders, a second page, nested children, accessible roots for a user with
+many shares and for a user with one inherited share, shared roots and search.
+It records API wall times, then profiles SQL in a separate pass. The fixture
+contains direct shares, link traces and favorites; `ANALYZE` runs before
 measurement.
 
 `historical` retains the `restricted_2` fixture, scenarios, session authentication

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -1434,7 +1434,7 @@ class ItemViewSet(
         queryset = self.queryset
         indexer = get_file_indexer()
 
-        queryset = queryset.select_related("creator")
+        queryset = queryset.select_related("creator").annotate_has_restriction()
         filterset = SearchItemFilter(request.GET, queryset=queryset, request=self.request)
 
         if not filterset.is_valid():
@@ -1524,14 +1524,24 @@ class ItemViewSet(
                 if item_id not in parents and item_id not in missing_parent_ids:
                     missing_parent_ids.add(item_id)
 
-        # Fetch missing ancestors from database
+        # Fetch missing ancestors from database, annotated like the items so that
+        # the serializer does not query per parent for its roles and restriction
         if missing_parent_ids:
+            user = self.request.user
             for parent in (
-                models.Item.objects.annotate_with_numchild()
+                models.Item.objects.select_related("creator")
+                .annotate_has_restriction()
+                .annotate_user_roles(user)
+                .annotate_with_numchild()
                 .filter(id__in=missing_parent_ids)
                 .iterator()
             ):
                 parents[str(parent.id)] = parent
+        models.Item.prefetch_nb_accesses(parents.values())
+        paths_links_mapping = self._compute_ancestors_link_definition(parents.values())
+        for item in parents.values():
+            links = paths_links_mapping.get(str(item.path[:-1]), [])
+            item.ancestors_link_definition = get_equivalent_link_definition(links)
 
         # Set parents for each item
         for item in items:

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -752,11 +752,14 @@ class ItemViewSet(
 
         # Among the results, we may have items that are ancestors/descendants
         # of each other. In this case we want to keep only the highest ancestors.
-        root_paths = utils.filter_root_paths(
-            queryset.order_by("path").values_list("path", flat=True),
-            skip_sorting=True,
-        )
-        queryset = queryset.filter(path__in=root_paths)
+        # Filter them back by id: equality on a list of paths goes through the
+        # GiST index, which is much slower than the primary key for that.
+        ids_by_path = {
+            str(path): item_id
+            for path, item_id in queryset.order_by("path").values_list("path", "id")
+        }
+        root_paths = utils.filter_root_paths(list(ids_by_path), skip_sorting=True)
+        queryset = queryset.filter(id__in=[ids_by_path[path] for path in root_paths])
 
         # Hide restricted roots the user already reaches through a live
         # restriction, so the folder shows up in a single location

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -1205,11 +1205,19 @@ class ItemViewSet(
         # Apply ordering only now that everything is filtered and annotated
         queryset = ItemOrdering().filter_queryset(self.request, queryset, self)
 
-        # Pre-compute number of accesses
+        # Pre-compute number of accesses with a correlated subquery: joining the
+        # accesses would force a GROUP BY on the listing and on its pagination count
         item_nb_accesses = item.nb_accesses
+        direct_accesses = (
+            models.ItemAccess.objects.filter(item=db.OuterRef("pk"))
+            .order_by()
+            .values("item")
+            .annotate(count=db.Count("pk"))
+            .values("count")
+        )
         queryset = queryset.annotate(
             _nb_accesses=db.Value(item_nb_accesses)
-            + Coalesce(db.Count("accesses", distinct=True), 0),
+            + Coalesce(db.Subquery(direct_accesses, output_field=db.IntegerField()), 0),
         )
 
         # Pass ancestors' links paths mapping to the serializer as a context variable

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -548,6 +548,7 @@ class ItemViewSet(
         page = self.paginate_queryset(queryset)
         if page is not None:
             items = list(page)
+            models.Item.prefetch_nb_accesses(items)
             if with_ancestors_link_definition:
                 paths_links_mapping = self._compute_ancestors_link_definition(items)
                 context["paths_links_mapping"] = paths_links_mapping
@@ -556,6 +557,7 @@ class ItemViewSet(
             return result
 
         items = list(queryset)
+        models.Item.prefetch_nb_accesses(items)
         if with_ancestors_link_definition:
             paths_links_mapping = self._compute_ancestors_link_definition(items)
             context["paths_links_mapping"] = paths_links_mapping

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -565,42 +565,29 @@ class ItemViewSet(
     def _compute_ancestors_link_definition(self, items):
         """
         Compute ancestors link definition for the items collection.
-        On the collection, we look for the deepest items, compute ancestors link definition
-        for each item and aggregate them in order to inject it in the serializer context.
+        All ancestors are loaded in a single query on their paths, then the link
+        definitions are chained by path prefix to be injected in the serializer context.
         """
-        if not items:
+        ancestors_paths = set()
+        for item in items:
+            labels = str(item.path).split(".")
+            ancestors_paths.update(".".join(labels[:depth]) for depth in range(1, len(labels)))
+        if not ancestors_paths:
             return {}
 
-        # Find deepest items and group them by parent path
-        # Items at the same depth in multiple trees (same parent path) share the same ancestors,
-        items_sorted = sorted(items, key=lambda x: len(x.path), reverse=True)
-        items_by_tree = {}  # Group deepest items by parent_path
-        seen_paths = set()  # Track all paths we've processed
-
-        for item in items_sorted:
-            # Check if this item is a parent of any longer path we've already seen
-            # A descendant path would start with the item's path followed by a dot
-            item_path_prefix = f"{item.path}."
-            has_descendants = any(
-                seen_path.startswith(item_path_prefix) for seen_path in seen_paths
-            )
-
-            if not has_descendants:
-                # Get parent path (empty string for root items)
-                parent_path = str(item.path[:-1]) if item.depth > 1 else ""
-                if parent_path not in items_by_tree:
-                    items_by_tree[parent_path] = item
-
-            # Add this item's path to the set for future checks (shorter paths)
-            seen_paths.add(str(item.path))
-
-        # Compute ancestors links paths mapping for one item per tree group and aggregate
+        definitions = {
+            str(path): {"link_reach": link_reach, "link_role": link_role}
+            for path, link_reach, link_role in models.Item.objects.filter(
+                path__in=ancestors_paths, ancestors_deleted_at__isnull=True
+            ).values_list("path", "link_reach", "link_role")
+        }
         paths_links_mapping = {}
-        for item in items_by_tree.values():
-            item_mapping = item.compute_ancestors_links_paths_mapping()
-            paths_links_mapping |= item_mapping
-
-        # Update the serializer context with the aggregated mapping
+        for path in definitions:
+            labels = path.split(".")
+            chain = (".".join(labels[:depth]) for depth in range(1, len(labels) + 1))
+            paths_links_mapping[path] = [
+                definitions[prefix] for prefix in chain if prefix in definitions
+            ]
         return paths_links_mapping
 
     def retrieve(self, request, *args, **kwargs):
@@ -818,7 +805,7 @@ class ItemViewSet(
         # Apply ordering only now that everyting is filtered and annotated
         queryset = ItemOrdering().filter_queryset(self.request, queryset, self)
 
-        return self.get_response_for_queryset(queryset)
+        return self.get_response_for_queryset(queryset, with_ancestors_link_definition=True)
 
     @drf.decorators.action(detail=True, methods=["post"], url_path="upload-ended")
     def upload_ended(self, request, *args, **kwargs):

--- a/src/backend/core/management/commands/benchmark.py
+++ b/src/backend/core/management/commands/benchmark.py
@@ -1,0 +1,97 @@
+"""Measure query performance in a disposable PostgreSQL database."""
+
+import uuid
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+
+from django.core.management import call_command
+from django.core.management.base import BaseCommand, CommandError
+from django.db import connection, connections, transaction
+from django.test.utils import override_settings
+
+from core.services.benchmark import PROFILES, Benchmark
+
+
+@contextmanager
+def temporary_database():
+    """Create only a fresh database; restore the connection and drop it on exit."""
+    if connection.vendor != "postgresql" or len(list(connections)) != 1:
+        raise CommandError("benchmark requires a single PostgreSQL database configuration")
+    if connection.in_atomic_block:
+        raise CommandError("benchmark cannot run inside an existing transaction")
+    original_name = connection.settings_dict["NAME"]
+    temporary_name = f"drive_bench_{uuid.uuid4().hex}"
+    created = False
+    connection.close()
+    try:
+        # Django's maintenance connection does not connect to the benchmark DB.
+        with connection._nodb_cursor() as cursor:  # pylint: disable=protected-access  # noqa: SLF001
+            cursor.execute(f"CREATE DATABASE {connection.ops.quote_name(temporary_name)}")
+        created = True
+        connection.settings_dict["NAME"] = temporary_name
+        yield temporary_name
+    finally:
+        connection.close()
+        connection.settings_dict["NAME"] = original_name
+        if created:
+            with connection._nodb_cursor() as cursor:  # pylint: disable=protected-access  # noqa: SLF001
+                cursor.execute(f"DROP DATABASE {connection.ops.quote_name(temporary_name)}")
+
+
+class Command(BaseCommand):
+    """Run API and SQL measurements without populating the configured database."""
+
+    help = "Run query benchmarks in a temporary database (requires CREATE DATABASE permission)"
+    requires_system_checks = []
+
+    def add_arguments(self, parser):
+        parser.add_argument("--mode", choices=("pghero", "historical"), default="pghero")
+        parser.add_argument("--profile", choices=(*PROFILES, "large"), default="smoke")
+        parser.add_argument("--reps", type=int, help="Repetitions per scenario, minimum 2")
+        parser.add_argument("--restrictions", action="store_true")
+        parser.add_argument("--output", type=Path, help="New JSON output path; never overwritten")
+        parser.add_argument("--commit", help="Git SHA, if the repository is not mounted")
+
+    def handle(self, *args, **options):
+        if options["reps"] is not None and options["reps"] < 2:
+            raise CommandError("--reps must be at least 2")
+        output = options["output"] or Path("bench_results") / (
+            f"bench_{options['mode']}_{datetime.now(timezone.utc):%Y%m%dT%H%M%S%fZ}.json"
+        )
+        if output.exists():
+            raise CommandError(f"Output already exists: {output}")
+        runner = Benchmark(
+            mode=options["mode"],
+            profile=options["profile"],
+            reps=options["reps"],
+            restrictions=options["restrictions"],
+            output=output,
+            commit=options["commit"],
+        )
+        # Keep requests local and disable external search, email and entitlement services.
+        # Roll back the workload to discard on_commit background jobs, like pytest did.
+        with (
+            override_settings(
+                ALLOWED_HOSTS=["testserver"],
+                SECURE_SSL_REDIRECT=False,
+                CACHES={"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}},
+                SESSION_CACHE_ALIAS="default",
+                EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend",
+                PASSWORD_HASHERS=["django.contrib.auth.hashers.MD5PasswordHasher"],
+                SEARCH_INDEXER_CLASS=None,
+                FEATURES_INDEXED_SEARCH=True,
+                ENTITLEMENTS_BACKEND="core.entitlements.backends.static.StaticEntitlementsBackend",
+                ENTITLEMENTS_BACKEND_PARAMETERS={},
+            ),
+            temporary_database() as database_name,
+        ):
+            self.stdout.write(f"Temporary database: {database_name}")
+            call_command("migrate", interactive=False, verbosity=0)
+            with transaction.atomic():
+                result = runner.run()
+                transaction.set_rollback(True)
+        for name, stats in result["scenarios"].items():
+            duration = stats["api"]["median_ms"] if "api" in stats else stats["ms_median"]
+            self.stdout.write(f"{name}: {duration:.3f} ms")
+        self.stdout.write(f"Results: {output}")

--- a/src/backend/core/migrations/0031_remove_redundant_user_indexes.py
+++ b/src/backend/core/migrations/0031_remove_redundant_user_indexes.py
@@ -1,0 +1,55 @@
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+def drop_index(name, table):
+    """Drop the index without locking the table, and recreate it on rollback."""
+    return migrations.RunSQL(
+        sql=f'DROP INDEX CONCURRENTLY IF EXISTS "{name}"',
+        reverse_sql=f'CREATE INDEX CONCURRENTLY IF NOT EXISTS "{name}" ON "{table}" ("user_id")',
+    )
+
+
+class Migration(migrations.Migration):
+
+    # The unique constraints on (user, item) already cover lookups by user, the
+    # single column indexes are redundant. DROP INDEX CONCURRENTLY cannot run
+    # inside a transaction and does not lock writes on these active tables.
+    atomic = False
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ("core", "0030_item_add_restriction_target"),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.AlterField(
+                    model_name="itemfavorite",
+                    name="user",
+                    field=models.ForeignKey(
+                        db_index=False,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="favorite_items",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                migrations.AlterField(
+                    model_name="linktrace",
+                    name="user",
+                    field=models.ForeignKey(
+                        db_index=False,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="link_traces",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+            database_operations=[
+                drop_index("drive_item_favorite_user_id_f4a0b235", "drive_item_favorite"),
+                drop_index("drive_link_trace_user_id_852fee0b", "drive_link_trace"),
+            ],
+        ),
+    ]

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -807,8 +807,12 @@ class ItemQuerySet(AnnotateUserRoleQuerySetMixin, TreeQuerySet):
 
     def annotate_has_restriction(self):
         """Annotate whether a restriction targets each item."""
+        # A left join on the unique target index costs one probe per returned row,
+        # whereas PostgreSQL turns the equivalent EXISTS into a full scan of the table
         return self.annotate(
-            has_restriction=models.Exists(self.model.objects.filter(target=models.OuterRef("pk")))
+            has_restriction=models.ExpressionWrapper(
+                models.Q(restriction__isnull=False), output_field=models.BooleanField()
+            )
         )
 
     def readable_per_se(self, user):

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -1821,7 +1821,10 @@ class LinkTrace(BaseModel):
         on_delete=models.CASCADE,
         related_name="link_traces",
     )
-    user = models.ForeignKey(User, on_delete=models.CASCADE, related_name="link_traces")
+    # The unique constraint on (user, item) already covers lookups by user
+    user = models.ForeignKey(
+        User, on_delete=models.CASCADE, related_name="link_traces", db_index=False
+    )
 
     class Meta:
         db_table = "drive_link_trace"
@@ -1847,7 +1850,10 @@ class ItemFavorite(BaseModel):
         on_delete=models.CASCADE,
         related_name="favorited_by_users",
     )
-    user = models.ForeignKey(User, on_delete=models.CASCADE, related_name="favorite_items")
+    # The unique constraint on (user, item) already covers lookups by user
+    user = models.ForeignKey(
+        User, on_delete=models.CASCADE, related_name="favorite_items", db_index=False
+    )
 
     class Meta:
         db_table = "drive_item_favorite"

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -1223,6 +1223,17 @@ class Item(TreeModel, BaseModel):
 
             return nb_accesses
 
+    @classmethod
+    def prefetch_nb_accesses(cls, items):
+        """Read the cached number of accesses of the items in a single cache round trip."""
+        keys = {
+            item.get_nb_accesses_cache_key(): item
+            for item in items
+            if not hasattr(item, "_nb_accesses")
+        }
+        for key, nb_accesses in cache.get_many(keys).items():
+            keys[key]._nb_accesses = nb_accesses  # pylint: disable=protected-access  # noqa: SLF001
+
     @property
     def numchild(self):
         """Return the number of non-deleted children from annotation."""

--- a/src/backend/core/services/benchmark.py
+++ b/src/backend/core/services/benchmark.py
@@ -1,0 +1,548 @@
+"""Query benchmark scenarios for the benchmark management command.
+
+Historical mode preserves restricted_2 scenarios and timing instrumentation.
+Both modes now run with isolated application settings; protocol versions differ
+from pytest-era runs, which must not be treated as identical measurements.
+"""
+
+import hashlib
+import json
+import platform
+import shutil
+import statistics
+import subprocess
+import time
+import uuid
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+
+from django.conf import settings
+from django.contrib.auth.hashers import make_password
+from django.core.management.base import CommandError
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+
+from rest_framework.test import APIClient
+
+from core import models
+from core.services.item_exports import export_descendants
+
+PROFILES = {
+    "smoke": (20, 60, 20, 3, 4, 10, 5, 10),
+    "big": (100, 500, 100, 3, 5, 20, 50, 5),
+    "xl": (100, 5000, 1500, 8, 20, 100, 50, 3),
+    "xxl": (200, 10000, 5000, 10, 25, 100, 50, 3),
+}
+
+
+def require(condition, message="Invalid benchmark response"):
+    """Abort invalid measurements even when Python assertions are disabled."""
+    if not condition:
+        raise CommandError(message)
+
+
+class Benchmark:  # pylint: disable=too-many-instance-attributes,too-many-arguments
+    """Run query scenarios against an already isolated and migrated database."""
+
+    def __init__(self, *, mode, profile, reps, restrictions, output, commit=None):  # noqa: PLR0913
+        self.mode = mode
+        self.profile = "xxl" if profile == "large" else profile
+        (
+            self.page_size,
+            self.nb_children,
+            self.nb_subtrees,
+            self.subtree_depth,
+            self.nb_files,
+            self.nb_redundant_users,
+            self.nb_abilities_sample,
+            historical_reps,
+        ) = PROFILES[self.profile]
+        self.reps = reps if reps is not None else historical_reps if mode == "historical" else 10
+        self.with_restrictions = restrictions
+        self.output = output
+        self.commit = commit
+        self.folder = models.ItemTypeChoices.FOLDER
+        self.file = models.ItemTypeChoices.FILE
+        self.restriction = getattr(models.ItemTypeChoices, "RESTRICTION", None)
+        self.restricted_every = 10
+        self.config = {
+            name: getattr(self, name)
+            for name in (
+                "profile",
+                "reps",
+                "page_size",
+                "nb_children",
+                "nb_subtrees",
+                "subtree_depth",
+                "nb_files",
+                "with_restrictions",
+                "restricted_every",
+                "nb_redundant_users",
+                "nb_abilities_sample",
+            )
+        }
+
+    # pylint: disable=too-many-locals,too-many-statements
+    def build_dataset(self):  # noqa: PLR0915 - explicit benchmark topology and access setup
+        """Build a deterministic tree, sized by the volume knobs above.
+
+        Items are inserted with bulk_create (paths computed by hand): the factories
+        go through create_child whose per-insert unique-title check scans siblings,
+        which is quadratic under a single parent and intractable at large volumes.
+        """
+
+        def bench_user(name):
+            user, _ = models.User.objects.get_or_create(
+                sub=f"bench-{name}",
+                defaults={
+                    "email": f"{name}@bench.local",
+                    "full_name": name.capitalize(),
+                    "language": "en-us",
+                    "password": make_password(None),
+                },
+            )
+            return user
+
+        sequence = 0
+
+        def next_id():
+            nonlocal sequence
+            if self.mode == "historical":
+                return uuid.uuid4()
+            sequence += 1
+            return uuid.uuid5(uuid.NAMESPACE_URL, f"drive-benchmark/{sequence}")
+
+        alice = bench_user("alice")
+        bob = bench_user("bob")
+        carol = bench_user("carol")
+
+        workspace_id = next_id()
+        workspace = models.Item.objects.create(
+            id=workspace_id,
+            path=str(workspace_id),
+            title="bench-ws",
+            type=self.folder,
+            creator=alice,
+        )
+        models.ItemAccess.objects.create(item=workspace, user=alice, role=models.RoleChoices.OWNER)
+        models.ItemAccess.objects.create(item=workspace, user=bob, role=models.RoleChoices.EDITOR)
+
+        def new_item(title, parent_path, type_, **kwargs):
+            pk = next_id()
+            return models.Item(
+                id=pk,
+                title=title,
+                creator=alice,
+                type=type_,
+                path=f"{parent_path}.{pk}" if parent_path else str(pk),
+                link_reach=models.LinkReachChoices.RESTRICTED,
+                **kwargs,
+            )
+
+        def new_restricted(title, parent_path):
+            """Return (root folder, restriction under parent_path targeting it)."""
+            folder = new_item(title, None, self.folder)
+            restriction = new_item(title, parent_path, self.restriction, target=folder)
+            return folder, restriction
+
+        restricted_indices = (
+            set(range(5, self.nb_children, self.restricted_every))
+            if self.with_restrictions
+            else set()
+        )
+
+        items = []
+        restrictions = []
+        folders = []
+        for i in range(self.nb_children):
+            if i in restricted_indices:
+                folder, restriction = new_restricted(f"folder-{i:04d}", workspace.path)
+                restrictions.append(restriction)
+            else:
+                folder = new_item(f"folder-{i:04d}", workspace.path, self.folder)
+            folders.append(folder)
+            items.append(folder)
+
+        deep_restricted = None
+        for i in range(self.nb_subtrees):
+            node = folders[i % self.nb_children]
+            for depth in range(self.subtree_depth):
+                if self.with_restrictions and i == 2 and depth == 0:
+                    node, restriction = new_restricted(f"sub-{i:04d}-{depth}", node.path)
+                    restrictions.append(restriction)
+                    deep_restricted = node
+                else:
+                    node = new_item(f"sub-{i:04d}-{depth}", node.path, self.folder)
+                items.append(node)
+                if depth == 0:
+                    for j in range(self.nb_files):
+                        items.append(
+                            new_item(
+                                f"file-{i:04d}-{j}",
+                                node.path,
+                                self.file,
+                                filename="file.txt",
+                                upload_state=models.ItemUploadStateChoices.READY,
+                            )
+                        )
+
+        models.Item.objects.bulk_create(items, batch_size=2000)
+        models.Item.objects.bulk_create(restrictions, batch_size=2000)
+
+        restricted = [folders[i] for i in sorted(restricted_indices)]
+        accesses = [
+            models.ItemAccess(item=item, user=carol, role=models.RoleChoices.OWNER)
+            for item in restricted + ([deep_restricted] if deep_restricted else [])
+        ]
+
+        # Redundant users for the deactivate scenario
+        redundant_users = [bench_user(f"redundant{i}") for i in range(self.nb_redundant_users)]
+        accesses.extend(
+            models.ItemAccess(item=workspace, user=user, role=models.RoleChoices.EDITOR)
+            for user in redundant_users
+        )
+        reader = None
+        if self.mode == "pghero":
+            # Dense direct shares exercise COUNT(DISTINCT accesses), in addition to inheritance.
+            accesses.extend(
+                models.ItemAccess(item=folder, user=user, role=models.RoleChoices.READER)
+                for folder in folders[: min(500, self.nb_children)]
+                for user in redundant_users[:10]
+            )
+            reader = bench_user("reader")
+            accesses.extend(
+                models.ItemAccess(item=folder, user=reader, role=models.RoleChoices.READER)
+                for folder in folders[::2]
+            )
+            models.ItemAccess.objects.bulk_create(accesses, batch_size=2000)
+            # Link-only access, disjoint from reader's explicit shares.
+            traced = folders[1::4]
+            models.Item.objects.filter(pk__in=[item.pk for item in traced]).update(
+                link_reach=models.LinkReachChoices.AUTHENTICATED
+            )
+            models.LinkTrace.objects.bulk_create(
+                [models.LinkTrace(item=item, user=reader) for item in traced], batch_size=2000
+            )
+            models.ItemFavorite.objects.bulk_create(
+                [models.ItemFavorite(item=item, user=bob) for item in folders[::10]],
+                batch_size=2000,
+            )
+        else:
+            models.ItemAccess.objects.bulk_create(accesses, batch_size=2000)
+
+        return {
+            "reader": reader,
+            "alice": alice,
+            "bob": bob,
+            "carol": carol,
+            "workspace": workspace,
+            "folders": folders,
+            "restricted": restricted,
+            "redundant_users": redundant_users,
+        }
+
+    def timing_summary(self, samples):
+        """Keep raw samples as well as robust summary statistics."""
+        return {
+            "median_ms": round(statistics.median(samples), 3),
+            "min_ms": round(min(samples), 3),
+            "max_ms": round(max(samples), 3),
+            "samples_ms": [round(value, 3) for value in samples],
+        }
+
+    def measure(self, fn):
+        """Separate normal API execution from SQL profiling overhead."""
+        expected = fn()  # Warm application and database caches.
+        samples = []
+        for _ in range(self.reps):
+            start = time.perf_counter()
+            actual = fn()
+            samples.append((time.perf_counter() - start) * 1000)
+            require(actual == expected, "Response IDs/count changed between repetitions")
+
+        statements = defaultdict(list)
+
+        def capture(execute, sql, params, many, context):
+            start = time.perf_counter()
+            try:
+                return execute(sql, params, many, context)
+            finally:
+                statements[sql].append((time.perf_counter() - start) * 1000)
+
+        with connection.execute_wrapper(capture):
+            require(fn() == expected, "Response IDs/count changed during SQL profiling")
+        sql_results = [
+            {
+                "sql": sql,
+                "calls": len(times),
+                "total_ms": round(sum(times), 3),
+                **self.timing_summary(times),
+            }
+            for sql, times in statements.items()
+        ]
+        sql_results.sort(key=lambda entry: entry["total_ms"], reverse=True)
+        return {
+            "api": self.timing_summary(samples),
+            "rows": len(expected[0]),
+            "count": expected[1],
+            "sql_calls": sum(len(times) for times in statements.values()),
+            "sql_execute_ms": round(sum(sum(times) for times in statements.values()), 3),
+            "sql": sql_results,
+        }
+
+    def run_pghero(self, data, result):
+        """Exercise folder listings and accessible-root selection on one fixed dataset."""
+        clients = {}
+        for role in ("alice", "bob", "reader"):
+            clients[role] = APIClient()
+            clients[role].force_authenticate(data[role])
+
+        def run(name, role, url, params):
+            def request():
+                response = clients[role].get(url, params)
+                require(response.status_code == 200, f"API returned {response.status_code}")
+                payload = response.json()
+                rows = payload["results"]
+                require(rows, f"Empty benchmark scenario: {name}")
+                require(len(rows) <= self.page_size, "Page size exceeded")
+                return tuple(row["id"] for row in rows), payload.get("count")
+
+            stats = self.measure(request)
+            result["scenarios"][name] = stats
+            print(  # noqa: T201 - benchmark CLI output
+                f"{name:35s} API={stats['api']['median_ms']:9.2f}ms "
+                f"SQL={stats['sql_execute_ms']:9.2f}ms queries={stats['sql_calls']}",
+                flush=True,
+            )
+
+        children_url = f"/api/v1.0/items/{data['workspace'].pk}/children/"
+        for role in ("alice", "bob"):
+            for ordering in ("-type,title", "created_at"):
+                run(
+                    f"children_{role}_{ordering}",
+                    role,
+                    children_url,
+                    {"page_size": self.page_size, "ordering": ordering},
+                )
+        run(
+            "children_second_page",
+            "bob",
+            children_url,
+            {"page_size": self.page_size, "page": 2, "ordering": "-type,title"},
+        )
+        # Exercise a deeper folder with both files and a nested folder.
+        nested = models.Item.objects.get(title="sub-0000-0")
+        run(
+            "nested_children",
+            "bob",
+            f"/api/v1.0/items/{nested.pk}/children/",
+            {"page_size": self.page_size, "ordering": "-type,title"},
+        )
+        run("accessible_roots", "reader", "/api/v1.0/items/", {"page_size": self.page_size})
+        run(
+            "shared_roots",
+            "reader",
+            "/api/v1.0/items/",
+            {"page_size": self.page_size, "is_creator_me": "false"},
+        )
+        run(
+            "search_title",
+            "bob",
+            "/api/v1.0/items/search/",
+            {"page_size": self.page_size, "title": "folder"},
+        )
+
+    def measure_historical(self, fn, setup=None, reps=None):
+        """Run fn `reps` times, return query count and timing stats."""
+        reps = self.reps if reps is None else reps
+        if setup:
+            setup()
+        fn()  # warmup (caches, connection)
+        times, queries = [], []
+        for _ in range(reps):
+            if setup:
+                setup()
+            start = time.perf_counter()
+            with CaptureQueriesContext(connection) as ctx:
+                fn()
+            times.append((time.perf_counter() - start) * 1000)
+            queries.append(len(ctx))
+        return {
+            "queries": max(queries),
+            "ms_median": round(statistics.median(times), 1),
+            "ms_min": round(min(times), 1),
+        }
+
+    def run_historical(self, data, results):
+        """Preserve restricted_2 authentication, capture overhead and scenario order."""
+        extra = {}
+
+        def scenario(name, fn, setup=None):
+            results["scenarios"][name] = self.measure_historical(fn, setup=setup)
+
+        workspace = data["workspace"]
+
+        # --- children list, as workspace owner
+        client = APIClient()
+        client.force_login(data["alice"])
+
+        def children_owner():
+            response = client.get(
+                f"/api/v1.0/items/{workspace.id!s}/children/?page_size={self.page_size}"
+            )
+            require(response.status_code == 200, f"API returned {response.status_code}")
+            extra["children_owner_rows"] = len(response.json()["results"])
+
+        scenario("children_list_owner", children_owner)
+
+        # --- children list, as editor
+        client_bob = APIClient()
+        client_bob.force_login(data["bob"])
+
+        def children_editor():
+            response = client_bob.get(
+                f"/api/v1.0/items/{workspace.id!s}/children/?page_size={self.page_size}"
+            )
+            require(response.status_code == 200, f"API returned {response.status_code}")
+            extra["children_editor_rows"] = len(response.json()["results"])
+
+        scenario("children_list_editor", children_editor)
+
+        # --- search by title, as editor
+        def search_title():
+            response = client_bob.get("/api/v1.0/items/search/?title=folder")
+            require(response.status_code == 200, f"API returned {response.status_code}")
+            payload = response.json()
+            extra["search_rows"] = len(payload if isinstance(payload, list) else payload["results"])
+
+        scenario("search_title", search_title)
+
+        # --- export descendants iteration, as editor
+        def export():
+            folder = models.Item.objects.get(pk=workspace.pk)
+            entries = list(export_descendants(folder))
+            extra["export_rows"] = len(entries)
+
+        scenario("export_descendants", export)
+
+        if self.with_restrictions:
+            restricted_ids = [item.pk for item in data["restricted"][: self.nb_abilities_sample]]
+
+            # --- get_abilities loop over restricted folders, as container owner (no access)
+            def abilities_container_owner():
+                for item in models.Item.objects.filter(pk__in=restricted_ids):
+                    item.get_abilities(data["alice"])
+
+            scenario("abilities_restricted_container_owner", abilities_container_owner)
+
+            # --- same loop, as editor of the workspace (no access to restricted content)
+            def abilities_editor():
+                for item in models.Item.objects.filter(pk__in=restricted_ids):
+                    item.get_abilities(data["bob"])
+
+            scenario("abilities_restricted_editor", abilities_editor)
+
+            # --- unrestrict on a folder with redundant accesses
+            target = data["folders"][50]
+            models.ItemAccess.objects.get_or_create(
+                item=target, user=data["carol"], defaults={"role": models.RoleChoices.OWNER}
+            )
+
+            def deactivate_setup():
+                target.refresh_from_db()
+                if not target.is_restricted:
+                    target.restrict(data["carol"])
+                for user in data["redundant_users"]:
+                    models.ItemAccess.objects.get_or_create(
+                        item=target, user=user, defaults={"role": models.RoleChoices.EDITOR}
+                    )
+
+            def deactivate():
+                target.refresh_from_db()
+                target.unrestrict()
+
+            scenario("unrestrict", deactivate, setup=deactivate_setup)
+
+        results["extra"] = extra
+
+    def git_metadata(self):
+        """Use explicit host metadata when .git is not mounted in Docker."""
+        revision = self.commit
+        dirty = None
+        git_binary = shutil.which("git")
+        if not revision and git_binary:
+            try:
+                revision = subprocess.check_output(  # noqa: S603 - fixed Git arguments, no shell
+                    [git_binary, "rev-parse", "HEAD"], stderr=subprocess.DEVNULL, text=True
+                ).strip()
+                dirty = bool(
+                    subprocess.check_output(  # noqa: S603 - fixed Git arguments, no shell
+                        [git_binary, "status", "--porcelain", "--untracked-files=no"],
+                        stderr=subprocess.DEVNULL,
+                        text=True,
+                    ).strip()
+                )
+            except (OSError, subprocess.CalledProcessError):
+                revision = None
+        return {
+            "commit": revision,
+            "tracked_dirty": dirty,
+            "benchmark_sha256": hashlib.sha256(Path(__file__).read_bytes()).hexdigest(),
+        }
+
+    def run(self):
+        """Run the selected protocol without changing the application queries."""
+        require(connection.vendor == "postgresql", "This benchmark requires PostgreSQL/ltree")
+        require(
+            not self.with_restrictions or self.restriction is not None, "Restrictions unavailable"
+        )
+        started = time.perf_counter()
+        data = self.build_dataset()
+        with connection.cursor() as cursor:
+            if self.mode == "pghero":
+                for model in (
+                    models.Item,
+                    models.ItemAccess,
+                    models.LinkTrace,
+                    models.ItemFavorite,
+                    models.User,
+                ):
+                    table = connection.ops.quote_name(model._meta.db_table)  # noqa: SLF001
+                    cursor.execute(f"ANALYZE {table}")
+            cursor.execute("SELECT version()")
+            postgres_version = cursor.fetchone()[0]
+            cursor.execute(
+                "SELECT indexname, indexdef FROM pg_indexes "
+                "WHERE tablename = 'drive_item' ORDER BY indexname"
+            )
+            indexes = [{"name": name, "definition": definition} for name, definition in cursor]
+        result = {
+            "schema_version": 2,
+            "mode": self.mode,
+            "protocol_version": "restricted_2-command-v1"
+            if self.mode == "historical"
+            else "pghero-command-v1",
+            "recorded_at": datetime.now(timezone.utc).isoformat(),
+            "config": self.config,
+            "has_restricted": self.with_restrictions,
+            "source": self.git_metadata(),
+            "python": platform.python_version(),
+            "postgres": postgres_version,
+            "item_indexes": indexes,
+            "cache_backend": settings.CACHES["default"]["BACKEND"],
+            "dataset_items": models.Item.objects.count(),
+            "dataset_accesses": models.ItemAccess.objects.count(),
+            "setup_seconds": round(time.perf_counter() - started, 3),
+            "scenarios": {},
+        }
+        if self.mode == "historical":
+            self.run_historical(data, result)
+        else:
+            self.run_pghero(data, result)
+        output = self.output
+        output.parent.mkdir(parents=True, exist_ok=True)
+        # Never silently replace an existing baseline, even with an explicit path.
+        with output.open("x", encoding="utf-8") as stream:
+            json.dump(result, stream, indent=2)
+        return result

--- a/src/backend/core/services/benchmark.py
+++ b/src/backend/core/services/benchmark.py
@@ -340,6 +340,7 @@ class Benchmark:  # pylint: disable=too-many-instance-attributes,too-many-argume
             {"page_size": self.page_size, "ordering": "-type,title"},
         )
         run("accessible_roots", "reader", "/api/v1.0/items/", {"page_size": self.page_size})
+        run("accessible_roots_bob", "bob", "/api/v1.0/items/", {"page_size": self.page_size})
         run(
             "shared_roots",
             "reader",

--- a/src/backend/core/tests/items/test_api_items_favorite_list.py
+++ b/src/backend/core/tests/items/test_api_items_favorite_list.py
@@ -278,7 +278,7 @@ def test_api_item_favorite_list_ordering_by_fields(ordering, django_assert_num_q
     is_descending = ordering.startswith("-")
     querystring = f"?ordering={ordering}"
 
-    with django_assert_num_queries(6):
+    with django_assert_num_queries(5):
         response = client.get(f"/api/v1.0/items/favorites/{querystring:s}")
     assert response.status_code == 200
     results = response.json()["results"]

--- a/src/backend/core/tests/items/test_api_items_list.py
+++ b/src/backend/core/tests/items/test_api_items_list.py
@@ -291,11 +291,11 @@ def test_api_items_list_authenticated_direct(django_assert_num_queries):
         str(child4_with_access.id),
     }
 
-    with django_assert_num_queries(11):
+    with django_assert_num_queries(10):
         response = client.get("/api/v1.0/items/")
 
     # nb_accesses should now be cached
-    with django_assert_num_queries(7):
+    with django_assert_num_queries(6):
         response = client.get("/api/v1.0/items/")
 
     assert response.status_code == 200
@@ -375,11 +375,11 @@ def test_api_items_list_authenticated_link_reach_restricted(
     folder_item = factories.ItemFactory(link_reach="public", type=models.ItemTypeChoices.FOLDER)
     models.LinkTrace.objects.create(item=folder_item, user=user)
 
-    with django_assert_num_queries(8):
+    with django_assert_num_queries(7):
         response = client.get("/api/v1.0/items/")
 
     # nb_accesses should now be cached
-    with django_assert_num_queries(6):
+    with django_assert_num_queries(5):
         response = client.get("/api/v1.0/items/")
 
     assert response.status_code == 200
@@ -433,11 +433,11 @@ def test_api_items_list_authenticated_link_reach_public_or_authenticated(
         str(visible_child.id),
     }
 
-    with django_assert_num_queries(12):
+    with django_assert_num_queries(10):
         response = client.get("/api/v1.0/items/")
 
     # nb_accesses should now be cached
-    with django_assert_num_queries(9):
+    with django_assert_num_queries(7):
         response = client.get("/api/v1.0/items/")
 
     assert response.status_code == 200

--- a/src/backend/core/tests/items/test_api_items_list_ancestors_links.py
+++ b/src/backend/core/tests/items/test_api_items_list_ancestors_links.py
@@ -1,0 +1,138 @@
+"""Tests for the inherited links of the items listed from several trees."""
+
+import pytest
+from rest_framework.test import APIClient
+
+from core import factories, models
+from core.api import serializers
+
+pytestmark = pytest.mark.django_db
+
+
+def _serialized(item, user):
+    """Build the expected representation of a folder, computed item by item."""
+    # A fresh instance without the listing annotations goes through the per-item
+    # computations of the model, independent from the grouped ancestors lookup
+    item = models.Item.objects.annotate_with_numchild().get(pk=item.pk)
+    return {
+        "id": str(item.id),
+        "abilities": item.get_abilities(user),
+        "ancestors_link_reach": item.ancestors_link_reach,
+        "ancestors_link_role": item.ancestors_link_role,
+        "computed_link_reach": item.computed_link_reach,
+        "computed_link_role": item.computed_link_role,
+        "created_at": item.created_at.isoformat().replace("+00:00", "Z"),
+        "creator": {
+            "id": str(item.creator.id),
+            "full_name": item.creator.full_name,
+            "short_name": item.creator.short_name,
+        },
+        "depth": item.depth,
+        "is_favorite": False,
+        "is_restricted": item.is_restricted,
+        "target": None,
+        "link_reach": item.link_reach,
+        "link_role": item.link_role,
+        "nb_accesses": item.nb_accesses,
+        "numchild": item.numchild,
+        "numchild_folder": item.numchild_folder,
+        "path": str(item.path),
+        "title": item.title,
+        "updated_at": item.updated_at.isoformat().replace("+00:00", "Z"),
+        "user_role": item.get_role(user),
+        "type": models.ItemTypeChoices.FOLDER,
+        "upload_state": None,
+        "url": None,
+        "url_permalink": None,
+        "url_preview": None,
+        "mimetype": None,
+        "main_workspace": False,
+        "filename": None,
+        "size": None,
+        "description": None,
+        "deleted_at": None,
+        "hard_delete_at": None,
+        "is_wopi_supported": False,
+    }
+
+
+def _folder(**kwargs):
+    """Create a folder."""
+    return factories.ItemFactory(type=models.ItemTypeChoices.FOLDER, **kwargs)
+
+
+def _build_trees(user):
+    """Create trees visited by the user through links, return the listed and hidden folders."""
+    # Tree A: the visited folder inherits an open link from its root
+    root_a = _folder(link_reach="public", link_role="editor")
+    child_a = _folder(parent=root_a, link_traces=[user])
+
+    # Tree B: the link is inherited through two levels
+    root_b = _folder(link_reach="authenticated", link_role="reader")
+    mid_b = _folder(parent=root_b, link_reach=None)
+    child_b = _folder(parent=mid_b, link_traces=[user])
+
+    # Tree C: the root link was closed after the visit
+    root_c = _folder(link_reach="public")
+    child_c = _folder(parent=root_c, link_traces=[user])
+    root_c.link_reach = "restricted"
+    root_c.save()
+
+    # Tree D: an ancestor of the visited folder was deleted
+    root_d = _folder(link_reach="public")
+    mid_d = _folder(parent=root_d)
+    child_d = _folder(parent=mid_d, link_traces=[user])
+    mid_d.soft_delete()
+
+    # Tree E: the visited folder sits under a restricted folder carrying the link
+    owner = factories.UserFactory()
+    container = _folder()
+    folder_e = _folder(parent=container, users=[(owner, "owner")])
+    folder_e = folder_e.restrict(owner)
+    folder_e.link_reach = "public"
+    folder_e.link_role = "reader"
+    folder_e.save()
+    child_e = _folder(parent=folder_e, link_traces=[user])
+
+    # A folder the user owns directly
+    own = _folder(users=[(user, "owner")])
+
+    return [child_a, child_b, child_e, own], [root_c, child_c, root_d, child_d, folder_e]
+
+
+def test_api_items_list_ancestors_links_across_trees():
+    """Listed roots carry the links inherited in their own tree, with full responses."""
+    user = factories.UserFactory()
+    listed, hidden = _build_trees(user)
+
+    client = APIClient()
+    client.force_login(user)
+    response = client.get("/api/v1.0/items/")
+
+    assert response.status_code == 200
+    results = {result["id"]: result for result in response.json()["results"]}
+    assert set(results) == {str(item.id) for item in listed}
+    assert not set(results) & {str(item.id) for item in hidden}
+    for item in listed:
+        assert results[str(item.id)] == _serialized(item, user)
+
+
+def test_api_items_favorites_ancestors_links_across_trees():
+    """Favorites carry the links inherited in their own tree, with full responses."""
+    user = factories.UserFactory()
+    listed, hidden = _build_trees(user)
+    for item in listed + hidden:
+        models.ItemFavorite.objects.create(item=item, user=user)
+
+    client = APIClient()
+    client.force_login(user)
+    response = client.get("/api/v1.0/items/favorites/")
+
+    assert response.status_code == 200
+    results = {result["id"]: result for result in response.json()["results"]}
+    assert set(results) == {str(item.id) for item in listed}
+    # The favorites use a lighter serializer, whose abilities still depend on the links
+    fields = serializers.ListItemLightSerializer.Meta.fields
+    for item in listed:
+        expected = {**_serialized(item, user), "is_favorite": True}
+        assert results[str(item.id)] == {field: expected[field] for field in fields}

--- a/src/backend/core/tests/items/test_api_items_recents.py
+++ b/src/backend/core/tests/items/test_api_items_recents.py
@@ -161,7 +161,7 @@ def test_api_items_recents_mixing_explicit_and_inherited_accesses(
     client = APIClient()
     client.force_login(user)
 
-    with django_assert_num_queries(7):
+    with django_assert_num_queries(6):
         response = client.get("/api/v1.0/items/recents/")
     assert response.status_code == 200
     content = response.json()
@@ -228,7 +228,7 @@ def test_api_items_recents_filtering(django_assert_num_queries):
     client = APIClient()
     client.force_login(user)
 
-    with django_assert_num_queries(7):
+    with django_assert_num_queries(6):
         response = client.get("/api/v1.0/items/recents/?type=folder")
 
     assert response.status_code == 200
@@ -237,7 +237,7 @@ def test_api_items_recents_filtering(django_assert_num_queries):
     assert content["results"][0]["id"] == str(parent.id)
     assert content["results"][1]["id"] == str(other_parent.id)
 
-    with django_assert_num_queries(7):
+    with django_assert_num_queries(6):
         response = client.get("/api/v1.0/items/recents/?type=file")
 
     assert response.status_code == 200
@@ -348,7 +348,7 @@ def test_api_item_recents_ordering_by_fields(ordering, django_assert_num_queries
     is_descending = ordering.startswith("-")
     querystring = f"?ordering={ordering}"
 
-    with django_assert_num_queries(7):
+    with django_assert_num_queries(6):
         response = client.get(f"/api/v1.0/items/recents/{querystring:s}")
     assert response.status_code == 200
     results = response.json()["results"]
@@ -433,7 +433,7 @@ def test_api_item_recents_ordering_by_size(ordering, django_assert_num_queries):
     is_descending = ordering.startswith("-")
     querystring = f"?ordering={ordering}"
 
-    with django_assert_num_queries(7):
+    with django_assert_num_queries(6):
         response = client.get(f"/api/v1.0/items/recents/{querystring:s}")
     assert response.status_code == 200
     results = response.json()["results"]
@@ -518,7 +518,7 @@ def test_api_item_recents_ordering_by_creator_full_name(ordering, django_assert_
     is_descending = ordering.startswith("-")
     querystring = f"?ordering={ordering}"
 
-    with django_assert_num_queries(7):
+    with django_assert_num_queries(6):
         response = client.get(f"/api/v1.0/items/recents/{querystring:s}")
     assert response.status_code == 200
     results = response.json()["results"]

--- a/src/backend/core/tests/test_management_benchmark.py
+++ b/src/backend/core/tests/test_management_benchmark.py
@@ -44,7 +44,7 @@ def test_benchmark_smoke(mode, tmp_path):
         assert set(cursor.fetchall()) == before
     result = json.loads(output.read_text(encoding="utf-8"))
     assert result["mode"] == mode
-    assert len(result["scenarios"]) == (9 if mode == "pghero" else 7)
+    assert len(result["scenarios"]) == (10 if mode == "pghero" else 7)
     assert result["config"]["reps"] == 2
 
 

--- a/src/backend/core/tests/test_management_benchmark.py
+++ b/src/backend/core/tests/test_management_benchmark.py
@@ -1,0 +1,68 @@
+"""Verify benchmark isolation, cleanup and command options."""
+
+import json
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.db import connection
+
+import pytest
+
+from core.services.benchmark import Benchmark
+
+
+def test_benchmark_rejects_invalid_reps():
+    """Invalid input must fail before touching the database."""
+    with pytest.raises(CommandError, match="at least 2"):
+        call_command("benchmark", reps=1)
+
+
+def test_benchmark_preserves_existing_output(tmp_path):
+    """An existing baseline must never be replaced."""
+    output = tmp_path / "baseline.json"
+    output.write_text("baseline", encoding="utf-8")
+    with pytest.raises(CommandError, match="already exists"):
+        call_command("benchmark", output=output)
+    assert output.read_text(encoding="utf-8") == "baseline"
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.parametrize("mode", ["pghero", "historical"])
+def test_benchmark_smoke(mode, tmp_path):
+    """Exercise each protocol and preserve the caller's database."""
+    original_name = connection.settings_dict["NAME"]
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT datname FROM pg_database WHERE datname LIKE 'drive_bench_%'")
+        before = set(cursor.fetchall())
+    output = tmp_path / "result.json"
+    call_command("benchmark", mode=mode, reps=2, restrictions=True, output=output)
+    assert connection.settings_dict["NAME"] == original_name
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT current_database()")
+        assert cursor.fetchone()[0] == original_name
+        cursor.execute("SELECT datname FROM pg_database WHERE datname LIKE 'drive_bench_%'")
+        assert set(cursor.fetchall()) == before
+    result = json.loads(output.read_text(encoding="utf-8"))
+    assert result["mode"] == mode
+    assert len(result["scenarios"]) == (9 if mode == "pghero" else 7)
+    assert result["config"]["reps"] == 2
+
+
+@pytest.mark.django_db(transaction=True)
+def test_benchmark_cleans_up_after_failure(monkeypatch, tmp_path):
+    """A workload error still drops its database and restores the original name."""
+    original_name = connection.settings_dict["NAME"]
+    temporary_names = []
+
+    def fail(_self):
+        temporary_names.append(connection.settings_dict["NAME"])
+        assert temporary_names[0] != original_name
+        raise RuntimeError("benchmark failed")
+
+    monkeypatch.setattr(Benchmark, "run", fail)
+    with pytest.raises(RuntimeError, match="benchmark failed"):
+        call_command("benchmark", output=tmp_path / "result.json")
+    assert connection.settings_dict["NAME"] == original_name
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT datname FROM pg_database WHERE datname = %s", temporary_names)
+        assert cursor.fetchall() == []

--- a/src/backend/core/tests/test_models_items.py
+++ b/src/backend/core/tests/test_models_items.py
@@ -1114,6 +1114,20 @@ def test_models_items__email_invitation__skipped_when_email_host_missing(
 # item number of accesses
 
 
+def test_models_items_prefetch_nb_accesses(django_assert_num_queries):
+    """Cached numbers of accesses are read at once, missing ones are computed on access."""
+    cached = factories.ItemFactory()
+    missing = factories.ItemFactory()
+    factories.UserItemAccessFactory.create_batch(2, item=cached)
+    assert cached.nb_accesses == 2
+
+    items = list(models.Item.objects.filter(pk__in=[cached.pk, missing.pk]))
+    with django_assert_num_queries(0):
+        models.Item.prefetch_nb_accesses(items)
+    with django_assert_num_queries(1):
+        assert {item.nb_accesses for item in items} == {2, 0}
+
+
 def test_models_items_nb_accesses_cache_is_set_and_retrieved(
     django_assert_num_queries,
 ):

--- a/src/backend/demo/management/commands/create_demo.py
+++ b/src/backend/demo/management/commands/create_demo.py
@@ -13,6 +13,7 @@ from django.core.management.base import BaseCommand, CommandError
 from faker import Faker
 
 from core import factories, models
+from core.services.benchmark import PROFILES, Benchmark
 
 from demo import defaults
 
@@ -261,6 +262,30 @@ def create_demo(stdout, *, file_types=False):
             item.save(update_fields=["title"])
 
 
+def create_bench(stdout, profile, role):
+    """Build the benchmark dataset and give development users the accesses of one bench user."""
+    if models.Item.objects.filter(title="bench-ws").exists():
+        raise CommandError("The benchmark dataset already exists, reset the database first")
+
+    with Timeit(stdout, f"Creating {profile} benchmark dataset"):
+        data = Benchmark(
+            mode="pghero", profile=profile, reps=None, restrictions=True, output=None
+        ).build_dataset()
+
+    with Timeit(stdout, f"Copying {role} accesses to development users"):
+        source = data[role]
+        dev_emails = [dev_user["email"] for dev_user in defaults.DEV_USERS]
+        for user in models.User.objects.filter(email__in=dev_emails):
+            models.ItemAccess.objects.bulk_create(
+                models.ItemAccess(item_id=access.item_id, user=user, role=access.role)
+                for access in models.ItemAccess.objects.filter(user=source)
+            )
+            models.LinkTrace.objects.bulk_create(
+                models.LinkTrace(item_id=trace.item_id, user=user)
+                for trace in models.LinkTrace.objects.filter(user=source)
+            )
+
+
 class Command(BaseCommand):
     """A management command to create a demo database."""
 
@@ -282,6 +307,17 @@ class Command(BaseCommand):
             default=False,
             help="Create items for several file types",
         )
+        parser.add_argument(
+            "--bench",
+            choices=tuple(PROFILES),
+            help="Also build the benchmark dataset of this profile",
+        )
+        parser.add_argument(
+            "--bench-role",
+            choices=("alice", "bob", "reader"),
+            default="bob",
+            help="Bench user whose accesses and link traces development users receive",
+        )
 
     def handle(self, *args, **options):
         """Handling of the management command."""
@@ -297,3 +333,5 @@ class Command(BaseCommand):
             self.stdout,
             file_types=options["file_types"],
         )
+        if options["bench"]:
+            create_bench(self.stdout, options["bench"], options["bench_role"])

--- a/src/backend/demo/tests/test_commands_create_demo.py
+++ b/src/backend/demo/tests/test_commands_create_demo.py
@@ -73,3 +73,22 @@ def test_commands_create_demo_can_be_run_twice_without_resetting_database():
     call_command("create_demo", "--file_types")
 
     assert models.User.objects.filter(email="drive@drive.world").count() == 1
+
+
+@override_settings(DEBUG=True)
+def test_commands_create_demo_with_bench():
+    """The create_demo command should optionally build the benchmark dataset for dev users."""
+    call_command("create_demo", "--bench", "smoke", "--bench-role", "reader")
+
+    dev_user = models.User.objects.get(email="drive@drive.world")
+    reader = models.User.objects.get(sub="bench-reader")
+    assert models.Item.objects.filter(title="bench-ws").exists()
+    reader_accesses = models.ItemAccess.objects.filter(user=reader)
+    assert reader_accesses.exists()
+    for access in reader_accesses:
+        assert models.ItemAccess.objects.filter(
+            user=dev_user, item_id=access.item_id, role=access.role
+        ).exists()
+    assert models.LinkTrace.objects.filter(user=dev_user).count() == (
+        models.LinkTrace.objects.filter(user=reader).count()
+    )


### PR DESCRIPTION
## Purpose

PgHero shows folder listings and top-level root selection as the two
heaviest query families in production. This branch reduces their cost
without changing the API responses, permissions or counters.

## Proposal

- [x] measure with a benchmark command on a disposable database
- [x] count direct accesses with a subquery instead of a join and GROUP BY
- [x] load the ancestors of a page in one query, select roots by id
- [x] read the cached numbers of accesses of a page in one cache call
- [x] serialize search results without querying per item
- [x] join the restriction instead of a correlated EXISTS
- [x] drop the user indexes covered by the unique constraints

Migration 0031 drops two indexes concurrently, outside a transaction. An
interrupted drop leaves an invalid index to remove by hand before retrying.
No commit depends on an index to build: the code can be deployed before or
after the migration.

Local results on the xl profile, median and minimum of ten runs: folder
listings -41 %, top-level roots -51 %, search -52 %; roots and search go
from 105 to 6 and 5 queries per page. The single cache call for the
numbers of accesses was measured separately against Redis: 100 GET
replaced by 1 MGET on a warm cache, -21 % on the call, no change on a
cold cache.

An expression index on the parent path, which halves the listing cost on
large folders, was measured and deferred: the counters depend on it and
its build must be complete before the code runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
