### PR TITLE
🔖(minor) bump release version 0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [v0.22.0] - 2026-09-09
+
 ### Added
 
 - 📈(backend) add a Sentry performance monitoring sample rate setting
@@ -532,7 +534,8 @@ and this project adheres to
 - 🌐(front) add english translation for rename modal
 - 🐛(global) fix wrong Content-Type on specific s3 implementations
 
-[unreleased]: https://github.com/suitenumerique/drive/compare/v0.21.2...main
+[unreleased]: https://github.com/suitenumerique/drive/compare/v0.22.0...main
+[v0.22.0]: https://github.com/suitenumerique/drive/releases/v0.22.0
 [v0.21.2]: https://github.com/suitenumerique/drive/releases/v0.21.2
 [v0.21.1]: https://github.com/suitenumerique/drive/releases/v0.21.1
 [v0.21.0]: https://github.com/suitenumerique/drive/releases/v0.21.0

--- a/docs/env.md
+++ b/docs/env.md
@@ -99,6 +99,8 @@ This document lists all configurable environment variables for the Drive applica
 | `OIDC_USER_INFO` | List of OIDC user info claims | `[]` |
 | `OIDC_USERINFO_FULLNAME_FIELDS` | Fields to use for full name | `["first_name", "last_name"]` |
 | `OIDC_USERINFO_SHORTNAME_FIELD` | Field to use for short name | `first_name` |
+| `PERMISSIONS_BACKEND` | Permissions backend class for items | `core.permissions.backends.role.RolePermissionsBackend` |
+| `PERMISSIONS_BACKEND_PARAMETERS` | Dictionary of parameters for the permissions backend | `{}` |
 | `POSTHOG_HOST` | PostHog analytics host URL | `https://eu.i.posthog.com` |
 | `POSTHOG_KEY` | PostHog analytics API key | `None` |
 | `REDIS_URL` | Redis connection URL | `redis://redis:6379/0` |

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "uv_build"
 
 [project]
 name = "drive"
-version = "0.21.2"
+version = "0.22.0"
 authors = [{ "name" = "DINUM", "email" = "dev@mail.numerique.gouv.fr" }]
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/src/backend/uv.lock
+++ b/src/backend/uv.lock
@@ -659,7 +659,7 @@ wheels = [
 
 [[package]]
 name = "drive"
-version = "0.21.2"
+version = "0.22.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/src/frontend/apps/drive/package.json
+++ b/src/frontend/apps/drive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drive",
-  "version": "0.21.2",
+  "version": "0.22.0",
   "private": true,
   "scripts": {
     "predev": "node scripts/copy-pdf-assets.mjs",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "main",
-  "version": "0.21.2",
+  "version": "0.22.0",
   "private": true,
   "workspaces": [
     "apps/*",

--- a/src/helm/drive/Chart.yaml
+++ b/src/helm/drive/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 type: application
 name: drive
-version: 0.21.2
+version: 0.22.0
 appVersion: latest

--- a/src/helm/helmfile.yaml.gotmpl
+++ b/src/helm/helmfile.yaml.gotmpl
@@ -1,7 +1,7 @@
 environments:
   dev:
     values:
-      - version: 0.21.2
+      - version: 0.22.0
 ---
 repositories:
 - name: dev-backends

--- a/src/mail/package.json
+++ b/src/mail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mail_mjml",
-  "version": "0.21.2",
+  "version": "0.22.0",
   "description": "An util to generate html and text django's templates from mjml templates",
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
### Added

- 📈(backend) add a Sentry performance monitoring sample rate setting
- ♻️(backend) route permission decisions through a swappable backend
- ✨(backend) add restricted access on folders, detached behind a restriction

### Changed

- ♻️(frontend) migrate to the merged @gouvfr-lasuite/ui-components package

### Fixed

- 🐛(frontend) render the JPEG 2000 layers of scanned PDFs in the preview
- 🐛(backend) prevent item deletion by a creator whose access was revoked
- 🐛(backend) resolve the direct parent by exact path after a move