### PR TITLE
🐛(docker) pull the minio images from quay.io

### DIFF
--- a/.github/workflows/drive.yml
+++ b/.github/workflows/drive.yml
@@ -143,13 +143,13 @@ jobs:
 
       - name: Start MinIO
         run: |
-          docker pull minio/minio
+          docker pull quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
           docker run -d --name minio \
             -p 9000:9000 \
             -e "MINIO_ACCESS_KEY=drive" \
             -e "MINIO_SECRET_KEY=password" \
             -v /data/media:/data \
-            minio/minio server --console-address :9001 /data
+            quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z server --console-address :9001 /data
 
       # Tool to wait for a service to be ready
       - name: Install Dockerize

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Fixed
 
+- 🐛(docker) pull the minio images from quay.io
 - 🐛(frontend) refresh the Recent view after item mutations
 
 ## [v0.22.0] - 2026-09-09

--- a/compose.yaml
+++ b/compose.yaml
@@ -29,7 +29,7 @@ services:
 
   minio:
     user: ${DOCKER_USER:-1000}
-    image: minio/minio
+    image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
     environment:
       - MINIO_ROOT_USER=drive
       - MINIO_ROOT_PASSWORD=password
@@ -47,7 +47,7 @@ services:
       - ./data/media:/data
 
   createbuckets:
-    image: minio/mc
+    image: quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
     depends_on:
       minio:
         condition: service_healthy

--- a/docs/examples/helm/minio.values.yaml
+++ b/docs/examples/helm/minio.values.yaml
@@ -1,6 +1,6 @@
 minio:
   enabled: true
-  image: minio/minio
+  image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
   name: minio
   # serviceNameOverride: drive-minio
   ingress:

--- a/src/helm/helmfile.yaml.gotmpl
+++ b/src/helm/helmfile.yaml.gotmpl
@@ -32,7 +32,7 @@ releases:
           password: pass
       - minio:
           enabled: true
-          image: minio/minio
+          image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
           name: minio
           # serviceNameOverride: drive-minio
           ingress:


### PR DESCRIPTION
## Purpose

Closes #830.

MinIO archived `minio/minio` and `minio/mc` on GitHub this morning and took both repositories off Docker Hub. `make bootstrap` now stops here:

```
Error response from daemon: pull access denied for minio/mc,
repository does not exist or may require 'docker login'
```

The reporter hit it on `minio/minio`; `minio/mc`, used by the `createbuckets` service, is gone as well.

The `test-back` job starts MinIO by hand with `docker pull minio/minio`, so CI fails at the same step. The last run on `main` (11/09) predates the removal.

## Proposal

- [x] `compose.yaml`: `quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z` and `quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z`
- [x] `.github/workflows/drive.yml`: same image for the `Start MinIO` step
- [x] `src/helm/helmfile.yaml.gotmpl` and `docs/examples/helm/minio.values.yaml`: same image
- [x] changelog entry

quay.io is the other registry MinIO publishes to, and the one this project already pulls Keycloak from. Tags are pinned rather than floating: the upstream repositories are archived, so `latest` can only move sideways from here. `RELEASE.2025-09-07T16-13-09Z` is the last server release pushed to quay (10-15 never was), and `RELEASE.2025-08-13T08-35-41Z` the last `mc` release.

## Verification

Reproduced on a clean clone: `docker compose pull minio createbuckets` fails on `minio/mc` before the change, both images pull after it.

With the new images, the dev stack comes up unchanged:

```
minio           Up (healthy)
createbuckets   Added `drive` successfully.
                Bucket created successfully `drive/drive-media-storage`.
                drive/drive-media-storage versioning is enabled
```

The healthcheck (`mc ready local`), `--console-address :9001` and the console itself still work, so the compose file needed no other change.

Backend suite against that MinIO, with the same settings as the `test-back` job: **1866 passed**. The bucket held 873 objects written by the run, versioning still enabled.

The CI steps were replayed one by one with the pinned image: `docker pull`, `docker run`, then `mc alias set`, `mc mb` and `mc version enable` inside the container, all fine. `docker ps | grep minio/minio` in the `Configure MinIO` step still matches, since the new reference contains that string.

One thing left over: the `dev-backends` chart hardcodes `minio/mc` in its own `minio.yaml` template, so the helm path needs a change in `suitenumerique/helm-dev-backend` too. Happy to open it if that helps.
