### PR TITLE
🐛(docker) pull minio images from quay.io

### DIFF
--- a/.github/workflows/drive.yml
+++ b/.github/workflows/drive.yml
@@ -143,13 +143,13 @@ jobs:
 
       - name: Start MinIO
         run: |
-          docker pull minio/minio
+          docker pull quay.io/minio/minio
           docker run -d --name minio \
             -p 9000:9000 \
             -e "MINIO_ACCESS_KEY=drive" \
             -e "MINIO_SECRET_KEY=password" \
             -v /data/media:/data \
-            minio/minio server --console-address :9001 /data
+            quay.io/minio/minio server --console-address :9001 /data
 
       # Tool to wait for a service to be ready
       - name: Install Dockerize
@@ -162,7 +162,7 @@ jobs:
 
       - name: Configure MinIO
         run: |
-          MINIO=$(docker ps | grep minio/minio | sed -E 's/.*\s+([a-zA-Z0-9_-]+)$/\1/')
+          MINIO=$(docker ps | grep quay.io/minio/minio | sed -E 's/.*\s+([a-zA-Z0-9_-]+)$/\1/')
           docker exec ${MINIO} sh -c \
             "mc alias set drive http://localhost:9000 drive password && \
             mc alias ls && \

--- a/compose.yaml
+++ b/compose.yaml
@@ -29,7 +29,7 @@ services:
 
   minio:
     user: ${DOCKER_USER:-1000}
-    image: minio/minio
+    image: quay.io/minio/minio
     environment:
       - MINIO_ROOT_USER=drive
       - MINIO_ROOT_PASSWORD=password
@@ -47,7 +47,7 @@ services:
       - ./data/media:/data
 
   createbuckets:
-    image: minio/mc
+    image: quay.io/minio/mc
     depends_on:
       minio:
         condition: service_healthy

--- a/docs/examples/helm/minio.values.yaml
+++ b/docs/examples/helm/minio.values.yaml
@@ -1,6 +1,6 @@
 minio:
   enabled: true
-  image: minio/minio
+  image: quay.io/minio/minio
   name: minio
   # serviceNameOverride: drive-minio
   ingress:

--- a/src/helm/drive/Chart.yaml
+++ b/src/helm/drive/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 type: application
 name: drive
-version: 0.22.0
+version: 0.22.1
 appVersion: latest

--- a/src/helm/helmfile.yaml.gotmpl
+++ b/src/helm/helmfile.yaml.gotmpl
@@ -1,7 +1,7 @@
 environments:
   dev:
     values:
-      - version: 0.22.0
+      - version: 0.22.1
 ---
 repositories:
 - name: dev-backends
@@ -32,7 +32,7 @@ releases:
           password: pass
       - minio:
           enabled: true
-          image: minio/minio
+          image: quay.io/minio/minio
           name: minio
           # serviceNameOverride: drive-minio
           ingress:


### PR DESCRIPTION
## Purpose

MinIO stopped publishing images on Docker Hub in October 2025. `minio/mc`
can no longer be pulled, so the `createbuckets` service fails on a fresh
setup. `minio/minio` only works from the local cache.

Closes #830

## Proposal

The same images are still served from quay.io.

- [x] Use `quay.io/minio/minio` and `quay.io/minio/mc` in `compose.yaml`
- [x] Same change in the CI workflow and the helm example values
